### PR TITLE
Fix UB in shrapnel function

### DIFF
--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -730,7 +730,7 @@ static std::map<const Creature *, int> shrapnel( const tripoint &src, const proj
 
     std::stable_sort( blast_map.begin(), blast_map.end(), []( dist_point_pair pair1,
     dist_point_pair pair2 ) {
-        return pair1.first <= pair2.first;
+        return pair1.first < pair2.first;
     } );
 
     int animated_explosion_range = 0.0f;


### PR DESCRIPTION
#### Summary
SUMMARY: Bugfixes "Fixed a crash related to explosions"

#### Purpose of change
Fixes #2379
I failed to find any correlation between the spot where the character waits and crash happening, but I lucked out and got a crash when I waited towards the north-east of starting position. The backtrace was a mess, so I tried again with Debug build, and on the first try it triggered an `invalid comparator` assertion in `std::stable_sort` at `explosion.cpp:733`.

#### Describe the solution
According to cppreference, `std::stable_sort` expected a comparator of type `A less then B`, but we had `A less then or equal B`. I fixed the comparator, and the crash seems to have gone away.

#### Testing
I tried waiting 10 times in different spots, but the crash didn't happen anymore. There was a different crash, but I'm not sure whether it was something real or just VS miscompiling again...