### PR TITLE
Persuade NPCs to stop treating helmets as godly superweapons

### DIFF
--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -2220,8 +2220,14 @@ double player::weapon_value( const item &weap, int ammo ) const
     const double more = std::max( val_gun, val_melee );
     const double less = std::min( val_gun, val_melee );
 
+    // discourage wielding helmets, but not worn firearms
+    int armor_penalty = 1;
+    if( weap.is_armor() && !weap.is_gun() ) {
+        armor_penalty = 0;
+    }
+
     // A small bonus for guns you can also use to hit stuff with (bayonets etc.)
-    const double my_val = more + ( less / 2.0 );
+    const double my_val = ( more + ( less / 2.0 ) ) * armor_penalty;
     add_msg( m_debug, "%s (%ld ammo) sum value: %.1f", weap.type->get_id().str(), ammo, my_val );
     if( is_wielding( weap ) ) {
         cached_info.emplace( "weapon_value", my_val );
@@ -2247,11 +2253,6 @@ double player::melee_value( const item &weap ) const
     // value style weapons more
     if( !martial_arts_data->enumerate_known_styles( weap.type->get_id() ).empty() ) {
         my_value *= 1.5;
-    }
-
-    // discourage wielding helmets, but not worn firearms
-    if( weapon.is_armor() && !weapon.is_gun() ) {
-        my_value = -1.0;
     }
 
     add_msg( m_debug, "%s as melee: %.1f", weap.type->get_id().str(), my_value );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Bigfixes "Set NPCs to not value standard armor as a melee weapon"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

On being reminded of the famous "NPC wielding helmet" bug I decided to look at how weapon value is calculated to see if I can try to forcibly put a stop to it.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

Changed `player::melee_value` in melee.cpp to override the value of any item that is counts as armor but does NOT count as a gun, setting it to minus one. The `is_gun()` bit is to ensure that guns with shoulder straps, bows, etc won't be devalued.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

I had at first assumed that maybe every helmet having `WBLOCK_1` was to blame, but it doesn't look like techniques are actually taken into account in the function.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

After a bit of testing with just a basic "multiply by zero" method I soon found that freshly-spawned NPCs might still choose to wield their helmet if their only other options are also at zero, so I started spawning dynamic NPCs out in the open and messing with them:
1. Rigged an NPC to be naked except for a worn army helmet. They successfully decided to stay unarmed.
2. Tested an NPC left naked except for a longbow. They correctly figured out that their longbow is a ranged weapon, and switched to it instead of keeping it worn.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

This is probably the oldest bug in Cataclysm that continues to show up.

![image](https://user-images.githubusercontent.com/11582235/136736298-3d95c745-5367-42c9-9358-8b5de179ccc8.png)