### PR TITLE
feat: `--version` command

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -45,6 +45,7 @@
 #include "type_id.h"
 #include "ui_manager.h"
 #include "path_display.h"
+#include "get_version.h"
 
 #if defined(PREFIX)
 #   undef PREFIX
@@ -571,6 +572,9 @@ int main( int argc, char *argv[] )
                 printHelpMessage( first_pass_arguments.data(), num_first_pass_arguments,
                                   second_pass_arguments.data(), num_second_pass_arguments );
                 return 0;
+            } else if( !strcmp( argv[0], "--version" ) ) {
+                cata_printf( "%s\n", getVersionString() );
+                return 0;
             } else if( !strcmp( argv[0], "--paths" ) ) {
                 asked_game_path = true;
                 argc--;
@@ -851,6 +855,8 @@ void printHelpMessage( const arg_handler *first_pass_arguments,
     cata_printf( R"(Info:
 --help
     print this message and exit
+--version
+    print the version and exit
 --paths
     print the paths used by the game and exit
 


### PR DESCRIPTION
## Purpose of change (The Why)

there's no way to get version of game binary without opening the game, there should be an way to get the version string in terminal too.

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

