### PR TITLE
Gambeson Coverage Buff

### DIFF
--- a/data/json/items/armor/suits_protection.json
+++ b/data/json/items/armor/suits_protection.json
@@ -538,7 +538,7 @@
     "looks_like": "coat_winter",
     "color": "light_gray",
     "covers": [ "torso", "arms", "legs" ],
-    "coverage": 95,
+    "coverage": 90,
     "encumbrance": 15,
     "warmth": 30,
     "material_thickness": 5,


### PR DESCRIPTION
#### Summary
SUMMARY: Balance "Gambeson Coverage Buff"

#### Purpose of change
Increase reliability & viability of gambeson, as well as maintain consistency with its "upgrades" (chainmail armor & hauberk) in coverage-capacity

#### Describe the solution
80 -> 95% coverage rate
Add a few words to explicitly detail the jackets length.

#### Describe alternatives you've considered
Remove leg coverage + explain how it's simply a garment covering arms and torso, though this would definitely imply 95-100% coverage.

#### Additional Context
A gambeson traditionally covers all of your torso and arms, and possibly extends down to your knees. 
Given the ingame one is one that covers the legs enough to merit declaring as such, it presumably goes does to your knees. In this context, 80% coverage on a normal slot hurts it significantly as without per-location coverage that also means your torso and arms are extremely exposed, making this a poor armor option.