### PR TITLE
Craftable mech power cells, related recipe availability changes

### DIFF
--- a/data/json/recipes/electronic/components.json
+++ b/data/json/recipes/electronic/components.json
@@ -158,7 +158,7 @@
     "time": "1 h 25 m",
     "reversible": true,
     "decomp_learn": 4,
-    "book_learn": [ [ "recipe_lab_elec", 7 ] ],
+    "book_learn": [ [ "recipe_lab_elec", 7 ], [ "textbook_atomic_lab", 8 ] ],
     "using": [ [ "soldering_standard", 24 ] ],
     "qualities": [ { "id": "SCREW", "level": 1 } ],
     "components": [ [ [ "power_supply", 6 ] ], [ [ "amplifier", 5 ] ], [ [ "scrap", 4 ] ], [ [ "cable", 14 ] ], [ [ "plut_cell", 2 ] ] ]

--- a/data/json/recipes/electronic/lighting.json
+++ b/data/json/recipes/electronic/lighting.json
@@ -159,7 +159,7 @@
     "difficulty": 2,
     "time": "20 m",
     "reversible": true,
-    "book_learn": [ [ "textbook_electronics", 3 ], [ "advanced_electronics", 3 ], [ "recipe_caseless", 2 ] ],
+    "book_learn": [ [ "textbook_electronics", 3 ], [ "advanced_electronics", 3 ], [ "recipe_caseless", 2 ], [ "textbook_atomic_lab", 4 ] ],
     "qualities": [ { "id": "SCREW", "level": 1 } ],
     "components": [
       [ [ "plastic_chunk", 1 ] ],
@@ -179,7 +179,7 @@
     "difficulty": 3,
     "time": "30 m",
     "reversible": true,
-    "book_learn": [ [ "textbook_electronics", 4 ], [ "advanced_electronics", 4 ], [ "recipe_caseless", 3 ] ],
+    "book_learn": [ [ "textbook_electronics", 4 ], [ "advanced_electronics", 4 ], [ "recipe_caseless", 3 ], [ "textbook_atomic_lab", 5 ] ],
     "qualities": [ { "id": "SCREW", "level": 1 } ],
     "components": [
       [ [ "plastic_chunk", 2 ] ],

--- a/data/json/recipes/electronic/parts.json
+++ b/data/json/recipes/electronic/parts.json
@@ -624,8 +624,7 @@
     "difficulty": 6,
     "skills_required": [ "fabrication", 6 ],
     "time": "60 m",
-    "decomp_learn": 4,
-    "book_learn": [ [ "recipe_atomic_battery", 6 ] ],
+    "book_learn": [ [ "recipe_atomic_battery", 6 ], [ "textbook_atomic_lab", 7 ] ],
     "using": [ [ "soldering_standard", 10 ] ],
     "qualities": [ { "id": "SCREW", "level": 1 } ],
     "components": [ [ [ "scrap", 6 ] ], [ [ "cable", 4 ] ], [ [ "plut_cell", 1 ] ] ]
@@ -639,8 +638,7 @@
     "difficulty": 6,
     "skills_required": [ "fabrication", 6 ],
     "time": "60 m",
-    "decomp_learn": 4,
-    "book_learn": [ [ "recipe_atomic_battery", 6 ] ],
+    "book_learn": [ [ "recipe_atomic_battery", 6 ], [ "textbook_atomic_lab", 7 ] ],
     "using": [ [ "soldering_standard", 10 ] ],
     "qualities": [ { "id": "SCREW", "level": 1 } ],
     "components": [ [ [ "scrap", 6 ] ], [ [ "cable", 4 ] ], [ [ "plut_cell", 2 ] ] ]
@@ -654,8 +652,7 @@
     "difficulty": 6,
     "skills_required": [ "fabrication", 6 ],
     "time": "60 m",
-    "decomp_learn": 4,
-    "book_learn": [ [ "recipe_atomic_battery", 6 ] ],
+    "book_learn": [ [ "recipe_atomic_battery", 6 ], [ "textbook_atomic_lab", 7 ] ],
     "using": [ [ "soldering_standard", 10 ] ],
     "qualities": [ { "id": "SCREW", "level": 1 } ],
     "components": [ [ [ "scrap", 6 ] ], [ [ "cable", 4 ] ], [ [ "plut_cell", 10 ] ] ]
@@ -669,11 +666,24 @@
     "difficulty": 6,
     "skills_required": [ "fabrication", 6 ],
     "time": "60 m",
-    "decomp_learn": 4,
-    "book_learn": [ [ "recipe_atomic_battery", 6 ] ],
+    "book_learn": [ [ "recipe_atomic_battery", 6 ], [ "textbook_atomic_lab", 7 ] ],
     "using": [ [ "soldering_standard", 10 ] ],
     "qualities": [ { "id": "SCREW", "level": 1 } ],
     "components": [ [ [ "scrap", 6 ] ], [ [ "cable", 4 ] ], [ [ "plut_cell", 20 ] ] ]
+  },
+  {
+    "result": "huge_atomic_battery_cell",
+    "type": "recipe",
+    "category": "CC_ELECTRONIC",
+    "subcategory": "CSC_ELECTRONIC_PARTS",
+    "skill_used": "electronics",
+    "difficulty": 8,
+    "skills_required": [ "fabrication", 8 ],
+    "time": "90 m",
+    "book_learn": [ [ "recipe_atomic_battery", 8 ], [ "textbook_atomic_lab", 9 ] ],
+    "using": [ [ "welding_standard", 50 ], [ "steel_standard", 5 ] ],
+    "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "SAW_M", "level": 1 } ],
+    "components": [ [ [ "cable", 20 ] ], [ [ "plut_cell", 200 ] ] ]
   },
   {
     "result": "solder_wire",

--- a/data/json/recipes/electronic/tools.json
+++ b/data/json/recipes/electronic/tools.json
@@ -395,7 +395,7 @@
     "difficulty": 6,
     "time": "1h 30 m",
     "reversible": true,
-    "book_learn": [ [ "recipe_caseless", 8 ] ],
+    "book_learn": [ [ "recipe_caseless", 8 ], [ "textbook_atomic_lab", 9 ] ],
     "qualities": [ { "id": "SCREW", "level": 1 } ],
     "components": [
       [ [ "plastic_chunk", 5 ] ],

--- a/data/mods/Aftershock/recipes/recipe_overrides.json
+++ b/data/mods/Aftershock/recipes/recipe_overrides.json
@@ -1,66 +1,6 @@
 [
   {
     "type": "recipe",
-    "result": "atomic_coffeepot",
-    "category": "CC_ELECTRONIC",
-    "subcategory": "CSC_ELECTRONIC_TOOLS",
-    "skill_used": "electronics",
-    "difficulty": 4,
-    "time": 3000,
-    "reversible": true,
-    "book_learn": [ [ "recipe_caseless", 8 ], [ "textbook_atomic_lab", 3 ] ],
-    "qualities": [ { "id": "SCREW", "level": 1 } ],
-    "components": [
-      [ [ "plastic_chunk", 5 ] ],
-      [ [ "adhesive", 1, "LIST" ] ],
-      [ [ "power_supply", 1 ] ],
-      [ [ "element", 1 ] ],
-      [ [ "scrap", 2 ] ],
-      [ [ "plut_cell", 1 ] ]
-    ]
-  },
-  {
-    "type": "recipe",
-    "result": "atomic_light",
-    "category": "CC_ELECTRONIC",
-    "subcategory": "CSC_ELECTRONIC_LIGHTING",
-    "skill_used": "electronics",
-    "difficulty": 3,
-    "time": 20000,
-    "reversible": true,
-    "book_learn": [ [ "recipe_caseless", 6 ], [ "textbook_atomic_lab", 3 ] ],
-    "qualities": [ { "id": "SCREW", "level": 1 } ],
-    "components": [
-      [ [ "plastic_chunk", 1 ] ],
-      [ [ "adhesive", 1, "LIST" ] ],
-      [ [ "power_supply", 1 ] ],
-      [ [ "cable", 1 ] ],
-      [ [ "lightstrip_inactive", 1 ], [ "e_scrap", 1 ] ],
-      [ [ "plut_cell", 1 ] ]
-    ]
-  },
-  {
-    "type": "recipe",
-    "result": "atomic_lamp",
-    "category": "CC_ELECTRONIC",
-    "subcategory": "CSC_ELECTRONIC_LIGHTING",
-    "skill_used": "electronics",
-    "difficulty": 3,
-    "time": 30000,
-    "reversible": true,
-    "book_learn": [ [ "recipe_caseless", 6 ], [ "textbook_atomic_lab", 3 ] ],
-    "qualities": [ { "id": "SCREW", "level": 1 } ],
-    "components": [
-      [ [ "plastic_chunk", 2 ] ],
-      [ [ "adhesive", 1, "LIST" ] ],
-      [ [ "power_supply", 1 ] ],
-      [ [ "cable", 2 ] ],
-      [ [ "lightstrip_inactive", 1 ], [ "e_scrap", 1 ] ],
-      [ [ "plut_cell", 2 ] ]
-    ]
-  },
-  {
-    "type": "recipe",
     "result": "wearable_atomic_light",
     "category": "CC_OTHER",
     "subcategory": "CSC_OTHER_TOOLS",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Add atomic-related recipes to lab journal-Curie, allow crafting mech power cells"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Gives a lab journal that currently has zero vanilla recipes some actual use, along with making certain advanced recipes a bit more accessible with enough lab-diving. Also aims to make it so keeping a mech running is feasible without constantly praying for rare cell drops, if you have the resources to make a replacement cell yourself.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Added lab journal-Curie as an alternative booklearn for atomic batteries, advanced UPS, and atomic-powered tools, at generally 1 level higher than the highest other booklearn level. Idea being, these all concern applications of nuclear power, the stated focus of the book. This also effectively mainlines Aftershock's overrides of relevant recipes.
2. Removed `decomp_learn` from plutonium battery recipes as they aren't actually reversible.
3. Added a recipe for making military plutonium power cells. Recipe difficulty is elevated over other plutonium batteries, material cost is increased accordingly, and additionally it requires an existing power cell as a tool for reference.
4. Removed now-redundant Aftershock recipe overrides, as per above.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Requiring nanomaterial for making atomic batteries.
2. Alternatively, allow taking plutonium fuel cells apart for nanomaterial and probably also some delicious nuclear waste.
3. Mainlining Aftershock's mininuke recipe since it seems to have presumably been the main use for the Curie journal back in the day, I think?

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

Checked affected files for syntax and lint errors.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

Side note, Aftershock has some weird recipe overrides in it that feel pretty redundant and weird.