### PR TITLE
Port over fleshing out of bronze recipe

### DIFF
--- a/data/json/recipes/other/materials.json
+++ b/data/json/recipes/other/materials.json
@@ -1004,7 +1004,16 @@
     "autolearn": true,
     "using": [ [ "forging_standard", 1 ] ],
     "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
-    "components": [ [ [ "tin", 12 ] ], [ [ "copper_scrap_equivalent", 2, "LIST" ] ] ]
+    "components": [
+      [
+        [ "tin", 12 ],
+        [ "material_aluminium_ingot", 1 ],
+        [ "aluminum_foil", 40 ],
+        [ "chem_aluminium_powder", 15 ],
+        [ "can_drink", 2 ]
+      ],
+      [ [ "copper_scrap_equivalent", 2, "LIST" ] ]
+    ]
   },
   {
     "type": "recipe",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Content "Allow aluminum as an alternative to tin for bronze, ported from DDA"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

A useful improvement to bronzemaking from DDA. One of these days I want to add more things to actually do with bronze, related to my plans to make anvil quality below 3 actually useful. But some simple improvements to making bronze are a good compliment to that, and it's already done for me so that makes it easier on me.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

Ported over change to bronze recipe to allow including aluminum as an alternative to tin, based off real-world concept of aluminum bronze. Unlike leaded bronze, arsenic bronze, or bismuth bronze, aluminum bronze involves using aluminum instead of tin as the alloying material, so it being a full alternative is a good way to make the recipe less annoying.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. There is also a casting mold item introduced in the recipe, however I did not port that inclusion over just yet. Main reason is it ONLY gets used for bronze, when if it gets added at all it should probably be used for gold and silver jewelry recipes too. That would increase the work needed quite a bit to implement that consistently, but could port it over if desired.
2. Reworking the material proportions specified in the recipe because it has literally never obeyed conservation of mass (see below).

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

Checked affected file for syntax and load errors.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

Source PR: https://github.com/CleverRaven/Cataclysm-DDA/pull/51321

Side note, conservation of mass seems completely ignored on this one. An aluminum ingot weighs 675 grams, is being used as a substitute for 24 grams of tin, and is used in making a 218 gram piece of bronze. On the other hand, the vanilla recipe before this change took 100 grams of copper and 24 grams of tin to make said 218-gram bronze scrap.

I went all the way back to checking https://github.com/CleverRaven/Cataclysm-DDA/pull/13192 to see if it was my fault and yeah, technically it totally is. I used 100 grams of copper and 20 grams of tin to make 218 grams of bronze. The only thing that seems to have been changed was the amount of tin required, presumably someone wanted it to be 12% tin like IRL but left the copper demand the same as before, making it 50% copper, 12% tin, and 38% VÖID as a consequence.