### PR TITLE
feat(balance): rework zombie supply sergeant

### DIFF
--- a/data/json/monster_special_attacks/spells.json
+++ b/data/json/monster_special_attacks/spells.json
@@ -327,8 +327,8 @@
     "min_aoe": 2,
     "max_aoe": 2,
     "base_casting_time": 3,
-    "min_duration": 2000,
-    "max_duration": 4000,
+    "min_duration": 2500,
+    "max_duration": 5000,
     "effect": "summon",
     "effect_str": "mon_zombie_soldier_minion"
   },

--- a/data/json/monsters/zed_soldiers.json
+++ b/data/json/monsters/zed_soldiers.json
@@ -561,14 +561,10 @@
     "type": "MONSTER",
     "copy-from": "mon_zombie_soldier",
     "looks_like": "mon_zombie_soldier",
-    "//": "Look like real zombies, hit like real zombies, but vanish on taking a single hit.  Keep the easter egg in the description though, per request.  If you're looking at monster descriptions to sort the real ones from the fakes, your priorities are misplaced since these can still hurt you. :3",
+    "//": "Look like real zombies, hit like real zombies, but overall weaker.  Keep the easter egg in the description though, per request.  If you're looking at monster descriptions to sort the real ones from the fakes, your priorities are misplaced since these can still hurt you. :3",
     "description": "These are the pathetic beings reluctantly dragged into action under the coercive command of their commanding officer.  They still wear expressions of profound displeasure and exhibit a visibly annoyed demeanor, moving listlessly to commands that are a confused echo of their past lives.  Forcibly deployed, they shamble towards you, but their every movement clearly conveys, \"Why do I have to do this?\"",
-    "hp": 1,
-    "armor_bash": 0,
-    "armor_cut": 0,
-    "armor_bullet": 0,
-    "special_attacks": [ { "type": "bite", "cooldown": 5, "min_mul": 0.8 }, [ "GRAB", 7 ], [ "scratch", 20 ] ],
-    "death_function": [ "DISAPPEAR" ]
+    "proportional": { "hp": 0.75, "speed": 0.75, "armor_bash": 0.75, "armor_cut": 0.75, "armor_bullet": 0.75 },
+    "death_function": [ "DISINTEGRATE" ]
   },
   {
     "id": "mon_zombie_soldier_shieldman",


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

This tweaks one of the recent elite zombies to make behavior a lil less wacky, as there were balance concerns about sarges being able to drop a steadily-growing horde of soldiers on the player's lap from out of thin air given enough time, as they could pile up faster than the `DISAPPEAR` special attack could remove them.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. Zombie supply sergeants reflavored a bit, renamed zombie sergeant for simplicity and given a description that better fits an undead NCO leading troops into battle (per @scarf005's request, I retained some elements of the original description as evidently it's also meant to riff on stereotypes about the Korean military and its conscription practices). Its summons are now reflavored as ghostly images instead of summoning more zeds out of thin air. Cooldown for the spell also bumped up to 30 seconds, and set to spawn them on its position instead of dropping them on the player.
2. The zombies conjured by sergeants adjusted accordingly, they're now set to use the same name as regular zombie soldiers, but have reduced health, speed, and armor. Idea is they're basically solid illusions, still capable of harming the player but easier to put down. Also removed the vanishing special attack, because...
3. Tweaked the summoning spell to no longer spawn permanent summons, instead a random duration of 25-50 seconds. Also properly uses random damage so it will summon a random number of the goobers, tightened up the AoE so they're grouped around sarge, and expanded range from 3-4 to 2-5.

## Describe alternatives you've considered

Reflavoring it to give command buffs like zombie masters.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected file for syntax and lint errors.
2. Load-tested in compiled test build.
3. Spawned sarge in, it drop the summons around it instead of next to the player.
4. Backed off and confirmed the summoned zeds will vanish over time.

<img width="498" height="56" alt="image" src="https://github.com/user-attachments/assets/40a59de3-78f7-4c31-b55a-3bd6138e2f76" />

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
