### PR TITLE
Expand on constructions that can be done in the dark

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -22,6 +22,7 @@
     "pre_flags": "EASY_DECONSTRUCT",
     "pre_special": "check_deconstruct",
     "post_flags": [ "keep_items" ],
+    "dark_craftable": true,
     "post_special": "done_deconstruct"
   },
   {
@@ -69,6 +70,7 @@
     "qualities": [ [ { "id": "AXE", "level": 2 }, { "id": "SAW_W", "level": 1 } ] ],
     "pre_terrain": "t_trunk",
     "post_terrain": "t_dirt",
+    "dark_craftable": true,
     "post_special": "done_trunk_plank"
   },
   {
@@ -81,6 +83,7 @@
     "qualities": [ [ { "id": "CUT", "level": 1 } ], [ { "id": "HAMMER", "level": 1 } ] ],
     "components": [ [ [ "stick", 12 ], [ "2x4", 6 ], [ "wood_panel", 1 ] ], [ [ "pine_bough", 24 ], [ "willowbark", 24 ] ] ],
     "pre_terrain": "t_pit_shallow",
+    "dark_craftable": true,
     "post_terrain": "t_improvised_shelter"
   },
   {
@@ -164,6 +167,7 @@
     "qualities": [ [ { "id": "DIG", "level": 2 } ] ],
     "components": [ [ [ "material_soil", 60 ], [ "material_sand", 600 ] ] ],
     "pre_terrain": "t_water_sh",
+    "dark_craftable": true,
     "post_terrain": "t_dirt"
   },
   {
@@ -176,6 +180,7 @@
     "qualities": [ [ { "id": "DIG", "level": 2 } ] ],
     "components": [ [ [ "material_soil", 60 ] ] ],
     "pre_terrain": "t_swater_sh",
+    "dark_craftable": true,
     "post_terrain": "t_dirt"
   },
   {
@@ -410,6 +415,7 @@
     "time": "5 m",
     "byproducts": [ { "item": "glass_shard", "count": [ 0, 2 ] } ],
     "pre_terrain": "t_window_frame",
+    "dark_craftable": true,
     "post_terrain": "t_window_empty"
   },
   {
@@ -422,6 +428,7 @@
     "time": "5 m",
     "components": [ [ [ "duct_tape", 50 ] ] ],
     "pre_terrain": "t_window",
+    "dark_craftable": true,
     "post_terrain": "t_window_taped"
   },
   {
@@ -434,6 +441,7 @@
     "time": "5 m",
     "components": [ [ [ "duct_tape", 50 ] ] ],
     "pre_terrain": "t_window_domestic",
+    "dark_craftable": true,
     "post_terrain": "t_window_domestic_taped"
   },
   {
@@ -446,6 +454,7 @@
     "time": "5 m",
     "components": [ [ [ "duct_tape", 50 ] ] ],
     "pre_terrain": "t_window_alarm",
+    "dark_craftable": true,
     "post_terrain": "t_window_alarm_taped"
   },
   {
@@ -458,6 +467,7 @@
     "time": "5 m",
     "components": [ [ [ "duct_tape", 50 ] ] ],
     "pre_terrain": "t_window_no_curtains",
+    "dark_craftable": true,
     "post_terrain": "t_window_no_curtains_taped"
   },
   {
@@ -810,6 +820,7 @@
     "components": [ [ [ "sandbag", 16 ] ] ],
     "pre_note": "Can be deconstructed without tools.",
     "pre_special": "check_empty",
+    "dark_craftable": true,
     "post_terrain": "f_sandbag_half"
   },
   {
@@ -823,6 +834,7 @@
     "components": [ [ [ "sandbag", 20 ] ] ],
     "pre_note": "Can be deconstructed without tools.",
     "pre_terrain": "f_sandbag_half",
+    "dark_craftable": true,
     "post_terrain": "f_sandbag_wall"
   },
   {
@@ -836,6 +848,7 @@
     "components": [ [ [ "earthbag", 16 ] ] ],
     "pre_note": "Can be deconstructed without tools.",
     "pre_special": "check_empty",
+    "dark_craftable": true,
     "post_terrain": "f_earthbag_half"
   },
   {
@@ -849,6 +862,7 @@
     "components": [ [ [ "earthbag", 20 ] ] ],
     "pre_note": "Can be deconstructed without tools.",
     "pre_terrain": "f_earthbag_half",
+    "dark_craftable": true,
     "post_terrain": "f_earthbag_wall"
   },
   {
@@ -930,6 +944,7 @@
     "qualities": [ [ { "id": "DIG", "level": 1 } ] ],
     "components": [ [ [ "material_soil", 200 ] ] ],
     "pre_terrain": "t_pit",
+    "dark_craftable": true,
     "post_terrain": "t_dirt"
   },
   {
@@ -942,6 +957,7 @@
     "time": "40 m",
     "components": [ [ [ "splinter", 50 ] ] ],
     "pre_terrain": "t_pit_shallow",
+    "dark_craftable": true,
     "post_terrain": "t_woodchips"
   },
   {
@@ -954,6 +970,7 @@
     "time": "40 m",
     "components": [ [ [ "pebble", 100 ] ] ],
     "pre_special": "check_empty",
+    "dark_craftable": true,
     "post_terrain": "t_railroad_rubble"
   },
   {
@@ -1746,6 +1763,7 @@
     "time": "1 m",
     "components": [ [ [ "w_table", 1 ] ] ],
     "pre_special": "check_empty",
+    "dark_craftable": true,
     "post_terrain": "f_table"
   },
   {
@@ -1781,6 +1799,7 @@
     "time": "1 m",
     "components": [ [ [ "workbench", 1 ] ] ],
     "pre_special": "check_empty",
+    "dark_craftable": true,
     "post_terrain": "f_workbench"
   },
   {
@@ -1845,6 +1864,7 @@
     "components": [ [ [ "2x4", 4 ], [ "stick", 4 ] ], [ [ "straw_pile", 8 ], [ "withered", 8 ], [ "pine_bough", 8 ] ] ],
     "pre_note": "Can be deconstructed without tools.",
     "pre_special": "check_empty",
+    "dark_craftable": true,
     "post_terrain": "f_straw_bed"
   },
   {
@@ -1857,6 +1877,7 @@
     "components": [ [ [ "withered", 50 ] ] ],
     "pre_note": "Can be deconstructed without tools.",
     "pre_special": "check_empty",
+    "dark_craftable": true,
     "post_terrain": "f_leaves_pile"
   },
   {
@@ -1909,6 +1930,7 @@
     "time": "5 m",
     "components": [ [ [ "mattress", 1 ], [ "down_mattress", 1 ] ] ],
     "pre_terrain": "f_bed_frame",
+    "dark_craftable": true,
     "post_terrain": "f_bed"
   },
   {
@@ -2023,6 +2045,7 @@
     "components": [ [ [ "char_forge", 1 ] ] ],
     "pre_note": "Can be deconstructed without tools.",
     "pre_special": "check_empty",
+    "dark_craftable": true,
     "post_terrain": "f_forge"
   },
   {
@@ -2035,6 +2058,7 @@
     "components": [ [ [ "still", 1 ] ] ],
     "pre_note": "Can be deconstructed without tools.",
     "pre_special": "check_empty",
+    "dark_craftable": true,
     "post_terrain": "f_still"
   },
   {
@@ -2070,6 +2094,7 @@
     "time": "10 m",
     "components": [ [ [ "straw_pile", 40 ], [ "withered", 40 ] ], [ [ "rope_30", 1 ], [ "rope_makeshift_30", 1 ], [ "vine_30", 1 ] ] ],
     "pre_special": "check_empty",
+    "dark_craftable": true,
     "post_terrain": "f_hay"
   },
   {
@@ -2356,6 +2381,7 @@
     "time": "1 m",
     "components": [ [ [ "manhole_cover", 1 ] ] ],
     "pre_terrain": "t_manhole",
+    "dark_craftable": true,
     "post_terrain": "t_manhole_cover"
   },
   {
@@ -2654,6 +2680,7 @@
     "time": "10 m",
     "//2": "no components required, they are filled in at runtime based on the vehicle parts that can be used to start a vehicle",
     "pre_special": "check_empty",
+    "dark_craftable": true,
     "post_special": "done_vehicle",
     "vehicle_start": true
   },
