### PR TITLE
Allow players to flick utility lights on and off

### DIFF
--- a/data/json/furniture_and_terrain/terrain-floors_indoor.json
+++ b/data/json/furniture_and_terrain/terrain-floors_indoor.json
@@ -317,7 +317,7 @@
     "type": "terrain",
     "id": "t_utility_light",
     "name": "utility light",
-    "description": "An industrial flood light set up to illuminate the surroundings.  Smashing it doesn't seem like it'd produce any worthwhile salvage.",
+    "description": "An industrial flood light set up to illuminate the surroundings.  Smashing it doesn't seem like it'd produce any worthwhile salvage.  Examine it to switch it off.",
     "symbol": ".",
     "color": "white",
     "move_cost": 2,
@@ -331,7 +331,33 @@
       "str_max": 400,
       "str_min_supported": 100,
       "items": [ { "item": "splinter", "count": [ 2, 8 ] }, { "item": "nail", "charges": [ 5, 10 ] } ]
-    }
+    },
+    "examine_action": "transform",
+    "transforms_into": "t_utility_light_off",
+    "message": "You flick the utility light off."
+  },
+  {
+    "type": "terrain",
+    "id": "t_utility_light_off",
+    "looks_like": "t_utility_light",
+    "name": "utility light (off)",
+    "description": "An industrial flood light, which could be turned on to illuminate your surroundings.  Smashing it doesn't seem like it'd produce any worthwhile salvage.  Examine it to switch it back on.",
+    "symbol": ".",
+    "color": "white",
+    "move_cost": 2,
+    "roof": "t_flat_roof",
+    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "ROAD", "MINEABLE" ],
+    "bash": {
+      "sound": "SMASH!",
+      "ter_set": "t_null",
+      "str_min": 50,
+      "str_max": 400,
+      "str_min_supported": 100,
+      "items": [ { "item": "splinter", "count": [ 2, 8 ] }, { "item": "nail", "charges": [ 5, 10 ] } ]
+    },
+    "examine_action": "transform",
+    "transforms_into": "t_utility_light",
+    "message": "You flick the utility light on."
   },
   {
     "type": "terrain",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Content "Add off state for utility lights, allow turning them on and off"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

A simple change making use of the transform feature introduced in https://github.com/cataclysmbnteam/Cataclysm-BN/pull/716, allowing players to turn utility lights off. Useful since it makes it less annoying trying to get some shuteye in places like the refugee center.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

Added a terrain entry for an off version of the utility light. Does not use copy-from for reasons mentioned below.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Could give the "concrete floor with overhead light" this feature too. It's not as useful since those tend to only show up in labs where players likely won't make a permanent base in anyway unless they're doing the lab challenge, plus presumably the switch would be either on the wall (not doable) or a hassle to reach. Could still do it if anyone requests however.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Checked affected file for syntax and load errors.
2. Ported file change over to test build and spawned in refugee center.
3. Played with the lights, confirmed transformation goes as planned, that the inactive light has a sprite via `looks_like`, and that it actually lets you render a lit room dark.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

Side note, turns out that terrain doesn't properly inherit `symbol` and `color` when using copy-from. It also seems that flags don't inherit properly either (`TRANSPARENT` at minimum visibly did not inherit right), so I quickly discarded my initial idea of using copy-from for it.