### PR TITLE
Fix broken builds due to Aftershock temperature modifiers

### DIFF
--- a/data/mods/Aftershock/mutations/mutations.json
+++ b/data/mods/Aftershock/mutations/mutations.json
@@ -50,7 +50,7 @@
     "id": "MIGO_HEAT_RESIST",
     "name": "Mi-go acclimatization",
     "points": 4,
-    "bodytemp_modifiers": [ -2500, -6500 ],
+    "bodytemp_modifiers": [ -6500, -2500 ],
     "description": "Fleshy fronds grown from your scalp function like organic heat sinks.  They allow you to live comfortably within the mi-go atmosphere.",
     "player_display": true,
     "threshreq": [ "THRESH_YUGGOTH" ],
@@ -92,7 +92,7 @@
     "description": "Your body becomes much more efficient at distributing heat from itself.",
     "category": [ "MIGO" ],
     "leads_to": [ "MIGO_HEAT_RESIST" ],
-    "bodytemp_modifiers": [ -500, -1250 ]
+    "bodytemp_modifiers": [ -1250, -500 ]
   },
   {
     "type": "mutation",

--- a/src/mutation_data.cpp
+++ b/src/mutation_data.cpp
@@ -322,7 +322,8 @@ void mutation_branch::load( const JsonObject &jo, const std::string & )
         bodytemp_max = bodytemp_array.get_int( 1 );
         if( bodytemp_max < bodytemp_min ) {
             std::swap( bodytemp_min, bodytemp_max );
-            debugmsg( _( "First temperature modifier can't be higher than the second" ) );
+            jo.throw_error( _( "First temperature modifier can't be higher than the second" ),
+                            "bodytemp_modifiers" );
         }
     }
 


### PR DESCRIPTION
Aftershock worked around the bug fixed in #1024 by swapping the values. Now the swap is unneeded.
Rather than just silently swapping it under the hood, I decided to make it an error. This causes build failures because of the Aftershock workaround.

Here I undo the workaround.