### PR TITLE
docs: fix broken link

### DIFF
--- a/doc/src/content/docs/en/mod/json/reference/map/mapgen.md
+++ b/doc/src/content/docs/en/mod/json/reference/map/mapgen.md
@@ -1075,7 +1075,7 @@ Another entry within a mapgen definition or palette can be a `"parameters"` key.
 Each entry in the `"parameters"` JSON object defines a parameter. The key is the parameter name.
 Each such key should have an associated JSON object. That object must provide its type (which should
 be a type string as for a `cata_variant`) and may optionally provide a default value. The default
-value should be a [mapgen value](#mapgen-value) as defined above.
+value should be a [mapgen value](#mapgen-values) as defined above.
 
 At time of writing, the only way for a parameter to get a value is via the `"default"`, so you
 probably want to always have one.


### PR DESCRIPTION
## Purpose of change

- fix #3827

## Describe the solution

add missing `s`

## Testing

was able to build locally

## Additional context

should probably add problem matcher for docs too.