### PR TITLE
Allow repairing installed storage batteries analogously to solar panels

### DIFF
--- a/data/json/requirements/materials.json
+++ b/data/json/requirements/materials.json
@@ -191,6 +191,12 @@
     "components": [ [ [ "solar_cell", 5 ] ], [ [ "cable", 8 ] ], [ [ "power_supply", 1 ] ], [ [ "amplifier", 1 ] ] ]
   },
   {
+    "id": "storage_battery",
+    "type": "requirement",
+    "//": "Materials used to repair storage batteries",
+    "components": [ [ [ "small_storage_battery", 1 ] ], [ [ "cable", 2 ] ] ]
+  },
+  {
     "id": "tire_repair",
     "type": "requirement",
     "//": "Materials used for repairing tires",

--- a/data/json/vehicleparts/battery.json
+++ b/data/json/vehicleparts/battery.json
@@ -63,7 +63,14 @@
       { "item": "steel_chunk", "count": [ 5, 10 ] },
       { "item": "scrap", "count": [ 5, 10 ] },
       { "item": "storage_battery", "count": [ 0, 1 ] }
-    ]
+    ],
+    "requirements": {
+      "repair": {
+        "skills": [ [ "electronics", 4 ] ],
+        "time": "50 m",
+        "using": [ [ "vehicle_screw", 1 ], [ "storage_battery", 6 ], [ "soldering_standard", 16 ] ]
+      }
+    }
   },
   {
     "id": "large_storage_battery_removable",
@@ -74,7 +81,12 @@
     "location": "on_battery_mount",
     "requirements": {
       "install": { "skills": [ [ "mechanics", 0 ] ], "time": "10 s", "using": [  ] },
-      "removal": { "skills": [ [ "mechanics", 0 ] ], "time": "10 s", "using": [  ] }
+      "removal": { "skills": [ [ "mechanics", 0 ] ], "time": "10 s", "using": [  ] },
+      "repair": {
+        "skills": [ [ "electronics", 4 ] ],
+        "time": "50 m",
+        "using": [ [ "vehicle_screw", 1 ], [ "storage_battery", 6 ], [ "soldering_standard", 16 ] ]
+      }
     },
     "description": "A battery for storing electrical power, and discharging it to power electrical devices built into the vehicle.  This one is mounted on a quick release framework to allow it to be easily swapped, though it still weighs so much that a lifting tool of some kind is necessary for most people.",
     "flags": [ "NEEDS_BATTERY_MOUNT" ]
@@ -91,7 +103,12 @@
     "breaks_into": [ { "item": "scrap", "count": [ 1, 4 ] }, { "item": "small_storage_battery", "count": [ 0, 7 ] } ],
     "requirements": {
       "install": { "skills": [ [ "mechanics", 0 ] ], "time": "200 s", "using": "vehicle_screw" },
-      "removal": { "skills": [ [ "mechanics", 0 ] ], "time": "200 s", "using": "vehicle_screw" }
+      "removal": { "skills": [ [ "mechanics", 0 ] ], "time": "200 s", "using": "vehicle_screw" },
+      "repair": {
+        "skills": [ [ "electronics", 4 ] ],
+        "time": "25 m",
+        "using": [ [ "vehicle_screw", 1 ], [ "storage_battery", 1 ], [ "soldering_standard", 3 ] ]
+      }
     },
     "extend": { "flags": [ "FOLDABLE" ] }
   },
@@ -107,7 +124,8 @@
     "breaks_into": [ { "item": "scrap", "count": [ 1, 2 ] } ],
     "requirements": {
       "install": { "skills": [ [ "mechanics", 0 ] ], "time": "100 s", "using": [  ] },
-      "removal": { "skills": [ [ "mechanics", 0 ] ], "time": "100 s", "using": [  ] }
+      "removal": { "skills": [ [ "mechanics", 0 ] ], "time": "100 s", "using": [  ] },
+      "repair": {  }
     },
     "extend": { "flags": [ "FOLDABLE" ] }
   },
@@ -132,7 +150,12 @@
     ],
     "requirements": {
       "install": { "skills": [ [ "mechanics", 2 ] ], "time": "600 s", "using": [ [ "welding_standard", 5 ] ] },
-      "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "300 s", "using": "vehicle_weld_removal" }
+      "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "300 s", "using": "vehicle_weld_removal" },
+      "repair": {
+        "skills": [ [ "electronics", 4 ] ],
+        "time": "50 m",
+        "using": [ [ "vehicle_screw", 1 ], [ "storage_battery", 3 ], [ "soldering_standard", 8 ] ]
+      }
     }
   },
   {


### PR DESCRIPTION
#### Summary

SUMMARY: Features "Allow repairing installed storage batteries analogously to solar panels"

#### Purpose of change

Completely blocking the player from repairing trashed batteries feels overly harsh. Currently, the only way to get good batteries from damaged ones is disassembling them for small storage batteries and re-crafting. Why not abstract this tedium away?

#### Describe the solution

It seems logical to allow repairing storage batteries in the same way as solar panels, i.e. by replacing individual cells within them. In our case, small storage batteries will play the role of such indivisible cells, which themselves still can't be repaired.

The following vehicle parts have been made repairable this way:
- storage battery
- large storage battery
- swappable variants of the above
- medium storage battery

They still aren't repairable as items, but neither are solar panels, so I figured it is acceptable, at least for now.

#### Describe alternatives you've considered

- Use the same repair requirements as for lead-acid car batteries.
- Make storage batteries repairable in their "loose item" form instead.

Both these options lead to the opposite extreme and feel like cheating.

#### Testing

Trying all battery types on a vehicle in a test world was enough to make sure all requirements work as intended.
