### PR TITLE
[DDA Port] Disable security checks in msvc builds for perf reasons.

### DIFF
--- a/msvc-full-features/Cataclysm-lib-vcpkg-static.vcxproj
+++ b/msvc-full-features/Cataclysm-lib-vcpkg-static.vcxproj
@@ -65,7 +65,8 @@
         <ClCompile>
             <WarningLevel>Level1</WarningLevel>
             <PrecompiledHeader>Use</PrecompiledHeader>
-            <SDLCheck>true</SDLCheck>
+            <SDLCheck>false</SDLCheck>
+            <BufferSecurityCheck>false</BufferSecurityCheck>
             <CompileAsManaged>false</CompileAsManaged>
             <MultiProcessorCompilation>true</MultiProcessorCompilation>
             <MinimalRebuild>false</MinimalRebuild>

--- a/msvc-full-features/Cataclysm-test-vcpkg-static.vcxproj
+++ b/msvc-full-features/Cataclysm-test-vcpkg-static.vcxproj
@@ -63,7 +63,8 @@
     <ClCompile>
       <WarningLevel>Level1</WarningLevel>
       <PrecompiledHeader>Use</PrecompiledHeader>
-      <SDLCheck>true</SDLCheck>
+      <SDLCheck>false</SDLCheck>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
       <CompileAsManaged>false</CompileAsManaged>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <MinimalRebuild>false</MinimalRebuild>

--- a/msvc-full-features/Cataclysm-vcpkg-static.vcxproj
+++ b/msvc-full-features/Cataclysm-vcpkg-static.vcxproj
@@ -63,7 +63,8 @@
     <ClCompile>
       <WarningLevel>Level1</WarningLevel>
       <PrecompiledHeader>Use</PrecompiledHeader>
-      <SDLCheck>true</SDLCheck>
+      <SDLCheck>false</SDLCheck>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
       <CompileAsManaged>false</CompileAsManaged>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <MinimalRebuild>false</MinimalRebuild>

--- a/msvc-full-features/JsonFormatter.vcxproj
+++ b/msvc-full-features/JsonFormatter.vcxproj
@@ -63,7 +63,8 @@
     <ClCompile>
       <WarningLevel>Level1</WarningLevel>
       <PrecompiledHeader>Use</PrecompiledHeader>
-      <SDLCheck>true</SDLCheck>
+      <SDLCheck>false</SDLCheck>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
       <CompileAsManaged>false</CompileAsManaged>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <MinimalRebuild>false</MinimalRebuild>


### PR DESCRIPTION
Port of https://github.com/CleverRaven/Cataclysm-DDA/pull/45182

Didn't measure the impact, though according to original PR it's somewhat noticeable.