### PR TITLE
Change Tool Belt Min Vol To 40 ml

### DIFF
--- a/data/json/items/armor/belts.json
+++ b/data/json/items/armor/belts.json
@@ -224,7 +224,7 @@
       "holster_prompt": "Store tool or blade",
       "holster_msg": "You put your %1$s in your %2$s",
       "multi": 6,
-      "min_volume": "50 ml",
+      "min_volume": "40 ml",
       "max_volume": "1500 ml",
       "max_weight": "1500 g",
       "draw_cost": 50,


### PR DESCRIPTION
-->

#### Summary

SUMMARY: Balance. "Change the min vol of the Tool Belt to 40 ml."


#### Purpose of change

Tool Belts can store a Screwdriver Set. That's reasonable. They can store a Multi-Tool, also reasonable. They can store Pliers, Hacksaws, Hammers, and several other items. Perfectly fine.

*attempts to put regular Screwdriver into Tool Belt*

"NO, SURVIVOR-CHAN, THAT DOESN'T GO THERE!"
"But, but...Tool-Belt-Kun, where am I to put my tool?"

OK, stupid attempt at a joke aside, this has been driving me bonkers for a while. Tool belts in the real world normally can hold a screwdriver, even if it's just in a 'generic' pocket. Yet in game, we have to wear another belt and shove the screwdriver into it, or else carry it around in our inventory loose all the time.

#### Describe the solution

Change the minimum volume to 40 ml, which matches a screwdriver.

#### Describe alternatives you've considered

Respecting the wishes of Tool-Belt-Kun and not changing the amount.

#### Testing

Changing the Minimum Volume to 40 ml allows the Screwdriver to be stored in the Tool Belt.

#### Additional context

Bothers me a bit that you can't store X-Acto Knives like that either (again, real world, most of them and the infinite number of carpet/hobby/similar kinds of knives have actual belt clips or the really snazzy ones have fancy reel-style lanyards that attach to your belt), but the volume of the knife is 20 ml and I don't know if that would be too drastic a change for the Tool Belt.
Survivor Utility Belt currently doesn't need this, as it already has a screwdriver set as a component.