### PR TITLE
Added autodoc installation datum which almost guarantees flawless installation of basic-tier bionics

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -57,6 +57,12 @@
     "conflicts": [ "OUTER", "SKINTIGHT", "WAIST", "PERSONAL", "AURA" ]
   },
   {
+    "id": "BIONIC_INSTALLATION_DATA",
+    "type": "json_flag",
+    "context": [ "GENERIC" ],
+    "info": "This item <info>provides</info> instructions and other required data for several bionics, allowing installation of them with <good>minimal failure chance</good>."
+  },
+  {
     "id": "BIONIC_NPC_USABLE",
     "type": "json_flag",
     "context": [ "BIONIC_ITEM" ],

--- a/data/json/itemgroups/electronics.json
+++ b/data/json/itemgroups/electronics.json
@@ -113,5 +113,34 @@
       { "item": "smart_phone", "prob": 9, "charges-min": 0, "charges-max": 15 },
       { "item": "smart_phone", "prob": 1, "charges-min": 130, "charges-max": 130 }
     ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "distribution",
+    "id": "autodoc_installation_programs",
+    "items": [
+      { "item": "AID_bio_alarm" },
+      { "item": "AID_bio_tattoo_led" },
+      { "item": "AID_bio_power_armor_interface" },
+      { "item": "AID_bio_power_storage" },
+      { "item": "AID_bio_power_storage_mkII" },
+      { "item": "AID_bio_watch" },
+      { "item": "AID_bio_syringe" },
+      { "item": "AID_bio_blood_anal" },
+      { "item": "AID_bio_flashlight" },
+      { "item": "AID_bio_magnet" },
+      { "item": "AID_bio_soporific" },
+      { "item": "AID_bio_armor_arms" },
+      { "item": "AID_bio_armor_legs" },
+      { "item": "AID_bio_shotgun" },
+      { "item": "AID_bio_blood_filter" },
+      { "item": "AID_bio_climate" },
+      { "item": "AID_bio_geiger" },
+      { "item": "AID_bio_heatsink" },
+      { "item": "AID_bio_meteorologist" },
+      { "item": "AID_bio_railgun" },
+      { "item": "AID_bio_ups" },
+      { "item": "AID_bio_weight" }
+    ]
   }
 ]

--- a/data/json/items/bionics.json
+++ b/data/json/items/bionics.json
@@ -64,7 +64,8 @@
     "description": "A motion-detecting alarm system will notice almost all movement within a fifteen-foot radius, and will silently alert the user.  This is very useful during sleep, or if the user suspects a cloaked pursuer.",
     "price": 25000,
     "weight": "500 g",
