### PR TITLE
Attempt to fix undefined behavior in weather gen

### DIFF
--- a/src/weather_gen.cpp
+++ b/src/weather_gen.cpp
@@ -250,7 +250,7 @@ const weather_type_id &weather_generator::get_weather_conditions( const w_point 
         }
         current_conditions = &type;
     }
-    return *current_conditions;
+    return current_conditions->obj().id;
 }
 
 int weather_generator::get_wind_direction( const season_type season ) const


### PR DESCRIPTION
Fixes #1055

It seems that, at least on some builds, weather generator must have been returning address of a temporary variable, rather than a reference to the actual object.
At least that's my best guess. With this fix, it worked for me. Without, it reliably crashed.