### PR TITLE
Fix spells being stopped by fences

### DIFF
--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -198,7 +198,7 @@ std::set<tripoint> spell_effect::spell_effect_cone( const spell &sp, const tripo
     for( const tripoint &ep : end_points ) {
         std::vector<tripoint> trajectory = line_to( source, ep );
         for( const tripoint &tp : trajectory ) {
-            if( ignore_walls || g->m.passable( tp ) ) {
+            if( ignore_walls || g->m.passable( tp ) || g->m.has_flag( "THIN_OBSTACLE", tp ) ) {
                 targets.emplace( tp );
             } else {
                 break;
@@ -216,7 +216,7 @@ static bool test_always_true( const tripoint & )
 }
 static bool test_passable( const tripoint &p )
 {
-    return g->m.passable( p );
+    return ( g->m.passable( p ) || g->m.has_flag( "THIN_OBSTACLE", p ) );
 }
 
 std::set<tripoint> spell_effect::spell_effect_line( const spell &, const tripoint &source,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Fix spells being completely halted by chain link fences"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Simple fix for one of many minor bugs with spellcasting code, chose to tinker with it while I'm in bed, before I forgot yet another misc problem I'd neglected to put on the todo list.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Changed checks in magic_spell_effect.cpp so that spellcasting checks for impassable terrain will ignore obstacles with the `THIN_OBSTACLE` flag. This fixes chain-link fences being able to fully halt spells when basically every other form of ranged attack goes right through.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Tying it to `PERMEABLE` instead? Not sure.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Compiled and load tested.
2. Dropped in Arcana_BN temporarily for testing.
3. Tested an AoE target_attack spell, a cone_attack spell, and a line_attack spell on both a solid wall and a fence.
4. As expected, all of them were properly stopped by the wall, but ignored the fence.
5. Tested versions of the above with IGNORE_WALLS flag.
6. As expected, those spells went through both walls and fences.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

Pinging @KorGgenT as they may wish to fix this on DDA's end too, once I've tested it and confirmed it works right. EDIT: And now seems to work, so.