### PR TITLE
Fix NPCs traits removal by purification

### DIFF
--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -420,8 +420,10 @@ void npc::randomize( const npc_class_id &type )
     clear_mutations();
 
     // Add fixed traits
-    for( const auto &tid : trait_group::traits_from( myclass->traits ) ) {
-        set_mutation( tid );
+    for( const trait_id &tid : trait_group::traits_from( myclass->traits ) ) {
+        if( !has_trait( tid ) ) {
+            toggle_trait( tid );
+        }
     }
 
     // Run mutation rounds


### PR DESCRIPTION


#### Summary

SUMMARY: Bugfixes "Stop purification from removal inherent traits of NPCs"

#### Purpose of change

Fixes https://github.com/cataclysmbnteam/Cataclysm-BN/issues/1670

#### Describe the solution

Replace `set_mutation` by `toggle_trait` at NPC generation.

#### Describe alternatives you've considered

I don't have alternatives.

#### Testing

Testing:
1. Started new game
2. Made friends with NPC
3. Made NPC drink purifier, notice no changes in traits.
4. Made NPC drink mutagen, notice new mutations.
5. Made NPC drink purifier, notice removal of mutations but preservation of original traits.

#### Additional context

Would also file a new PR with removal of `toggle_trait` soon but it is harder to implement and test so this is fast bugfix.