### PR TITLE
fix: Remove initial charge cost of light survivor mask and half-mask

### DIFF
--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -1318,7 +1318,6 @@
     "to_hit": -3,
     "max_charges": 100,
     "initial_charges": 100,
-    "charges_per_use": 1,
     "ammo": "gasfilter_m",
     "use_action": "GASMASK",
     "material": [ "kevlar", "cotton" ],


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

Survivor masks also used to consume one charge when one prepared it for use. However, this didn't make any sense so it was removed from all the gas masks. It seems light survivor mask and, by extent, survivor half-mask were forgotten.

## Describe the solution (The How)

Remove the line

## Describe alternatives you've considered

Continue being minutely annoyed by my mask consuming a single charge upon getting it ready for use.
Why do they even need to be prepared anyway? It's not like you weren't already wearing it over your face.

## Testing

spawned in
They don't do the thing anymore

## Additional context

none given

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.