### PR TITLE
[DDA Port] Skip sfx calls during test to improve performance

### DIFF
--- a/src/sdlsound.cpp
+++ b/src/sdlsound.cpp
@@ -20,6 +20,7 @@
 #    include <SDL_mixer.h>
 #endif
 
+#include "cached_options.h"
 #include "debug.h"
 #include "init.h"
 #include "json.h"
@@ -159,6 +160,10 @@ void musicFinished();
 
 static void play_music_file( const std::string &filename, int volume )
 {
+    if( test_mode ) {
+        return;
+    }
+
     if( !check_sound( volume ) ) {
         return;
     }
@@ -180,6 +185,10 @@ static void play_music_file( const std::string &filename, int volume )
 /** Callback called when we finish playing music. */
 void musicFinished()
 {
+    if( test_mode ) {
+        return;
+    }
+
     Mix_HaltMusic();
     Mix_FreeMusic( current_music );
     current_music = nullptr;
@@ -245,6 +254,10 @@ void play_music( const std::string &playlist )
 
 void stop_music()
 {
+    if( test_mode ) {
+        return;
+    }
+
     Mix_FreeMusic( current_music );
     Mix_HaltMusic();
     current_music = nullptr;
@@ -256,6 +269,10 @@ void stop_music()
 
 void update_music_volume()
 {
+    if( test_mode ) {
+        return;
+    }
+
     if( !sounds::sound_enabled ) {
         stop_music();
         return;
@@ -461,6 +478,10 @@ static Mix_Chunk *do_pitch_shift( Mix_Chunk *s, float pitch )
 
 void sfx::play_variant_sound( const std::string &id, const std::string &variant, int volume )
 {
+    if( test_mode ) {
+        return;
+    }
+
     add_msg( m_debug, "sound id: %s, variant: %s, volume: %d ", id, variant, volume );
 
     if( !check_sound( volume ) ) {
@@ -487,6 +508,10 @@ void sfx::play_variant_sound( const std::string &id, const std::string &variant,
 void sfx::play_variant_sound( const std::string &id, const std::string &variant, int volume,
                               int angle, double pitch_min, double pitch_max )
 {
+    if( test_mode ) {
+        return;
+    }
+
     add_msg( m_debug, "sound id: %s, variant: %s, volume: %d ", id, variant, volume );
 
     if( !check_sound( volume ) ) {
@@ -534,6 +559,9 @@ void sfx::play_variant_sound( const std::string &id, const std::string &variant,
 void sfx::play_ambient_variant_sound( const std::string &id, const std::string &variant, int volume,
                                       channel channel, int fade_in_duration, double pitch, int loops )
 {
+    if( test_mode ) {
+        return;
+    }
     if( !check_sound( volume ) ) {
         return;
     }


### PR DESCRIPTION
Speeds up tests a bit.

Port of https://github.com/CleverRaven/Cataclysm-DDA/pull/46475