@@ -2910,6 +2937,7 @@
     "qualities": [ [ { "id": "DIG", "level": 1 } ] ],
     "byproducts": [ { "item": "material_sand", "charges": [ 300, 600 ] } ],
     "pre_terrain": "t_sand",
+    "dark_craftable": true,
     "post_special": "done_extract_maybe_revert_to_dirt"
   },
   {
@@ -2922,6 +2950,7 @@
     "qualities": [ [ { "id": "DIG", "level": 1 } ] ],
     "byproducts": [ { "item": "clay_lump", "count": [ 6, 12 ] } ],
     "pre_terrain": "t_clay",
+    "dark_craftable": true,
     "post_special": "done_extract_maybe_revert_to_dirt"
   },
   {
@@ -3227,6 +3256,7 @@
     "components": [ [ [ "rock", 20 ] ] ],
     "pre_note": "Can be deconstructed without tools.",
     "pre_terrain": "t_pit_shallow",
+    "dark_craftable": true,
     "post_terrain": "f_firering"
   },
   {
@@ -3436,6 +3466,7 @@
     "on_display": false,
     "qualities": [ { "id": "DIG", "level": 1 } ],
     "pre_flags": [ "DIGGABLE", "FLAT" ],
+    "dark_craftable": true,
     "post_terrain": "t_pit_shallow"
   },
   {
@@ -3448,6 +3479,7 @@
     "on_display": false,
     "qualities": [ { "id": "DIG", "level": 2 } ],
     "pre_flags": [ "DIGGABLE", "FLAT" ],
+    "dark_craftable": true,
     "post_terrain": "t_pit"
   },
   {
@@ -4363,6 +4395,7 @@
     "qualities": [ [ { "id": "DIG", "level": 1 } ] ],
     "byproducts": [ { "item": "pebble", "count": [ 6, 10 ] } ],
     "pre_terrain": "t_railroad_rubble",
+    "dark_craftable": true,
     "post_terrain": "t_dirt"
   }
 ]

