### PR TITLE
[DDA Port] Enable tile variations and animations for background and multitile

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -2128,6 +2128,9 @@ bool cata_tiles::draw_from_id_string( const std::string &id, TILE_CATEGORY categ
             // offset by loc_rand so that everything does not blink at the same time:
             int frame = idle_animations.current_frame() + loc_rand;
             int frames_in_loop = display_tile.fg.get_weight();
+            if( frames_in_loop == 1 ) {
+                frames_in_loop = display_tile.bg.get_weight();
+            }
             // loc_rand is actually the weighed index of the selected tile, and
             // for animations the "weight" is the number of frames to show the tile for:
             loc_rand = frame % frames_in_loop;


### PR DESCRIPTION
Source PRs:
https://github.com/CleverRaven/Cataclysm-DDA/pull/50180
https://github.com/CleverRaven/Cataclysm-DDA/pull/51257
https://github.com/CleverRaven/Cataclysm-DDA/pull/51287