### PR TITLE
fix: Effects causing HP changes only reports hurt on damage

### DIFF
--- a/src/character_turn.cpp
+++ b/src/character_turn.cpp
@@ -489,14 +489,14 @@ void Character::process_one_effect( effect &it, bool is_new )
             if( !bp ) {
                 if( val > 5 ) {
                     add_msg_if_player( _( "Your %s HURTS!" ), body_part_name_accusative( bp_torso ) );
-                } else {
+                } else if( val > 0 ) {
                     add_msg_if_player( _( "Your %s hurts!" ), body_part_name_accusative( bp_torso ) );
                 }
                 apply_damage( nullptr, bodypart_id( "torso" ), val, true );
             } else {
                 if( val > 5 ) {
                     add_msg_if_player( _( "Your %s HURTS!" ), body_part_name_accusative( bp ) );
-                } else {
+                } else if( val > 0 ) {
                     add_msg_if_player( _( "Your %s hurts!" ), body_part_name_accusative( bp ) );
                 }
                 apply_damage( nullptr, bp.id(), val, true );


### PR DESCRIPTION
## Purpose of change (The Why)

Healing effects reports damage constantly, despite the player healing. A simple else if change fixes this.

## Describe the solution (The How)

An else if so damage has to be above 0 to report. Negative values are used on healing.

## Describe alternatives you've considered

Chaosvolt

## Testing

The player was first given a Med-shot from Essence 2200 which rapidly healed without reporting your X hurts.

The player was then given Red Rot, and they freaked out in pain as Ebola liquefied their innards. :(

Just in case I was being stupid, I made sure to subtract half my HP with debug and use a med-shot again. I had to be doubly sure I was doing this right.

<img width="2046" height="1206" alt="image" src="https://github.com/user-attachments/assets/693bc150-8712-4661-9ca7-1a61504abd98" />
<img width="2046" height="1206" alt="image" src="https://github.com/user-attachments/assets/fe7a1710-0dc8-400c-9fab-72b160ddcc06" />


## Additional context

The best learning is from fucking up. Preferably BEFORE you release your mistakes to the public.

## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.