### PR TITLE
feat: add a parameterized palette to allow different linoleum colors in houses bathrooms

### DIFF
--- a/data/json/mapgen_palettes/house_general_palette.json
+++ b/data/json/mapgen_palettes/house_general_palette.json
@@ -284,7 +284,8 @@
       "S": { "param": "linoleum_color_bathroom", "fallback": "t_linoleum_white" },
       "8": { "param": "linoleum_color_bathroom", "fallback": "t_linoleum_white" },
       "Q": { "param": "linoleum_color_bathroom", "fallback": "t_linoleum_white" },
-      "w": { "param": "linoleum_color_bathroom", "fallback": "t_linoleum_white" }
+      "w": { "param": "linoleum_color_bathroom", "fallback": "t_linoleum_white" },
+      "¨": { "param": "linoleum_color_bathroom", "fallback": "t_linoleum_white" }
     }
   },
   {


### PR DESCRIPTION
## Purpose of change (The Why)
Because gray linoleum is the only color for bathrooms in houses using `standard_domestic_lino_bathroom`
## Describe the solution (The How)
Add the palette `parameterized_linoleum_color_bathroom` to house_general_palette.json
## Describe alternatives you've considered
none
## Testing
No errors when starting a new game.
## Additional context
The palette is unused for the moment, but will replace `standard_domestic_lino_bathroom`
## Checklist

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.