-    "difficulty": 1
+    "difficulty": 1,
+    "installation_data": "AID_bio_alarm"
   },
   {
     "id": "bio_armor_arms",
@@ -73,7 +74,8 @@
     "name": { "str": "Arms Alloy Plating CBM" },
     "description": "Alloy plating that replaces the flesh on the user's arms.  Provides passive protection and can be used in conjunction with bionic martial arts.",
     "price": 350000,
-    "difficulty": 3
+    "difficulty": 3,
+    "installation_data": "AID_bio_armor_arms"
   },
   {
     "id": "bio_armor_eyes",
@@ -105,7 +107,8 @@
     "looks_like": "bio_int_enhancer",
     "description": "Alloy plating that replaces the flesh on the user's legs.  Provides passive protection and can be used in conjunction with bionic martial arts.",
     "price": 350000,
-    "difficulty": 3
+    "difficulty": 3,
+    "installation_data": "AID_bio_armor_legs"
   },
   {
     "id": "bio_armor_torso",
@@ -148,7 +151,8 @@
     "looks_like": "bio_int_enhancer",
     "description": "A concealed, single shot 12 gauge shotgun that is implanted inside the left forearm.  Perfect in a pinch.",
     "price": 220000,
-    "difficulty": 3
+    "difficulty": 3,
+    "installation_data": "AID_bio_shotgun"
   },
   {
     "id": "bio_blood_anal",
@@ -159,7 +163,8 @@
     "description": "Small sensors that are implanted in the user's heart, allowing them to analyze their blood.  This will detect many illnesses, drugs, and other conditions.",
     "price": 320000,
     "weight": "150 g",
-    "difficulty": 2
+    "difficulty": 2,
+    "installation_data": "AID_bio_blood_anal"
   },
   {
     "id": "bio_blood_filter",
@@ -170,7 +175,8 @@
     "description": "A filtration system that is installed in the heart and can actively filter out chemical impurities, primarily drugs, with limited impact on viruses.  Note that it is not a targeted filter; ALL drugs in the system will be affected.",
     "price": 350000,
     "weight": "200 g",
-    "difficulty": 3
+    "difficulty": 3,
+    "installation_data": "AID_bio_blood_filter"
   },
   {
     "id": "bio_cable",
@@ -222,7 +228,8 @@
     "looks_like": "bio_int_enhancer",
     "description": "A network of thermal piping which eases the effects of high and low ambient temperatures once activated.",
     "price": 350000,
-    "difficulty": 3
+    "difficulty": 3,
+    "installation_data": "AID_bio_climate"
   },
   {
     "id": "bio_cloak",
@@ -392,7 +399,8 @@
     "description": "A small, but powerful LED flashlight that is mounted between the eyes.",
     "price": 20000,
     "weight": "250 g",
-    "difficulty": 2
+    "difficulty": 2,
+    "installation_data": "AID_bio_flashlight"
   },
   {
     "id": "bio_tattoo_led",
@@ -403,7 +411,8 @@
     "description": "An LED display implanted beneath the epidermis that can display patterns or pictures through the skin.  When active it glows dimly, providing a very small amount of light.",
     "price": 20000,
     "weight": "20 g",
-    "difficulty": 1
+    "difficulty": 1,
+    "installation_data": "AID_bio_tattoo_led"
   },
   {
     "id": "bio_geiger",
@@ -414,7 +423,8 @@
     "description": "Small radiation sensors that are implanted throughout the body, allowing the user to analyze their level of absorbed radiation.  They will also alert the user whenever exposed to environmental radiation.",
     "price": 350000,
     "weight": "150 g",
-    "difficulty": 3
+    "difficulty": 3,
+    "installation_data": "AID_bio_geiger"
   },
   {
     "id": "bio_gills",
@@ -457,7 +467,8 @@
     "looks_like": "bio_int_enhancer",
     "description": "Powerful heatsinks and supermaterials are woven into the user's flesh.  While powered, this system will prevent external heat damage up to 2000 degrees Fahrenheit.  Note that this does not affect the internal body temperature.",
     "price": 350000,
-    "difficulty": 3
+    "difficulty": 3,
+    "installation_data": "AID_bio_heatsink"
   },
   {
     "id": "bio_hydraulics",
@@ -543,7 +554,8 @@
     "description": "A powerful electromagnet that is implanted into the user's right hand, allowing them to indiscriminately pull all nearby magnetic objects towards them.  Unlucky bystanders might be injured or killed by flying objects.",
     "price": 200000,
     "weight": "700 g",
-    "difficulty": 2
+    "difficulty": 2,
+    "installation_data": "AID_bio_magnet"
   },
   {
     "id": "bio_membrane",
@@ -587,7 +599,8 @@
     "description": "A multitude of scientific instruments and sensors collect environmental data.  The data is compiled and presented as a simple readout of the current weather.  It also passively tells the user their external temperature.",
     "price": 350000,
     "weight": "700 g",
-    "difficulty": 3
+    "difficulty": 3,
+    "installation_data": "AID_bio_meteorologist"
   },
   {
     "id": "bio_nanobots",
@@ -652,7 +665,8 @@
     "description": "Interfaces the user's bionic power system with the internal charging port on suits of power armor, allowing them to draw from the user's bionic power banks.",
     "price": 120000,
     "weight": "500 g",
-    "difficulty": 1
+    "difficulty": 1,
+    "installation_data": "AID_bio_power_armor_interface"
   },
   {
     "id": "bio_power_armor_interface_mkII",
@@ -674,7 +688,8 @@
     "description": "A Compact Bionics Module that upgrades the user's power capacity by 100 units.  Having at least one of these is a prerequisite to using powered bionics.  The user will also need a power supply, found in various CBMs.",
     "price": 380000,
     "weight": "70 g",
-    "difficulty": 1
+    "difficulty": 1,
+    "installation_data": "AID_bio_power_storage"
   },
   {
     "id": "bio_power_storage_mkII",
@@ -685,7 +700,8 @@
     "description": "A Compact Bionics Module developed at DoubleTech Industries as a replacement for the highly successful Power Storage CBM.  Increases the user's power capacity by 250 units.",
     "price": 1000000,
     "weight": "50 g",
-    "difficulty": 1
+    "difficulty": 1,
+    "installation_data": "AID_bio_power_storage_mkII"
   },
   {
     "id": "bio_probability_travel",
@@ -728,7 +744,8 @@
     "description": "EM field generators in the user's arms increase the range and damage of thrown magnetic objects at a cost of 1 bionic power per throw.  They will create a trail of electricity that can cause additional damage.",
     "price": 220000,
     "weight": "1000 g",
-    "difficulty": 3
+    "difficulty": 3,
+    "installation_data": "AID_bio_railgun"
   },
   {
     "id": "bio_razors",
@@ -944,7 +961,8 @@
     "description": "A Unified Power System that is wired into the user's bionic power banks.  Objects that run on a UPS can now directly draw power from the bionic power supply.",
     "price": 25000,
     "weight": "700 g",
-    "difficulty": 3
+    "difficulty": 3,
+    "installation_data": "AID_bio_ups"
   },
   {
     "id": "bio_watch",
@@ -955,7 +973,8 @@
     "description": "This bionic module contains an atomic clock, complete with silent alarm clock function.",
     "price": 1000,
     "weight": "10 g",
-    "difficulty": 1
+    "difficulty": 1,
+    "installation_data": "AID_bio_watch"
   },
   {
     "id": "bio_water_extractor",
@@ -977,7 +996,8 @@
     "description": "A small tube with a retractable needle that terminates in a net of tiny hoses instead of a plunger.  Installed, it allows the user to draw substances directly into their bloodstream akin to a regular syringe.",
     "price": 1000,
     "weight": "10 g",
-    "difficulty": 1
+    "difficulty": 1,
+    "installation_data": "AID_bio_syringe"
   },
   {
     "id": "bio_weight",
@@ -988,7 +1008,8 @@
     "description": "A set of hinges, springs, and other synthetic augments for the skeletal structure.  These artificial enhancers strengthen the knees and elbows, allowing the user to carry more weight.",
     "price": 50000,
     "weight": "3000 g",
-    "difficulty": 3
+    "difficulty": 3,
+    "installation_data": "AID_bio_weight"
   },
   {
     "id": "bio_shock_absorber",
@@ -1021,7 +1042,8 @@
     "description": "A microscopic electrode designed to gently stimulate a particular cluster of neurons in the hypothalamus, helping the user to fall asleep.",
     "price": 350000,
     "weight": "50 g",
-    "difficulty": 2
+    "difficulty": 2,
+    "installation_data": "AID_bio_soporific"
   },
   {
     "id": "bio_ankles",

--- a/data/json/items/software.json
+++ b/data/json/items/software.json
@@ -1,5 +1,171 @@
 [
   {
+    "abstract": "AID_abstract",
+    "type": "GENERIC",
+    "name": { "str": "abstract autodoc installation data" },
+    "symbol": "#",
+    "weight": "150 g",
+    "volume": "50 ml",
+    "price": "200 USD",
+    "price_postapoc": "50 USD",
+    "looks_like": "data_card",
+    "flags": [ "BIONIC_INSTALLATION_DATA" ]
+  },
+  {
+    "id": "AID_bio_alarm",
+    "copy-from": "AID_abstract",
+    "type": "GENERIC",
+    "name": { "str_sp": "Alarm System CBM installation data" },
+    "description": "Precise step-by-step instructions and other required data for installation of Alarm System CBM, stored on a data card of proprietary form-factor, designed to be used extensively by an Autodoc, and allowing bionic installation with minimal failure chance.  Integrated security subroutine renders it unusable after installation."
+  },
+  {
+    "id": "AID_bio_tattoo_led",
+    "type": "GENERIC",
+    "copy-from": "AID_abstract",
+    "name": { "str_sp": "LED Tattoo CBM installation data" },
+    "description": "Precise step-by-step instructions and other required data for installation of LED Tattoo CBM, stored on a data card of proprietary form-factor, designed to be used extensively by an Autodoc, and allowing bionic installation with minimal failure chance.  Integrated security subroutine renders it unusable after installation."
+  },
+  {
+    "id": "AID_bio_power_armor_interface",
+    "type": "GENERIC",
+    "copy-from": "AID_abstract",
+    "name": { "str_sp": "Power Armor Interface CBM installation data" },
+    "description": "Precise step-by-step instructions and other required data for installation of Power Armor Interface CBM, stored on a data card of proprietary form-factor, designed to be used extensively by an Autodoc, and allowing bionic installation with minimal failure chance.  Integrated security subroutine renders it unusable after installation."
+  },
+  {
+    "id": "AID_bio_power_storage",
+    "type": "GENERIC",
+    "copy-from": "AID_abstract",
+    "name": { "str_sp": "Power Storage CBM installation data" },
+    "description": "Precise step-by-step instructions and other required data for installation of Power Storage CBM, stored on a data card of proprietary form-factor, designed to be used extensively by an Autodoc, and allowing bionic installation with minimal failure chance.  Integrated security subroutine renders it unusable after installation."
+  },
+  {
+    "id": "AID_bio_power_storage_mkII",
+    "type": "GENERIC",
+    "copy-from": "AID_abstract",
+    "name": { "str_sp": "Power Storage CBM Mk. II installation data" },
+    "description": "Precise step-by-step instructions and other required data for installation of Power Storage CBM Mk. II, stored on a data card of proprietary form-factor, designed to be used extensively by an Autodoc, and allowing bionic installation with minimal failure chance.  Integrated security subroutine renders it unusable after installation."
+  },
+  {
+    "id": "AID_bio_watch",
+    "type": "GENERIC",
+    "copy-from": "AID_abstract",
+    "name": { "str_sp": "Internal Chronometer CBM installation data" },
+    "description": "Precise step-by-step instructions and other required data for installation of Internal Chronometer CBM, stored on a data card of proprietary form-factor, designed to be used extensively by an Autodoc, and allowing bionic installation with minimal failure chance.  Integrated security subroutine renders it unusable after installation."
+  },
+  {
+    "id": "AID_bio_syringe",
+    "type": "GENERIC",
+    "copy-from": "AID_abstract",
+    "name": { "str_sp": "Intravenous Needletip CBM installation data" },
+    "description": "Precise step-by-step instructions and other required data for installation of Intravenous Needletip CBM, stored on a data card of proprietary form-factor, designed to be used extensively by an Autodoc, and allowing bionic installation with minimal failure chance.  Integrated security subroutine renders it unusable after installation."
+  },
+  {
+    "id": "AID_bio_blood_anal",
+    "type": "GENERIC",
+    "copy-from": "AID_abstract",
+    "name": { "str_sp": "Blood Analysis CBM installation data" },
+    "description": "Precise step-by-step instructions and other required data for installation of Blood Analysis CBM, stored on a data card of proprietary form-factor, designed to be used extensively by an Autodoc, and allowing bionic installation with minimal failure chance.  Integrated security subroutine renders it unusable after installation."
+  },
+  {
+    "id": "AID_bio_flashlight",
+    "type": "GENERIC",
+    "copy-from": "AID_abstract",
+    "name": { "str_sp": "Cranial Flashlight CBM installation data" },
+    "description": "Precise step-by-step instructions and other required data for installation of Cranial Flashlight CBM, stored on a data card of proprietary form-factor, designed to be used extensively by an Autodoc, and allowing bionic installation with minimal failure chance.  Integrated security subroutine renders it unusable after installation."
+  },
+  {
+    "id": "AID_bio_magnet",
+    "type": "GENERIC",
+    "copy-from": "AID_abstract",
+    "name": { "str_sp": "Electromagnetic Unit CBM installation data" },
+    "description": "Precise step-by-step instructions and other required data for installation of Electromagnetic Unit CBM, stored on a data card of proprietary form-factor, designed to be used extensively by an Autodoc, and allowing bionic installation with minimal failure chance.  Integrated security subroutine renders it unusable after installation."
+  },
+  {
+    "id": "AID_bio_soporific",
+    "type": "GENERIC",
+    "copy-from": "AID_abstract",
+    "name": { "str_sp": "Soporific Induction CBM installation data" },
+    "description": "Precise step-by-step instructions and other required data for installation of Soporific Induction CBM, stored on a data card of proprietary form-factor, designed to be used extensively by an Autodoc, and allowing bionic installation with minimal failure chance.  Integrated security subroutine renders it unusable after installation."
+  },
+  {
+    "id": "AID_bio_armor_arms",
+    "type": "GENERIC",
+    "copy-from": "AID_abstract",
+    "name": { "str_sp": "Arms Alloy Plating CBM installation data" },
+    "description": "Precise step-by-step instructions and other required data for installation of Arms Alloy Plating CBM, stored on a data card of proprietary form-factor, designed to be used extensively by an Autodoc, and allowing bionic installation with minimal failure chance.  Integrated security subroutine renders it unusable after installation."
+  },
+  {
+    "id": "AID_bio_armor_legs",
+    "type": "GENERIC",
+    "copy-from": "AID_abstract",
+    "name": { "str_sp": "Legs Alloy Plating CBM installation data" },
+    "description": "Precise step-by-step instructions and other required data for installation of Legs Alloy Plating CBM, stored on a data card of proprietary form-factor, designed to be used extensively by an Autodoc, and allowing bionic installation with minimal failure chance.  Integrated security subroutine renders it unusable after installation."
+  },
+  {
+    "id": "AID_bio_shotgun",
+    "type": "GENERIC",
+    "copy-from": "AID_abstract",
+    "name": { "str_sp": "Shotgun Arm CBM installation data" },
+    "description": "Precise step-by-step instructions and other required data for installation of Shotgun Arm CBM, stored on a data card of proprietary form-factor, designed to be used extensively by an Autodoc, and allowing bionic installation with minimal failure chance.  Integrated security subroutine renders it unusable after installation."
+  },
+  {
+    "id": "AID_bio_blood_filter",
+    "type": "GENERIC",
+    "copy-from": "AID_abstract",
+    "name": { "str_sp": "Blood Filter CBM installation data" },
+    "description": "Precise step-by-step instructions and other required data for installation of Blood Filter CBM, stored on a data card of proprietary form-factor, designed to be used extensively by an Autodoc, and allowing bionic installation with minimal failure chance.  Integrated security subroutine renders it unusable after installation."
+  },
+  {
+    "id": "AID_bio_climate",
+    "type": "GENERIC",
+    "copy-from": "AID_abstract",
+    "name": { "str_sp": "Internal Climate Control CBM installation data" },
+    "description": "Precise step-by-step instructions and other required data for installation of Internal Climate Control CBM, stored on a data card of proprietary form-factor, designed to be used extensively by an Autodoc, and allowing bionic installation with minimal failure chance.  Integrated security subroutine renders it unusable after installation."
+  },
+  {
+    "id": "AID_bio_geiger",
+    "type": "GENERIC",
+    "copy-from": "AID_abstract",
+    "name": { "str_sp": "Integrated Dosimeter CBM installation data" },
+    "description": "Precise step-by-step instructions and other required data for installation of Integrated Dosimeter CBM, stored on a data card of proprietary form-factor, designed to be used extensively by an Autodoc, and allowing bionic installation with minimal failure chance.  Integrated security subroutine renders it unusable after installation."
+  },
+  {
+    "id": "AID_bio_heatsink",
+    "type": "GENERIC",
+    "copy-from": "AID_abstract",
+    "name": { "str_sp": "Thermal Dissipation CBM installation data" },
+    "description": "Precise step-by-step instructions and other required data for installation of Thermal Dissipation CBM, stored on a data card of proprietary form-factor, designed to be used extensively by an Autodoc, and allowing bionic installation with minimal failure chance.  Integrated security subroutine renders it unusable after installation."
+  },
+  {
+    "id": "AID_bio_meteorologist",
+    "type": "GENERIC",
+    "copy-from": "AID_abstract",
+    "name": { "str_sp": "Weather Reader CBM installation data" },
+    "description": "Precise step-by-step instructions and other required data for installation of Weather Reader CBM, stored on a data card of proprietary form-factor, designed to be used extensively by an Autodoc, and allowing bionic installation with minimal failure chance.  Integrated security subroutine renders it unusable after installation."
+  },
+  {
+    "id": "AID_bio_railgun",
+    "type": "GENERIC",
+    "copy-from": "AID_abstract",
+    "name": { "str_sp": "Railgun CBM installation data" },
+    "description": "Precise step-by-step instructions and other required data for installation of Railgun CBM, stored on a data card of proprietary form-factor, designed to be used extensively by an Autodoc, and allowing bionic installation with minimal failure chance.  Integrated security subroutine renders it unusable after installation."
+  },
+  {
+    "id": "AID_bio_ups",
+    "type": "GENERIC",
+    "copy-from": "AID_abstract",
+    "name": { "str_sp": "Unified Power System CBM installation data" },
+    "description": "Precise step-by-step instructions and other required data for installation of Unified Power System CBM, stored on a data card of proprietary form-factor, designed to be used extensively by an Autodoc, and allowing bionic installation with minimal failure chance.  Integrated security subroutine renders it unusable after installation."
+  },
+  {
+    "id": "AID_bio_weight",
+    "type": "GENERIC",
+    "copy-from": "AID_abstract",
+    "name": { "str_sp": "Titanium Skeletal Bracing CBM installation data" },
+    "description": "Precise step-by-step instructions and other required data for installation of Titanium Skeletal Bracing CBM, stored on a data card of proprietary form-factor, designed to be used extensively by an Autodoc, and allowing bionic installation with minimal failure chance.  Integrated security subroutine renders it unusable after installation."
+  },
+  {
     "id": "software",
     "type": "GENERIC",
     "name": { "str_sp": "software" },

--- a/data/json/mapgen/hospital.json
+++ b/data/json/mapgen/hospital.json
@@ -43,12 +43,12 @@
         "#......................x...........l#8....#...#rrr.l#``#l.rrr#...#rrr.l#",
         "#....................../.....A..BT.l#8....!...!....l#``#l....!...!....l#",
         "#....................../.....?..B..r#88888#...#rrr.l#``#l.rrr#...#rrr.l#",
-        "#......................x...........r#######///#######``#######///#######",
-        "####################///##############...cT#...#Tc...#``#...cT#...#Tc...#",
-        "###########.......l#...x...........l#BB...+...+...BB#``#BB...+...+...BB#",
-        "###########r.TBBT..#.../.....TBBT...#BB...+...+...BB#``#BB...+...+...BB#",
-        "###########r..BB...#.../......BB...r#....l#...#l....#``#....l#...#l....#",
-        "###########........#...x...........r#######...#######``#######...#######",
+        "#5.....................x...........r#######///#######``#######///#######",
+        "##X#################///##############...cT#...#Tc...#``#...cT#...#Tc...#",
+        "#H.......H#.......l#...x...........l#BB...+...+...BB#``#BB...+...+...BB#",
+        "#H.......H#r.TBBT..#.../.....TBBT...#BB...+...+...BB#``#BB...+...+...BB#",
+        "#H.......H#r..BB...#.../......BB...r#....l#...#l....#``#....l#...#l....#",
+        "#H.......H#........#...x...........r#######...#######``#######...#######",
         "###########xxx//xxx#...##############....l#...#l....#``#....l#...#l....#",
         "#l........x............x...........R#BB...+...+...BB#``#BB...+...+...BB#",
         "#R.TB..A../............/.....6.....R#BB...+...+...BB#``#BB...+...+...BB#",
@@ -85,8 +85,16 @@
         "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx#######################;;#################"
       ],
       "palettes": [ "hospital" ],
+      "terrain": { "5": "t_floor", "H": "t_floor", "X": "t_door_metal_locked" },
+      "furniture": { "H": "f_locker" },
       "vendingmachines": { "D": { "item_group": "vending_drink" }, "F": { "item_group": "vending_food" } },
       "computers": {
+        "5": {
+          "name": "Medical Supply Access",
+          "security": 2,
+          "options": [ { "name": "Unlock Door", "action": "unlock" } ],
+          "failures": [ { "action": "shutdown" }, { "action": "alarm" } ]
+        },
         "6": {
           "name": "Centrifuge",
           "options": [ { "name": "Analyze blood", "action": "blood_anal" } ],
@@ -108,8 +116,16 @@
         "9": { "item": "produce", "chance": 40 },
         "T": { "item": "snacks", "chance": 50 },
         "2": { "item": "hospital_samples", "chance": 50 },
-        "k": { "item": "doctors_books", "chance": 60 }
+        "k": { "item": "doctors_books", "chance": 60 },
+        "H": [
+          { "item": "harddrugs", "chance": 60 },
+          { "item": "gear_medical", "chance": 60, "repeat": [ 1, 3 ] },
+          { "item": "drugs_analgesic", "chance": 60, "repeat": [ 1, 3 ] },
+          { "item": "drugs_rare", "chance": 60 },
+          { "item": "surgery", "chance": 60 }
+        ]
       },
+      "place_loot": [ { "group": "autodoc_installation_programs", "x": 1, "y": [ 34, 37 ], "chance": 75, "repeat": 4 } ],
       "place_monsters": [
         { "monster": "GROUP_HOSPITAL", "x": [ 0, 23 ], "y": [ 0, 23 ], "repeat": [ 0, 3 ], "density": 3 },
         { "monster": "GROUP_HOSPITAL", "x": [ 25, 46 ], "y": [ 1, 22 ], "repeat": [ 0, 3 ], "density": 3 },

--- a/data/json/mapgen/office_doctor.json
+++ b/data/json/mapgen/office_doctor.json
@@ -337,7 +337,8 @@
         { "item": "laptop", "x": 4, "y": 4, "chance": 85 },
         { "item": "television", "x": 15, "y": 6, "chance": 95 },
         { "item": "soap", "x": 5, "y": 18, "chance": 95 },
-        { "item": "anesthetic_kit", "x": 13, "y": 18, "chance": 75 }
+        { "item": "anesthetic_kit", "x": 13, "y": 18, "chance": 75 },
+        { "group": "autodoc_installation_programs", "x": 21, "y": [ 16, 18 ], "chance": 75, "repeat": 3 }
       ],
       "vehicles": { "W": { "vehicle": "swivel_chair", "chance": 100, "status": 1 } }
     }

--- a/data/json/mapgen/s_electronics.json
+++ b/data/json/mapgen/s_electronics.json
@@ -79,7 +79,7 @@
         { "item": "bionics_common", "x": [ 9, 12 ], "y": 8, "chance": 60, "repeat": [ 1, 2 ] },
         { "item": "elecsto_lights", "x": 2, "y": [ 9, 12 ], "chance": 80, "repeat": [ 2, 6 ] },
         { "item": "elecsto_pcs", "x": [ 5, 8 ], "y": 10, "chance": 85, "repeat": [ 1, 4 ] },
-        { "item": "elecsto_stor", "x": [ 9, 10 ], "y": 10, "chance": 75, "repeat": [ 1, 4 ] },
+        { "item": "electronics", "x": [ 9, 10 ], "y": 10, "chance": 75, "repeat": [ 1, 4 ] },
         { "item": "elecsto_entapl", "x": [ 5, 7 ], "y": 11, "chance": 70, "repeat": [ 2, 4 ] },
         { "item": "elecsto_persele", "x": [ 8, 9 ], "y": 11, "chance": 70, "repeat": [ 1, 6 ] },
         { "item": "elecsto_homapl", "x": [ 5, 10 ], "y": [ 13, 14 ], "chance": 90, "repeat": [ 1, 4 ] },
@@ -93,7 +93,7 @@
         { "item": "electronics", "x": [ 14, 17 ], "y": 14, "chance": 85, "repeat": [ 1, 4 ] },
         { "item": "snacks", "x": 16, "y": 9, "chance": 85 },
         { "item": "magazines", "x": 16, "y": 9, "chance": 60, "repeat": [ 1, 8 ] },
-        { "item": "electronics", "x": 21, "y": [ 12, 13 ], "chance": 85, "repeat": [ 1, 4 ] },
+        { "item": "autodoc_installation_programs", "x": 21, "y": [ 12, 13 ], "chance": 85, "repeat": [ 1, 4 ] },
         { "item": "trash", "x": 18, "y": 15, "chance": 65 },
         { "item": "trash", "x": [ 15, 17 ], "y": [ 20, 21 ], "chance": 80 }
       ],

--- a/data/json/monsterdrops/zombie_lab.json
+++ b/data/json/monsterdrops/zombie_lab.json
@@ -19,7 +19,8 @@
           { "group": "electronics", "prob": 40 },
           { "group": "bionics", "prob": 10 },
           { "group": "radio", "prob": 15 },
-          { "group": "textbooks", "prob": 25 }
+          { "group": "textbooks", "prob": 25 },
+          { "group": "autodoc_installation_programs", "prob": 5 }
         ]
       },
       { "item": "id_science", "prob": 5 },

