### PR TITLE
chore: enable clangd inlay hints

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,2 +1,10 @@
 Style:
   QuotedHeaders: "src/.*"
+
+InlayHints:
+  Enabled: true
+  ParameterNames: true
+  DeducedTypes: true
+  Designators: false
+  BlockEnd: false
+  DefaultArguments: true


### PR DESCRIPTION

## Purpose of change (The Why)

![image](https://github.com/user-attachments/assets/9336b68b-0717-4ae7-894d-a03da9f90c57)

make `auto` great again! also less hovering needed to find type is good

## Describe the solution (The How)

adds clangd config to display inlay hints in your favorite IDE. see https://clangd.llvm.org/config#inlayhints for details.

![image](https://github.com/user-attachments/assets/6a3fde5d-1056-4223-9496-4163f9884eea)

- infers type of `auto`!

![image](https://github.com/user-attachments/assets/d06c14a8-8cef-4e7f-830d-311821cc27ba)

- named parameters! (ish)
- displays default value for function!

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

