### PR TITLE
Add bastion fort to scenarios

### DIFF
--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -37,7 +37,7 @@
     "name": "Large Building",
     "points": -2,
     "description": "Whether due to stubbornness, ignorance, or just plain bad luck, you missed the evacuation, and are stuck in a large building full of the risen dead.",
-    "allowed_locs": [ "sloc_mall_loading_area", "sloc_mall_food_court", "sloc_apartments_rooftop", "sloc_hospital" ],
+    "allowed_locs": [ "sloc_mall_loading_area", "sloc_mall_food_court", "sloc_apartments_rooftop", "sloc_hospital", "sloc_bastion_fort" ],
     "start_name": "In Large Building",
     "flags": [ "SUR_START", "CITY_START", "LONE_START" ]
   },
@@ -327,7 +327,8 @@
       "sloc_hermit_shack",
       "sloc_farm_survivalist",
       "sloc_campsite",
-      "sloc_campground"
+      "sloc_campground",
+      "sloc_bastion_fort"
     ],
     "start_name": "Outside Town",
     "flags": [ "SUR_START", "WIN_START", "LONE_START" ],
@@ -358,7 +359,8 @@
       "sloc_campsite",
       "sloc_campground",
       "sloc_cabin_lake",
-      "sloc_lighthouse_ground"
+      "sloc_lighthouse_ground",
+      "sloc_bastion_fort"
     ],
     "start_name": "Outside Town",
     "flags": [ "SUM_ADV_START", "LONE_START" ],

--- a/data/json/start_locations.json
+++ b/data/json/start_locations.json
@@ -453,5 +453,12 @@
     "name": "Mansion",
     "terrain": [ "mansion_+2", "mansion_+1", "mansion_+4", "mansion_+3" ],
     "flags": [ "ALLOW_OUTSIDE" ]
+  },
+  {
+    "type": "start_location",
+    "id": "sloc_bastion_fort",
+    "name": "Bastion Fort",
+    "terrain": [ "Bastion_Fort_1_SW" ],
+    "flags": [ "ALLOW_OUTSIDE" ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.

CODE STYLE: please follow below guide.
JSON: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/src/content/docs/en/mod/json/explanation/json_style.md
C++ and Markdown: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/src/content/docs/en/dev/explanation/code_style.md

!!!!!!!!!! WARNING !!!!!!!!!!

If you forget to format the PR, autofix.ci app will run automated format commit for you.
When this happens, YOU MUST DO EITHER OF THE FOLLOWING:

- Run `git pull` to merge the automated commit into your PR branch.
- Format your code locally, and force push to your PR branch. 

If you don't do this, your following work will be based on the old commit, and cause MERGE CONFLICT.
-->

## Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/src/content/docs/en/contribute/changelog_guidelines.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Features "Add bastion fort as a starting location for Large Building, Ambush, and Next Summer"

## Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Smol followup idea brought up in https://github.com/cataclysmbnteam/Cataclysm-BN/pull/3351

## Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Defined starting location for bastion fort.
2. Added the starting location to Large Building, Ambush, and Next Summer scenarios.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Adding it to Burning Building scenario for the lulz. Don't know if a barrel of gunpowder will go kaboom properly though so hmm.
2. Adding a dedicated scenario for it like DDA does. While flavorful, that doesn't really add anything that just letting you witness a zombie seige in the Large Building scenario already does, or that being a post-apoc raider in the other two scenarios adds.
3. Adding the power plant or industrial center to any scenarios?

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Checked affected files for syntax and lint errors.
2. Load-tested and started in a fort in Large Building scenario.

One time I tested it and the game just closed on leaving character creation, I haven't been able to recreate it since.

And another single time I spawned in blind for the first turn, something I've seen before happening at random with no idea why it happens.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
