### PR TITLE
feat(balance): GHB reduces "you need a drink" spam

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -891,6 +891,8 @@
   {
     "type": "effect_type",
     "id": "took_antinarcoleptic",
+    "name": [ "Took GHB" ],
+    "desc": [ "You took GHB some time ago and you might still be under its influence." ],
     "blood_analysis_description": "GHB"
   },
   {

--- a/data/json/items/comestibles/med.json
+++ b/data/json/items/comestibles/med.json
@@ -726,7 +726,7 @@
   {
     "id": "ghb",
     "type": "COMESTIBLE",
-    "comestible_type": "DRINK",
+    "comestible_type": "MED",
     "name": { "str_sp": "GHB" },
     "description": "A potent CNS depressant and natural neurotransmitter, used medically for narcolepsy and sometimes alcohol withdrawal.  Recreational use is risky due to high overdose potential, especially with alcohol.",
     "weight": "1 g",

--- a/src/addiction.cpp
+++ b/src/addiction.cpp
@@ -114,7 +114,7 @@ void addict_effect( Character &u, addiction &add )
             const int morale_penalty_max = on_ghb ? -5 * in : -10 * in;
 
             if( is_alcohol || add.type == add_type::DIAZEPAM ) {
-                if( x_in_y( in, to_turns<int>( 2_minutes ) * 20 ) ) {
+                if( x_in_y( in, to_turns<int>( 2_minutes ) * 20 ) && ( !on_ghb || one_in( 2 ) ) ) {
                     const std::string msg_1 = is_alcohol ?
                                               _( "You could use a drink." ) :
                                               _( "You could use some diazepam." );
@@ -123,7 +123,7 @@ void addict_effect( Character &u, addiction &add )
                     if( on_ghb && one_in( 5 ) ) {
                         u.add_msg_if_player( _( "The GHB makes it not so bad." ) );
                     }
-                } else if( calendar::once_every( 1_minutes ) && rng( 8, 300 ) < in ) {
+                } else if( calendar::once_every( 1_minutes ) && rng( 8, 300 ) < in && ( !on_ghb || one_in( 2 ) ) ) {
                     const std::string msg_2 = is_alcohol ?
                                               _( "Your hands start shaking… you need a drink bad!" ) :
                                               _( "You're shaking… you need some diazepam!" );


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

Belated lil followup to https://github.com/cataclysmbnteam/Cataclysm-BN/pull/6554 I brought up but decided can go as a follow-up PR, plus a lil extra QoL and minor fixes that came to mind.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

C++ changes:
1. In addiction.cpp, changed the regular "you need a drink" messages and related effects in `addict_effect` to trigger half as often when on GHB.

JSON changes:
1. Added a name and description to the GHB effect so you can see on the effect screen if you're under the effect of it, same with most of the other medicines like antibiotics, xnanx, thorazine, prozac etc.
2. Changed GHB's `comestible_type` from `DRINK` to `MED` so it won't also print a "you drink GHB" message on top of the use action message.

## Describe alternatives you've considered

Just making it suppress the messages entirely to make it easier to test.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected JSON for syntax and lint errors.
2. Compiled and load-tested, for testing purposes initially set the message chance on GHB much lower to make it easier to tell the difference.
3. Started off as a hobo and waited a while, got the expected message spam.
4. Repeated same wait duration after applying some GHB, message log shows less message spam.
5. Checked affected C++ for astyle.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task doc` so the Lua API documentation is updated.
-->
