### PR TITLE
Fix buggy "You feel your x getting warm" messages

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -5085,17 +5085,17 @@ void Character::update_bodytemp( const map &m, weather_manager &weather )
     // We run it outside the loop because we can and so we should
     // Also, it makes bonus heat application more stable
     // TODO: Affect future convection temperature instead (might require adding back to loop)
-    temp_equalizer( bodypart_id( "torso" ), bodypart_id( "arm_l" ) );
-    temp_equalizer( bodypart_id( "torso" ), bodypart_id( "arm_r" ) );
-    temp_equalizer( bodypart_id( "torso" ), bodypart_id( "leg_l" ) );
-    temp_equalizer( bodypart_id( "torso" ), bodypart_id( "leg_r" ) );
-    temp_equalizer( bodypart_id( "torso" ), bodypart_id( "head" ) );
+    temp_equalizer( body_part_torso, body_part_arm_l );
+    temp_equalizer( body_part_torso, body_part_arm_r );
+    temp_equalizer( body_part_torso, body_part_leg_l );
+    temp_equalizer( body_part_torso, body_part_leg_r );
+    temp_equalizer( body_part_torso, body_part_head );
 
-    temp_equalizer( bodypart_id( "arm_l" ), bodypart_id( "hand_l" ) );
-    temp_equalizer( bodypart_id( "arm_r" ), bodypart_id( "hand_r" ) );
+    temp_equalizer( body_part_arm_l, body_part_hand_l );
+    temp_equalizer( body_part_arm_r, body_part_hand_r );
 
-    temp_equalizer( bodypart_id( "leg_l" ), bodypart_id( "foot_l" ) );
-    temp_equalizer( bodypart_id( "leg_r" ), bodypart_id( "foot_r" ) );
+    temp_equalizer( body_part_leg_l, body_part_foot_l );
+    temp_equalizer( body_part_leg_r, body_part_foot_r );
 
     for( const item &it : worn ) {
         // TODO: Port body part set id changes
@@ -5124,10 +5124,10 @@ void Character::update_bodytemp( const map &m, weather_manager &weather )
 
         const bool submerged_bp = submerged ||
                                   ( submerged_low &&
-                                    ( bp == bodypart_id( "foot_l" ) ||
-                                      bp == bodypart_id( "foot_r" ) ||
-                                      bp == bodypart_id( "leg_l" ) ||
-                                      bp == bodypart_id( "leg_r" ) ) );
+                                    ( bp == body_part_foot_l ||
+                                      bp == body_part_foot_r ||
+                                      bp == body_part_leg_l ||
+                                      bp == body_part_leg_r ) );
         // This adjusts the temperature scale to match the bodytemp scale
         const int adjusted_temp = submerged_bp ?
                                   water_temperature :
@@ -5315,8 +5315,8 @@ void Character::update_bodytemp( const map &m, weather_manager &weather )
         Less than -35F, more than 10 mp
         **/
 
-        if( bp == bodypart_id( "mouth" ) || bp == bodypart_id( "foot_r" ) ||
-            bp == bodypart_id( "foot_l" ) || bp == bodypart_id( "hand_r" ) || bp == bodypart_id( "hand_l" ) ) {
+        if( bp == body_part_mouth || bp == body_part_foot_r ||
+            bp == body_part_foot_l || bp == body_part_hand_r || bp == body_part_hand_l ) {
             // Handle the frostbite timer
             // Need temps in F, windPower already in mph
             int wetness_percentage = 100 * body_wetness[bp->token] / drench_capacity[bp->token]; // 0 - 100
@@ -5431,10 +5431,10 @@ void Character::update_bodytemp( const map &m, weather_manager &weather )
         // AND you have frostbite, then that also prevents you from sleeping
         if( in_sleep_state() ) {
             int curr_temperature = temp_cur[bp->token];
-            if( bp == bodypart_id( "torso" ) && curr_temperature <= BODYTEMP_COLD ) {
+            if( bp == body_part_torso && curr_temperature <= BODYTEMP_COLD ) {
                 add_msg( m_warning, _( "Your shivering prevents you from sleeping." ) );
                 wake_up();
-            } else if( bp != bodypart_id( "torso" ) && curr_temperature <= BODYTEMP_VERY_COLD &&
+            } else if( bp != body_part_torso && curr_temperature <= BODYTEMP_VERY_COLD &&
                        has_effect( effect_frostbite ) ) {
                 add_msg( m_warning, _( "You are too cold.  Your frostbite prevents you from sleeping." ) );
                 wake_up();


### PR DESCRIPTION
I couldn't get the game to produce "endless" messages, but I noticed that these messages are frequently printed twice or thrice instead of once, or sometimes are not printed at all.

The cause of latter is unhandled edge case in threshold check (if temperature before or after equals threshold, no message is printed), but the former was caused by bodypart temperature equalization "reducing" limb temperature between reports enough that the threshold could be hit multiple times.

The solution is to 
1. Fix threshold check to include threshold itself in comparison
2. Include temperature change from equalization into the overall change checked against the threshold.

This should fix #911 as I believe it was some edge case where temperature has stabilized slightly above the threshold, so on each turn the equalization would dip it slightly below, and the following warming check would bump it back above and trigger the message.