### PR TITLE
feat(balance): Change some recipes to an easier smithing standard

### DIFF
--- a/data/json/recipes/weapon/cutting.json
+++ b/data/json/recipes/weapon/cutting.json
@@ -403,7 +403,7 @@
     "difficulty": 5,
     "time": "5 h",
     "autolearn": true,
-    "using": [ [ "blacksmithing_advanced", 12 ], [ "steel_standard", 3 ] ],
+    "using": [ [ "blacksmithing_easy", 12 ], [ "steel_standard", 3 ] ],
     "components": [ [ [ "2x4", 1 ], [ "stick", 2 ] ], [ [ "fabric_hides_any", 1, "LIST" ] ] ]
   },
   {

--- a/data/json/recipes/weapon/piercing.json
+++ b/data/json/recipes/weapon/piercing.json
@@ -62,7 +62,7 @@
     "difficulty": 4,
     "time": "5 h",
     "autolearn": true,
-    "using": [ [ "blacksmithing_advanced", 4 ], [ "steel_standard", 1 ] ],
+    "using": [ [ "blacksmithing_easy", 4 ], [ "steel_standard", 1 ] ],
     "components": [ [ [ "fabric_hides_any", 1, "LIST" ] ] ]
   },
   {
@@ -251,7 +251,7 @@
     "difficulty": 3,
     "time": "1 h",
     "autolearn": true,
-    "using": [ [ "blacksmithing_intermediate", 1 ] ],
+    "using": [ [ "blacksmithing_easy", 1 ] ],
     "components": [ [ [ "javelin", 1 ] ], [ [ "scrap", 1 ] ] ]
   },
   {
@@ -668,7 +668,7 @@
     "skills_required": [ "melee", 5 ],
     "time": "5 m",
     "autolearn": true,
-    "using": [ [ "blacksmithing_advanced", 5 ] ],
+    "using": [ [ "blacksmithing_easy", 5 ] ],
     "qualities": [ { "id": "SAW_M", "level": 1 } ],
     "components": [ [ [ "blade", 1 ] ], [ [ "spike", 1 ] ], [ [ "pipe", 2 ] ], [ [ "duct_tape", 100 ] ] ]
   },

--- a/data/json/recipes/weapon/ranged.json
+++ b/data/json/recipes/weapon/ranged.json
@@ -642,7 +642,7 @@
     "difficulty": 4,
     "time": "1 h",
     "autolearn": true,
-    "using": [ [ "blacksmithing_intermediate", 3 ], [ "steel_tiny", 1 ] ]
+    "using": [ [ "blacksmithing_easy", 3 ], [ "steel_tiny", 1 ] ]
   },
   {
     "type": "recipe",

--- a/data/json/requirements/toolsets.json
+++ b/data/json/requirements/toolsets.json
@@ -42,6 +42,13 @@
     "tools": [ [ [ "forge", 20 ], [ "oxy_torch", 20 ] ] ]
   },
   {
+    "id": "blacksmithing_easy",
+    "type": "requirement",
+    "//": "As easy as it can get, until we add wooden tongs.",
+    "qualities": [ { "id": "ANVIL", "level": 1 }, { "id": "HAMMER", "level": 2 } ],
+    "tools": [ [ [ "forge", 20 ], [ "oxy_torch", 20 ] ], [ [ "tongs", -1 ] ] ]
+  },
+  {
     "id": "blacksmithing_standard",
     "type": "requirement",
     "//": "Includes forging resources as well as tools needed for basic blacksmithing.  Permits working hot metal on stone surfaces.",


### PR DESCRIPTION
## Purpose of change (The Why)

We discussed a few recipes being easier and not needing a crucible, so I went through all the weapon recipes to find any with smithing standards that could get easier while maintaining realism.

## Describe the solution (The How)

Adds blacksmithing_easy which needs no crucible. Any anvil or rock with anvil, a rock hammer, tongs, and a forge will let you make these items.

## Describe alternatives you've considered

new recipes?

## Testing

Tests
<img width="2050" height="1206" alt="image" src="https://github.com/user-attachments/assets/6173ffb9-3455-422b-89f0-ed6642fa9998" />


## Additional context
## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.