### PR TITLE
fix: survivor workbench construction correctly makes its furniture

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -2301,7 +2301,7 @@
     "components": [ [ [ "survivors_workbench", 1 ] ] ],
     "pre_special": "check_empty",
     "dark_craftable": true,
-    "post_furniture": "f_workbench"
+    "post_furniture": "f_survivors_workbench"
   },
   {
     "type": "construction",


### PR DESCRIPTION
## Purpose of change (The Why)

#6922

Wasn't caught in reviewing, and I had no PC at the time because my boot SSD started failing and caused a kernel panic.

<img width="480" height="270" alt="image" src="https://github.com/user-attachments/assets/54a8dffe-34e3-412f-a120-278e3e161485" />


## Describe the solution (The How)

f_survivors_workbench

## Describe alternatives you've considered

Always have at least 70 backup laptops at all moments of the day, buried in electromagnetic resistant materials to avoid solar flares.

## Testing

Nah

## Additional context
## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.