### PR TITLE
feat(balance): make electrohack easier per comments

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -868,7 +868,7 @@ static int hack_level( const Character &who )
     // odds go up with int>8, down with int<8
     // 4 int stat is worth 1 computer skill here
     ///\EFFECT_INT increases success chance of hacking card readers
-    return who.get_skill_level( skill_computer ) + who.int_cur / 2 - 8;
+    return who.get_skill_level( skill_computer ) + ( who.int_cur - 8 ) / 4;
 }
 
 static hack_result hack_attempt( Character &who, const bool using_bionic )


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

The equation in `hack_level()`, used to determine player's ability when using an electrohack, was not consistent with the comments. It says:
```
///\EFFECT_COMPUTER increases success chance of hacking card readers
// odds go up with int>8, down with int<8
// 4 int stat is worth 1 computer skill here
///\EFFECT_INT increases success chance of hacking card readers
```
But what it actually calculated was
_Computers + INT / 2 - 8_

The wording on the comments is somewhat ambiguous (odds go down from what?), but they seem to imply that at 0 computers and 8 int, you should get a result of 0. Instead, that gives you -4. And obviously, one computer skill is worth 2 int, not 4.

## Describe the solution (The How)

Made the numbers match the comments. Now, at 8 int, your `hack_level` is just your computer skill, and every 4 int over or under this zero level gives you a one point bonus or penalty.

## Describe alternatives you've considered

This will obviously make electrohacking easier. It's hard to say how much easier, exactly, since the skill roll that this number is used for is a normal distribution, but I think it's quite a bit. In my opinion, it's clearly not meant to be as hard as it is now, but one could also argue that it's the _comment_ that is wrong.

There's other changes I'd like to make to electrohacks, if I can get them working, but this seemed like it could be easily done separately.

## Testing

Compiled, loaded, used electrohack to open a gun safe.
Did not calculate or experimentally verify exact probability of succeeding in hack, but it _feels_ easier now.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task doc` so the Lua API documentation is updated.
-->
