### PR TITLE
ci: clean up build matrix

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -43,7 +43,6 @@ jobs:
           - title: GCC, Ubuntu, Curses
             compiler: g++
             os: ubuntu-latest
-            cmake: 0
             tiles: 0
             sound: 0
             test-stage: 1
@@ -56,7 +55,6 @@ jobs:
           - title: GCC, Ubuntu, Tiles, Sound, CMake, Languages
             compiler: g++
             os: ubuntu-latest
-            cmake: 1
             tiles: 1
             sound: 1
             languages: all
@@ -69,7 +67,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       ZSTD_CLEVEL: 17
-      CMAKE: ${{ matrix.cmake }}
+      CMAKE: 1
       COMPILER: ${{ matrix.compiler }}
       OS: ${{ matrix.os }}
       TILES: ${{ matrix.tiles }}


### PR DESCRIPTION

## Purpose of change (The Why)

clean up `matrix.yml`

## Describe the solution (The How)

- remove comments unused for years
- remove mac builds to simplify build
- only keep tile and curses build, no need to have 3 checks when one is subset of other

## Describe alternatives you've considered

## Testing

should probably work

## Additional context


## Checklist


### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

