### PR TITLE
fix: display of healthy[_mod] in character edit debug menu

### DIFF
--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -966,19 +966,22 @@ void character_edit_menu( Character &c )
             break;
         case edit_character::healthy: {
             uilist smenu;
-            smenu.addentry( 0, true, 'h', "%s: %d", _( "Health" ), p.get_healthy() );
-            smenu.addentry( 1, true, 'm', "%s: %d", _( "Health modifier" ), p.get_healthy_mod() );
+            smenu.addentry( 0, true, 'h', "%s: %d", _( "Health" ), static_cast<int>( p.get_healthy() ) );
+            smenu.addentry( 1, true, 'm', "%s: %d", _( "Health modifier" ),
+                            static_cast<int>( p.get_healthy_mod() ) );
             smenu.addentry( 2, true, 'r', "%s: %d", _( "Radiation" ), p.get_rad() );
             smenu.query();
             int value;
             switch( smenu.ret ) {
                 case 0:
-                    if( query_int( value, _( "Set the value to?  Currently: %d" ), p.get_healthy() ) ) {
+                    if( query_int( value, _( "Set the value to?  Currently: %d" ),
+                                   static_cast<int>( p.get_healthy() ) ) ) {
                         p.set_healthy( value );
                     }
                     break;
                 case 1:
-                    if( query_int( value, _( "Set the value to?  Currently: %d" ), p.get_healthy_mod() ) ) {
+                    if( query_int( value, _( "Set the value to?  Currently: %d" ),
+                                   static_cast<int>( p.get_healthy_mod() ) ) ) {
                         p.set_healthy_mod( value );
                     }
                     break;


### PR DESCRIPTION
## Purpose of change (The Why)
Formatting error when displaying healthy and healthy_mod values in character edit menu

## Describe the solution (The How)
Wrap `get_` calls with a `static_cast<int>`. The values are only `float`s for precision purposes during calculations.

## Describe alternatives you've considered
Change the format to expect a `float` for display, but would need to keep `query_int` for the input since we don't have a `query_float`.

## Testing
Opened character edit debug menu and it displays properly. Set `Health` to 20 from 0 and it set properly. Waited for 30m so that `update_health` would be called and checked it again, properly displays once more.

## Additional context
Image of error
![image](https://github.com/user-attachments/assets/8868649d-f661-4ddc-974d-36b456b2a691)

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.