--- a/data/mods/CRT_EXPANSION/constructions/crt_constructions.json
+++ b/data/mods/CRT_EXPANSION/constructions/crt_constructions.json
@@ -105,6 +105,7 @@
     "qualities": [ [ { "id": "AXE", "level": 2 }, { "id": "SAW_W", "level": 1 } ] ],
     "byproducts": [ { "item": "log", "count": [ 2, 3 ] } ],
     "pre_terrain": "t_trunk",
+    "dark_craftable": true,
     "post_terrain": "t_dirt"
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Allow additional construction recipes to be done in darkness"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

The feature allowing certain constructions to be initiated in the dark wasn't applied to some things that seemed like they'd be an easy fit for it, simple fix.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

Added `dark_craftable` boolean to:
1. Deconstruct Simple Furniture, reason being it explicitly takes less time and no tools than standard deconstruction.
2. Chop Tree Trunk Into Planks, consistency with axe item actions not restricting player during darkness, allowing possibility of obtaining planks in "oh shit how'd it get dark so fast" scenarios without having to force the player to do the trunk-log-plank tango instead.
3. Build Improvised Shelter, playability reasons permitting player to have at least some option for a working shelter should they find it getting late. Use of tools implies it entails some degree of shaping the wooden support but realistically it'd mostly just be lightly staking in the branches and covering it in brush securely enough to keep it from blowing away.
4. Fill Shallow Water With Dirt, consistency with other digging actions.
5. Fill Salt Water With Dirt, as above.
6. Clean Broken Window, you're literally just brushing some glass aside with presumably anything that will keep your hand from getting cut up, and allowing it in the dark adds a mildly useful option during nighttime.
7. All variants of Tape Up Window, as using tape entails no tools. Also makes the option a bit more worth bothering with when trying to be subtle.
8. Both steps of Build Sandbag Wall and Build Earthbag Wall, involving placement of bags with no tools.
9. Fill Pit With Dirt, consistency with digging actions.
10. Make Woodchip Floor, it involves basically just dumping wood chips into a shallow pit.
11. Make Gravel Floor, another construction that involves just dumping material onto the ground.
12. Place Table and Place Workbench, basic "just plonk down this item" recipes.
13. Build Straw Bed. Of the bed recipes, this is probably about second-simplest or so, and does not entail any tools. It seems to be more like some sticks arranged to very loosely corral a pile of straw.
14. Build Pile of Leaves, another "decorate floor with a smattering of stuff" construction.
15. Add Mattress to Bed Frame, involves just plonking down an item.
16. Place Forge, Place Still, item-dropping constructions.
17. Place Haybale, technically you're just dumping a pile of straw on the ground, but I suppose it's "placing" a pile rather than a single item.
18. Cover Manhole, just gotta avoid dropping it on your feet.
19. Start Vehicle Construction. In practical terms this is merely just dropping down a single frame and picking a name for your deathmobile in the making.
20. Extract Sand and Extract Clay, additional basic digging-related recipes.
21. Build Fire Ring, it's dropping rocks in a circle.
22. Dig a Shallow Pit and Dig a Deep Pit, consistency. Could've sworn those were dummied out but aight.
23. Remove gravel and replace with dirt, one more digging-type construction.
24. And only in-repo mod to be affected by this, also added to Chop Tree Trunk Into Logs construction in CRIT mod.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Left out cutting grass and any easy-deconstruct stone furniture more complicated than the fire ring. Could allow building rock forges and kilns in the dark if asked.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

Checked affected files for syntax and load errors.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
