### PR TITLE
fix: small `read uint as int bug`

### DIFF
--- a/src/json.h
+++ b/src/json.h
@@ -1281,6 +1281,9 @@ class JsonValue
         int get_int() const {
             return seek().get_int();
         }
+        unsigned int get_uint() const {
+            return seek().get_uint();
+        }
         int64_t get_int64() const {
             return seek().get_int64();
         }

--- a/src/safe_reference.cpp
+++ b/src/safe_reference.cpp
@@ -42,7 +42,7 @@ void safe_reference<T>::deserialize_global( const JsonArray &jsin )
         }
 
         pair = false;
-        uint32_t count = val.get_int();
+        uint32_t count = val.get_uint();
         record *rec = new record( id );
         rec->json_count = count;
         records_by_id.insert( {id, rec} );


### PR DESCRIPTION
## Purpose of change (The Why)
Deserialization of `safe_reference<item>` tries to load an `int` when it should be loading an `unsigned int` and can generate an error if the read value is outside of the expected range.

## Describe the solution (The How)
Add `get_uint` function to `JsonValue` to fill out `seek().get_X` (`JsonIn::get_X()`) and change call to `JsonValue::get_int` to `JsonValue::get_uint`.

## Describe alternatives you've considered
More involved templatization to `get<T> [T = Arithmetic]` since most of these functions are just passing the call forward to `JsonIn` and those functions also have a lot of repetition.

## Testing
Compiles, didn't get any complaints from the compiler. I do not currently have a save file that generates the error.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.