### PR TITLE
Tweak DMSO Description

### DIFF
--- a/data/json/items/chemicals_and_resources.json
+++ b/data/json/items/chemicals_and_resources.json
@@ -1138,7 +1138,7 @@
     "symbol": "~",
     "color": "light_cyan",
     "container": "bottle_glass",
-    "description": "Dimethyl sulfoxide, or DMSO, is a common and important aprotic solvent, capable of dissolving a huge range of things.  It has the weird property that it absorbs very quickly through the skin, causing a garlic flavor in the mouth even if it touched your arm.",
+    "description": "Dimethyl sulfoxide, or DMSO, is a common and important aprotic solvent, capable of dissolving a huge range of things.  It can help many chemical agents diffuse more quickly through the skin, and has a mild analgesic effect on its own.",
     "volume": "25 ml",
     "phase": "liquid",
     "use_action": {


### PR DESCRIPTION
Recently, DMSO was given a use as a mild painkiller, but the description for the item doesn't mention that. This updates the description to let players know that it is in fact a painkiller.