### PR TITLE
Fix hit_you_effect effects triggering even on misses

### DIFF
--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -585,6 +585,7 @@ void Character::melee_attack( Creature &t, bool allow_special, const matec_id &f
         }
 
         t.check_dead_state();
+        did_hit( t );
 
         if( t.is_dead_state() ) {
             // trigger martial arts on-kill effects
@@ -611,7 +612,6 @@ void Character::melee_attack( Creature &t, bool allow_special, const matec_id &f
     martial_arts_data->ma_onattack_effects( *this );
     // some things (shattering weapons) can harm the attacking creature.
     check_dead_state();
-    did_hit( t );
     if( t.as_character() ) {
         dealt_projectile_attack dp = dealt_projectile_attack();
         t.as_character()->on_hit( this, bodypart_id( "num_bp" ), 0.0f, &dp );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Fix hit_you_effect spells triggering on attack instead of on hit"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Fix for this classic bit of buggy relic code turned out to be trivial once I followed the thread of functions. Fixes the nonsense where on-hit-enemy relic effects trigger even when you miss, unlike on-player-hit relic effects that correctly only trigger when the player is actually HIT, not just attacked.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

Moved `did_hit( t );` in melee.cpp's `Character::melee_attack` function from the very end to the section inside the actual "here's what we do if we didn't miss" part.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Scooting `hit_me_effect` check to some equally non-sensical place so missed attacks can trigger them, so we can be consistently buggy.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Started up a test build without this change, using Magiclysm.
2. Spawned in a fireball hammer and a zombie child.
3. Confirmed that it blows up in my face even on a miss.
4. Compiled and load-tested file change.
5. Started with a world with Magiclysm, fireball hammer, and zombie child again.
6. No explosions until I actually scored a hit, as expected and desired.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

![image](https://user-images.githubusercontent.com/11582235/137258294-5a45ec00-8f71-440e-a12e-9a6e50ee84ea.png)

Pinging @KorGgenT for awareness of another easy fix to their magic code they may wish to port over to DDA.