### PR TITLE
Remove support for mutation::destroys_gear

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -2446,7 +2446,6 @@
     "flags": [ "UNARMED_BONUS" ],
     "mixed_effect": true,
     "restricts_gear": [ "hand_l", "hand_r" ],
-    "destroys_gear": true,
     "description": "Your index fingers have grown into huge talons.  After a bit of practice, you find that this does not affect your dexterity, but allows for a deadly unarmed attack.  They also prevent wearing gloves.",
     "types": [ "CLAWS" ],
     "prereqs": [ "NAILS" ],
@@ -2675,7 +2674,6 @@
     "types": [ "LEGS" ],
     "category": [ "RAPTOR" ],
     "restricts_gear": [ "foot_l", "foot_r" ],
-    "destroys_gear": true,
     "attacks": {
       "attack_text_u": "You slash %s with a talon",
       "attack_text_npc": "%1$s slashes %2$s with a talon",
@@ -2697,7 +2695,6 @@
     "category": [ "CATTLE", "CHIMERA" ],
     "wet_protection": [ { "part": "foot_l", "neutral": 10 }, { "part": "foot_r", "neutral": 10 } ],
     "restricts_gear": [ "foot_l", "foot_r" ],
-    "destroys_gear": true,
     "armor": [ { "parts": [ "foot_l", "foot_r" ], "physical": 10 } ],
     "attacks": {
       "attack_text_u": "You kick %s with your hooves",
@@ -2855,7 +2852,6 @@
     "threshreq": [ "THRESH_FELINE", "THRESH_CHIMERA" ],
     "category": [ "FELINE", "CHIMERA" ],
     "restricts_gear": [ "mouth" ],
-    "destroys_gear": true,
     "social_modifiers": { "intimidate": 15 },
     "attacks": {
       "attack_text_u": "You tear into %s with your saber teeth",
@@ -3469,7 +3465,6 @@
     "category": [ "INSECT", "SPIDER" ],
     "wet_protection": [ { "part": "mouth", "ignored": 100 } ],
     "restricts_gear": [ "mouth" ],
-    "destroys_gear": true,
     "attacks": {
       "attack_text_u": "You bite %s with your fangs",
       "attack_text_npc": "%1$s bites %2$s with their fangs",
@@ -3730,7 +3725,6 @@
     "hp_adjustment": -6,
     "fatigue_modifier": 0.15,
     "restricts_gear": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r", "hand_l", "hand_r", "head", "foot_l", "foot_r" ],
-    "destroys_gear": true,
     "weight_capacity_modifier": 1.1
   },
   {
@@ -3750,7 +3744,6 @@
     "category": [ "URSINE", "CATTLE" ],
     "passive_mods": { "str_mod": 4 },
     "restricts_gear": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r", "hand_l", "hand_r", "head", "foot_l", "foot_r" ],
-    "destroys_gear": true,
     "weight_capacity_modifier": 1.1
   },
   {
@@ -4759,7 +4752,6 @@
     "category": [ "BIRD", "CEPHALOPOD" ],
     "wet_protection": [ { "part": "mouth", "ignored": 1 } ],
     "restricts_gear": [ "mouth" ],
-    "destroys_gear": true,
     "attacks": {
       "attack_text_u": "You peck %s",
       "attack_text_npc": "%1$s pecks %2$s",
@@ -4785,7 +4777,6 @@
     "category": [ "BIRD" ],
     "wet_protection": [ { "part": "mouth", "ignored": 2 } ],
     "restricts_gear": [ "mouth" ],
-    "destroys_gear": true,
     "attacks": [
       {
         "attack_text_u": "You jackhammer into %s with your beak",
@@ -4813,8 +4804,7 @@
     "category": [ "BIRD" ],
     "wet_protection": [ { "part": "mouth", "ignored": 2 } ],
     "active": true,
-    "restricts_gear": [ "mouth" ],
-    "destroys_gear": true
+    "restricts_gear": [ "mouth" ]
   },
   {
     "type": "mutation",
@@ -5503,7 +5493,6 @@
     "category": [ "CEPHALOPOD" ],
     "wet_protection": [ { "part": "torso", "ignored": 26 } ],
     "restricts_gear": [ "torso" ],
-    "destroys_gear": true,
     "armor": [ { "parts": "torso", "bash": 6, "cut": 14 } ]
   },
   {
@@ -5524,7 +5513,6 @@
     "wet_protection": [ { "part": "torso", "ignored": 26 } ],
     "active": true,
     "restricts_gear": [ "torso" ],
-    "destroys_gear": true,
     "armor": [ { "parts": "torso", "bash": 9, "cut": 17 } ]
   },
   {

--- a/data/mods/Aftershock/mutations/mutations.json
+++ b/data/mods/Aftershock/mutations/mutations.json
@@ -421,7 +421,6 @@
     "types": [ "LEGS" ],
     "category": [ "MASTODON" ],
     "wet_protection": [ { "part": "foot_l", "neutral": 10 }, { "part": "foot_r", "neutral": 10 } ],
-    "destroys_gear": true,
     "armor": [ { "parts": [ "foot_l", "foot_r" ], "bash": 2, "cut": 2 } ],
     "attacks": {
       "attack_text_u": "You kick %s with your massive feet",

--- a/data/mods/Aftershock/mutations/obsolete.json
+++ b/data/mods/Aftershock/mutations/obsolete.json
@@ -254,7 +254,6 @@
     "hp_adjustment": -6,
     "fatigue_modifier": 0.15,
     "restricts_gear": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r", "hand_l", "hand_r", "head", "foot_l", "foot_r" ],
-    "destroys_gear": true,
     "weight_capacity_modifier": 1.1
   },
   {
@@ -274,7 +273,6 @@
     "leads_to": [ "MUT_TANK" ],
     "passive_mods": { "str_mod": 4 },
     "restricts_gear": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r", "hand_l", "hand_r", "head", "foot_l", "foot_r" ],
-    "destroys_gear": true,
     "weight_capacity_modifier": 1.1
   },
   {

--- a/data/mods/DinoMod/mutations/mutations.json
+++ b/data/mods/DinoMod/mutations/mutations.json
@@ -256,7 +256,6 @@
     "threshreq": [ "THRESH_TYRANT" ],
     "category": [ "TYRANT" ],
     "restricts_gear": [ "mouth" ],
-    "destroys_gear": true,
     "social_modifiers": { "intimidate": 20 },
     "attacks": {
       "attack_text_u": "You tear into %s with your serrated teeth",

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -9538,7 +9538,7 @@ void Character::on_worn_item_washed( const item &it )
 void Character::on_item_wear( const item &it )
 {
     for( const trait_id &mut : it.mutations_from_wearing( *this ) ) {
-        mutation_effect( mut, true );
+        mutation_effect( mut );
         recalc_sight_limits();
         calc_encumbrance();
 

--- a/src/character.h
+++ b/src/character.h
@@ -933,8 +933,8 @@ class Character : public Creature, public visitable<Character>
         /** Returns the multiplier on move cost of attacks. */
         float mabuff_attack_cost_mult() const;
 
-        /** Handles things like destruction of armor, etc. */
-        void mutation_effect( const trait_id &mut, bool worn_destroyed_override );
+        /** Handles things like removal of armor, etc. */
+        void mutation_effect( const trait_id &mut );
         /** Handles what happens when you lose a mutation. */
         void mutation_loss_effect( const trait_id &mut );
 

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -166,7 +166,7 @@ void Character::set_mutation( const trait_id &trait )
     }
     my_mutations.emplace( trait, trait_data{} );
     rebuild_mutation_cache();
-    mutation_effect( trait, false );
+    mutation_effect( trait );
     recalc_sight_limits();
     reset_encumbrance();
 }
@@ -196,7 +196,7 @@ void Character::switch_mutations( const trait_id &switched, const trait_id &targ
 
     set_mutation( target );
     my_mutations[target].powered = start_powered;
-    mutation_effect( target, false );
+    mutation_effect( target );
 }
 
 int Character::get_mod( const trait_id &mut, const std::string &arg ) const
@@ -265,7 +265,7 @@ void Character::recalculate_size()
     }
 }
 
-void Character::mutation_effect( const trait_id &mut, const bool worn_destroyed_override )
+void Character::mutation_effect( const trait_id &mut )
 {
     if( mut == trait_GLASSJAW ) {
         recalc_hp();
@@ -314,19 +314,12 @@ void Character::mutation_effect( const trait_id &mut, const bool worn_destroyed_
         if( !branch.conflicts_with_item( armor ) ) {
             return false;
         }
-        if( !worn_destroyed_override && branch.destroys_gear ) {
-            add_msg_player_or_npc( m_bad,
-                                   _( "Your %s is destroyed!" ),
-                                   _( "<npcname>'s %s is destroyed!" ),
-                                   armor.tname() );
-            armor.contents.spill_contents( pos() );
-        } else {
-            add_msg_player_or_npc( m_bad,
-                                   _( "Your %s is pushed off!" ),
-                                   _( "<npcname>'s %s is pushed off!" ),
-                                   armor.tname() );
-            g->m.add_item_or_charges( pos(), armor );
-        }
+
+        add_msg_player_or_npc( m_bad,
+                               _( "Your %s is pushed off!" ),
+                               _( "<npcname>'s %s is pushed off!" ),
+                               armor.tname() );
+        get_map().add_item_or_charges( pos(), armor );
         return true;
     } );
 

--- a/src/mutation.h
+++ b/src/mutation.h
@@ -111,8 +111,6 @@ struct mutation_branch {
         bool activated     = false;
         // Should it activate as soon as it is gained?
         bool starts_active = false;
-        // Should it destroy gear on restricted body parts? (otherwise just pushes it off)
-        bool destroys_gear = false;
         // Allow soft (fabric) gear on restricted body parts
         bool allow_soft_gear  = false;
         // IF any of the three are true, it drains that as the "cost"

--- a/src/mutation_data.cpp
+++ b/src/mutation_data.cpp
@@ -290,7 +290,6 @@ void mutation_branch::load( const JsonObject &jo, const std::string & )
     optional( jo, was_loaded, "mixed_effect", mixed_effect, false );
     optional( jo, was_loaded, "active", activated, false );
     optional( jo, was_loaded, "starts_active", starts_active, false );
-    optional( jo, was_loaded, "destroys_gear", destroys_gear, false );
     optional( jo, was_loaded, "allow_soft_gear", allow_soft_gear, false );
     optional( jo, was_loaded, "cost", cost, 0 );
     optional( jo, was_loaded, "time", cooldown, 0 );


### PR DESCRIPTION
Mutations destroying gear on gain doesn't fit the game. It would work in a fast-paced game where mutations "pop" into existence, but here, the instant mutations are supposed to be an abstraction representing them growing "enough that it counts".

I considered keeping it just for the sake of possible activatable mutations, but I'd rather reimplement it explicitly for those, as an effect of activation, than keep this flag but make it not work in most cases.