### PR TITLE
feat(balance): adjust effects and point cost of psychosis trait

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -1063,7 +1063,7 @@
     "type": "mutation",
     "id": "SCHIZOPHRENIC",
     "name": { "str": "Psychosis" },
-    "points": -1,
+    "points": -6,
     "description": "You will periodically suffer from delusions, ranging from minor effects to full visual hallucinations.  Some of these effects may be controlled through the use of Thorazine.",
     "starting_trait": true,
     "valid": false,

--- a/data/json/obsoletion/uncategorized.json
+++ b/data/json/obsoletion/uncategorized.json
@@ -421,5 +421,19 @@
     "id": "HAND_AXES",
     "name": "Hand Axes",
     "//": "Axe with a short handle, typically wielded in one hand, ocassionally thrown."
+  },
+  {
+    "type": "snippet",
+    "category": "schizo_weapon_drop",
+    "text": [
+      "%1$s starts burning your hands!",
+      "%1$s feels freezing cold!",
+      "An electric shock shoots into your hand from %1$s!",
+      "%1$s lied to you.",
+      "%1$s was working for… THEM",
+      "%1$s said something stupid.",
+      "%1$s is running away!",
+      "%1$s finds you filthy."
+    ]
   }
 ]

--- a/data/json/snippets/schizophrenia.json
+++ b/data/json/snippets/schizophrenia.json
@@ -171,20 +171,6 @@
   },
   {
     "type": "snippet",
-    "category": "schizo_weapon_drop",
-    "text": [
-      "%1$s starts burning your hands!",
-      "%1$s feels freezing cold!",
-      "An electric shock shoots into your hand from %1$s!",
-      "%1$s lied to you.",
-      "%1$s was working for… THEM",
-      "%1$s said something stupid.",
-      "%1$s is running away!",
-      "%1$s finds you filthy."
-    ]
-  },
-  {
-    "type": "snippet",
     "category": "broken_limb",
     "text": [ "Your limb breaks!" ]
   }

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -513,15 +513,10 @@ void Character::suffer_from_schizophrenia()
         shout( SNIPPET.random_from_category( "schizo_self_shout" ).value_or( translation() ).translated() );
         return;
     }
-    // Drop weapon
-    if( one_turn_in( 2_days ) && !weapon.is_null() ) {
-        const translation snip = SNIPPET.random_from_category( "schizo_weapon_drop" ).value_or(
-                                     translation() );
-        std::string str = string_format( snip, i_name_w );
-        str[0] = toupper( str[0] );
-
-        add_msg_if_player( m_bad, "%s", str );
-        drop( primary_weapon(), pos() );
+    // Focus debuff
+    if( one_turn_in( 8_hours ) ) {
+        add_msg_if_player( m_bad, _( "You find it hard to focus all of a sudden." ) );
+        focus_pool -= rng( 20, 40 );
         return;
     }
     // Talk to self


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

Some much-belated rebalancing of the psychosis trait. Notable problems with it were:
1. It barely gives any points despite how much it can fuck with the player, the same bonus as the much more mild chemical imbalance trait in fact.
2. Some of its effects are very...spicy. Main one I see complaints about is the whole "drop your weapon once every couple days" effect which is a recipe for forgetting your weapon during fast travel.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

C++ changes:
1. In suffer.cpp, updated `Character::suffer_from_schizophrenia` to remove the "your weapon betrayhed you, drop it on the ground" effect due to being the most commonly complained about aspect of the trait. Instead, added an effect that reduces focus pool by a random amount. Felt it'd be mildly interesting as an effect that doesn't show very often outside of two non-standard addictions (mutation and marloss).

JSON changes:
1. Bumped point bonus of psychosis up from -1 to -6, on par with Illiterate (the other notable "most players avoid it like the plague" trait that, unlike Wayfarer, can be mitigated in some way). It's generally more disruptive than Chemical Imbalance (-1), basically impossible to get rid of, can only be suppressed by a hard to craft uncommon drug, and unlike Illiterate you can't bypass the effects with a seeing-eye NPC.
2. Moved the `schizo_weapon_drop` snippet category to obsolete folder.

## Describe alternatives you've considered

1. Keeping weapon drops but adding an int roll to resist dropping it, printing a different message if you successfully resist. Maybe also making it a full-on popup like when technicians steal your weapon.
2. Picking a different point cost. Dunno what else to add?
3. Changing the intensity and/or frequency of the focus debuff as desired.
4. Adding any other side effects one can think of that might be neat, especially more flavor to hallucination effects to fuck with the player in particular.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected JSON changes for syntax and lint errors.
2. Compiled and load-tested.
3. Started with psychosis trait and waited around, noted that eventually a focus drop occured with associated message.
4. Checked affected C++ for astyle.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task doc` so the Lua API documentation is updated.
-->
