### PR TITLE
Revert more item types

### DIFF
--- a/data/json/items/tool/misc.json
+++ b/data/json/items/tool/misc.json
@@ -372,7 +372,7 @@
   },
   {
     "id": "horn_bicycle",
-    "type": "GENERIC",
+    "type": "TOOL",
     "category": "veh_parts",
     "name": { "str": "bicycle horn" },
     "description": "This is a simple bulb horn, found on many bicycles.  Use to honk.  Honk honk.",
@@ -927,7 +927,7 @@
   },
   {
     "id": "whistle_multitool",
-    "type": "GENERIC",
+    "type": "TOOL",
     "category": "tools",
     "name": { "str": "whistle multitool" },
     "description": "A cheap gadget combining a whistle, thermometer, magnifying glass, and compass.",

--- a/data/json/items/tool/shelters.json
+++ b/data/json/items/tool/shelters.json
@@ -17,7 +17,7 @@
   },
   {
     "id": "large_tent_kit",
-    "type": "GENERIC",
+    "type": "TOOL",
     "category": "tools",
     "name": { "str": "large tent" },
     "description": "This is a family sized tent.  It provides a large amount of space, but is very bulky.",
@@ -43,7 +43,7 @@
   },
   {
     "id": "shelter_kit",
-    "type": "GENERIC",
+    "type": "TOOL",
     "category": "tools",
     "name": { "str": "shelter kit" },
     "description": "This is a small shelter, made of sticks and skins.  Use it to place.",
@@ -68,7 +68,7 @@
   },
   {
     "id": "tent_kit",
-    "type": "GENERIC",
+    "type": "TOOL",
     "category": "tools",
     "name": { "str": "tent" },
     "description": "This is a small personal tent, it's just big enough to fit you comfortably.",

--- a/data/json/items/tool/toileteries.json
+++ b/data/json/items/tool/toileteries.json
@@ -75,7 +75,7 @@
   },
   {
     "id": "rag",
-    "type": "GENERIC",
+    "type": "TOOL",
     "category": "spare_parts",
     "name": { "str": "rag" },
     "description": "This is a largish piece of cloth, useful in crafting and possibly for staunching bleeding.",


### PR DESCRIPTION
Fix duplicating tents and shelter kits; fix bicycle horn & whistle multitool; stop infinite spawns of bloody rags.

Same deal as with #951