### PR TITLE
feat: update NPC bionic installation to be informative

### DIFF
--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1856,7 +1856,7 @@ class bionic_install_preset: public inventory_selector_preset
                                                std::placeholders::_1 ) ) ) {
                 return _( "Superior version installed" );
             } else if( pa.is_npc() && !bid->has_flag( flag_BIONIC_NPC_USABLE ) ) {
-                return _( "CBM not compatible with patient" );
+                return _( "CBM not usable by NPC's" );
             } else if( units::energy_max - pa.get_max_power_level() < bid->capacity ) {
                 return _( "Max power capacity already reached" );
             } else if( !has_enough_anesthesia( itemtype, p, pa ) ) {


### PR DESCRIPTION
## Purpose of change (The Why)

NPC's are incapable of a lot of bionic usage. Players don't always realize this. This message is not informative.
<img width="2046" height="1206" alt="image" src="https://github.com/user-attachments/assets/8e48878a-5de6-4b82-9474-65ee9154c86a" />


## Describe the solution (The How)

Updates the message to a fourth wall break that cleanly describes the problem. "CBM not usable by NPC's"

A fourth wall break is preferred when we're trying to convey you can't do something through no fault of your own.

## Describe alternatives you've considered

Someone making them usable.

## Testing

It's trivial.

## Additional context
## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.