--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -1846,6 +1846,7 @@ CBMs can be defined like this:
 "bionic_id" : "bio_advreactor", // ID of the installed bionic if not equivalent to "id"
 "difficulty" : 11,              // Difficulty of installing CBM
 "is_upgrade" : true             // Whether the CBM is an upgrade of another bionic.
+"installation_data" : "AID_bio_advreactor" // ID of the item which allows for almost guaranteed installation of corresponding bionic.
 ```
 
 ### Comestibles

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -4687,12 +4687,23 @@ void iexamine::autodoc( player &p, const tripoint &examp )
                 return;
             }
 
+            std::vector<item_comp> progs;
+            bool has_install_program = false;
+
+            std::vector<const item *> install_programs = p.crafting_inventory().items_with( [itemtype](
+                        const item & it ) -> bool { return it.typeId() == itemtype->bionic->installation_data; } );
+
+            if( !install_programs.empty() ) {
+                has_install_program = true;
+                progs.emplace_back( install_programs[0]->typeId(), 1 );
+            }
+
             const int weight = 7;
             const int surgery_duration = itemtype->bionic->difficulty * 2;
             const requirement_data req_anesth = *requirement_id( "anesthetic" ) *
                                                 surgery_duration * weight;
 
-            if( patient.can_install_bionics( ( *itemtype ), installer, true ) ) {
+            if( patient.can_install_bionics( ( *itemtype ), installer, true, has_install_program ? 10 : -1 ) ) {
                 const time_duration duration = itemtype->bionic->difficulty * 20_minutes;
                 patient.introduce_into_anesthesia( duration, installer, needs_anesthesia );
                 bionic.remove_item();
@@ -4706,7 +4717,11 @@ void iexamine::autodoc( player &p, const tripoint &examp )
                     p.invalidate_crafting_inventory();
                 }
                 installer.mod_moves( -to_moves<int>( 1_minutes ) );
-                patient.install_bionics( ( *itemtype ), installer, true );
+                patient.install_bionics( ( *itemtype ), installer, true, has_install_program ? 10 : -1 );
+
+                if( has_install_program ) {
+                    patient.consume_items( progs );
+                }
             }
             break;
         }

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -1392,7 +1392,7 @@ size_t inventory_selector::get_layout_height() const
 
 size_t inventory_selector::get_header_height() const
 {
-    return display_stats || !hint.empty() ? 2 : 1;
+    return display_stats || !hint.empty() ? 3 : 1;
 }
 
 size_t inventory_selector::get_header_min_width() const
@@ -1428,7 +1428,7 @@ size_t inventory_selector::get_footer_min_width() const
 void inventory_selector::draw_header( const catacurses::window &w ) const
 {
     trim_and_print( w, point( border + 1, border ), getmaxx( w ) - 2 * ( border + 1 ), c_white, title );
-    trim_and_print( w, point( border + 1, border + 1 ), getmaxx( w ) - 2 * ( border + 1 ), c_dark_gray,
+    fold_and_print( w, point( border + 1, border + 1 ), getmaxx( w ) - 2 * ( border + 1 ), c_dark_gray,
                     hint );
 
     mvwhline( w, point( border, border + get_header_height() ), LINE_OXOX, getmaxx( w ) - 2 * border );

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -2215,6 +2215,8 @@ void Item_factory::load( islot_bionic &slot, const JsonObject &jo, const std::st
 
     assign( jo, "difficulty", slot.difficulty, strict, 0 );
     assign( jo, "is_upgrade", slot.is_upgrade );
+
+    assign( jo, "installation_data", slot.installation_data );
 }
 
 void Item_factory::load_bionic( const JsonObject &jo, const std::string &src )

--- a/src/itype.h
+++ b/src/itype.h
@@ -753,6 +753,10 @@ struct islot_bionic {
      * Whether this CBM is an upgrade of another.
      */
     bool is_upgrade = false;
+    /**
+    * Item with installation data that can be used to provide almost guaranteed successful install of corresponding bionic.
+    */
+    itype_id installation_data;
 };
 
 struct islot_seed {


### PR DESCRIPTION
#### Summary

SUMMARY: Features "Added autodoc installation datum which almost guarantees flawless installation of basic-tier bionics."

#### Purpose of change
Port autodoc tweaks from DDA.

#### Describe the solution
Added programs that make installation of basic-tier bionics (difficulty 1 to 3) almost completely safe. Made them spawn in hospitals, doctor's offices, electronic stores, and seldom drop from lab zombies.

Full details are in the following PRs:
https://github.com/CleverRaven/Cataclysm-DDA/pull/46808
https://github.com/CleverRaven/Cataclysm-DDA/pull/47267

#### Describe alternatives you've considered
None.

#### Testing
Debug-spawned AID for power storage CBM, tried to install CBM on autodoc with and without AID, looked at the chances of failure.

#### Additional context
None.
