### PR TITLE
Update body_parts.json

### DIFF
--- a/data/json/body_parts.json
+++ b/data/json/body_parts.json
@@ -60,7 +60,7 @@
     "cold_morale_mod": 2,
     "squeamish_penalty": 7,
     "base_hp": 60,
-    "bionic_slots": 18
+    "bionic_slots": 20
   },
   {
     "id": "eyes",
@@ -80,7 +80,7 @@
     "stylish_bonus": 2,
     "squeamish_penalty": 8,
     "base_hp": 60,
-    "bionic_slots": 4
+    "bionic_slots": 5
   },
   {
     "id": "mouth",
@@ -102,7 +102,7 @@
     "cold_morale_mod": 2,
     "squeamish_penalty": 9,
     "base_hp": 60,
-    "bionic_slots": 4
+    "bionic_slots": 5
   },
   {
     "id": "arm_l",
@@ -127,7 +127,7 @@
     "cold_morale_mod": 0.5,
     "squeamish_penalty": 5,
     "base_hp": 60,
-    "bionic_slots": 20
+    "bionic_slots": 30
   },
   {
     "id": "arm_r",
@@ -151,7 +151,7 @@
     "cold_morale_mod": 0.5,
     "squeamish_penalty": 5,
     "base_hp": 60,
-    "bionic_slots": 20
+    "bionic_slots": 30
   },
   {
     "id": "hand_l",
@@ -175,7 +175,7 @@
     "cold_morale_mod": 0.5,
     "squeamish_penalty": 3,
     "base_hp": 60,
-    "bionic_slots": 5
+    "bionic_slots": 10
   },
   {
     "id": "hand_r",
@@ -199,7 +199,7 @@
     "cold_morale_mod": 0.5,
     "squeamish_penalty": 3,
     "base_hp": 60,
-    "bionic_slots": 5
+    "bionic_slots": 10
   },
   {
     "id": "leg_l",
@@ -273,7 +273,7 @@
     "cold_morale_mod": 0.5,
     "squeamish_penalty": 3,
     "base_hp": 60,
-    "bionic_slots": 7
+    "bionic_slots": 10
   },
   {
     "id": "foot_r",
@@ -297,6 +297,6 @@
     "cold_morale_mod": 0.5,
     "squeamish_penalty": 3,
     "base_hp": 60,
-    "bionic_slots": 7
+    "bionic_slots": 10
   }
 ]


### PR DESCRIPTION
Tweaks for bionic slots to allow more cbms to be installed


#### Summary


SUMMARY: Mods "Changed CBM slots to be a bit more giving"


#### Purpose of change

I've noticed that playing with CBM slots is fun! but at times it can be restrictive so hopefully this will help. 

#### Describe the solution

I changed the slots up a bit to allow more cbms to be installed. This also is to enforce consistent multiples of five and to have body parts with similar function be more consistent sizewise, making it easier to balance different CBMs via being able to look at what sizes similar bionics on different extremities occupy.

#### Describe alternatives you've considered

- I considered changing the cbms themselves but I figured that this way would be faster, and would allow for more cbms.
- Also thought of increasing the size of all slots to 100 and instead balancing CBM size based on what percentage of available room we believe they should occupy.

#### Testing

Spawned in with cbm slots. I have more! 

#### Additional context

![Screenshot (334)](https://user-images.githubusercontent.com/82045140/171743713-1b3ca4f4-fcba-46a2-90df-f5e61b6ae686.png)

