### PR TITLE
Hacky fix for item drop crash

### DIFF
--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -116,6 +116,10 @@ class item_location::impl
         //Flag that controls whether functions like obtain() should stack the obtained item
         //with similar existing items in the inventory or create a new stack for the item
         bool should_stack = true;
+
+        void make_dirty() {
+            needs_unpacking = true;
+        }
 };
 
 class item_location::impl::nowhere : public item_location::impl
@@ -741,4 +745,9 @@ const item *item_location::get_item() const
 void item_location::set_should_stack( bool should_stack ) const
 {
     ptr->should_stack = should_stack;
+}
+
+void item_location::make_dirty()
+{
+    ptr->make_dirty();
 }

--- a/src/item_location.h
+++ b/src/item_location.h
@@ -89,6 +89,9 @@ class item_location
         /** returns the parent item, or an invalid location if it has no parent */
         item_location parent_item() const;
 
+        // This is a dirty hack, don't use. TODO: Delete
+        void make_dirty();
+
     private:
         class impl;
 


### PR DESCRIPTION
Dropping items can alter their place in memory, but `item_location` doesn't re-get them by default, instead returning `null`.
Added a temporary hack in the form of `item_location::make_dirty` for this case.