### PR TITLE
Safe mode manager: reset cursor when switching tabs

### DIFF
--- a/src/safemode_ui.cpp
+++ b/src/safemode_ui.cpp
@@ -260,14 +260,14 @@ void safemode::show( const std::string &custom_name_in, bool is_safemode_in )
             tab++;
             if( tab >= MAX_TAB ) {
                 tab = 0;
-                line = 0;
             }
+            line = 0;
         } else if( action == "PREV_TAB" ) {
             tab--;
             if( tab < 0 ) {
                 tab = MAX_TAB - 1;
-                line = 0;
             }
+            line = 0;
         } else if( action == "QUIT" ) {
             break;
         } else if( tab == CHARACTER_TAB && g->u.name.empty() ) {


### PR DESCRIPTION
Fixes crash discovered by @Lamandus on discord.

Repro steps:
1. Have 2 rules in "global" tab and 1 in "character" tab
2. Select 2nd rule in "global" tab
3. Switch tab
4. Press `M`
