### PR TITLE
feat(balance): allow additional double-barrel weapons to have double fire mode

### DIFF
--- a/data/json/items/gun/38.json
+++ b/data/json/items/gun/38.json
@@ -19,6 +19,7 @@
     "dispersion": 620,
     "durability": 3,
     "clip_size": 2,
+    "modes": [ [ "DEFAULT", "single", 1 ], [ "DOUBLE", "double", 2 ] ],
     "reload": 200,
     "valid_mod_locations": [ [ "accessories", 4 ], [ "grip", 1 ], [ "sights", 1 ], [ "underbarrel", 1 ], [ "rail", 1 ], [ "stock", 1 ] ],
     "delete": { "flags": "NEVER_JAMS" }

--- a/data/json/items/gun/flintlock.json
+++ b/data/json/items/gun/flintlock.json
@@ -28,6 +28,7 @@
     "name": { "str": "handmade double-barrel flintlock" },
     "description": "This is a compact muzzle-loading rifle combining a pair of rudimentary flintlock actions and two barrels.  Whereas an antique multiple-barrel flintlock is an intricate work of gunsmithing, this weapon is simpler yet still serviceable.",
     "clip_size": 2,
+    "modes": [ [ "DEFAULT", "single", 1 ], [ "DOUBLE", "double", 2 ] ],
     "price_postapoc": "2750 cent",
     "proportional": { "dispersion": 1.3, "weight": 1.25, "volume": 1.25 },
     "relative": { "weight": 400, "range": -1, "ranged_damage": { "damage_type": "bullet", "amount": -2 } },

--- a/data/json/items/gunmod/underbarrel.json
+++ b/data/json/items/gunmod/underbarrel.json
@@ -70,7 +70,8 @@
       "dispersion": 345,
       "durability": 10,
       "blackpowder_tolerance": 72,
-      "clip_size": 2
+      "clip_size": 2,
+      "modes": [ [ "DEFAULT", "single", 1 ], [ "DOUBLE", "double", 2 ] ]
     },
     "flags": [ "IRREMOVABLE", "RELOAD_ONE", "RELOAD_EJECT" ]
   },
@@ -89,7 +90,15 @@
     "color": "light_red",
     "location": "underbarrel",
     "mod_target_category": [ [ "RIFLES" ], [ "MACHINE_GUNS" ], [ "GATLING_GUNS" ] ],
-    "gun_data": { "ammo": "shot", "skill": "shotgun", "dispersion": 480, "durability": 6, "blackpowder_tolerance": 72, "clip_size": 2 },
+    "gun_data": {
+      "ammo": "shot",
+      "skill": "shotgun",
+      "dispersion": 480,
+      "durability": 6,
+      "blackpowder_tolerance": 72,
+      "clip_size": 2,
+      "modes": [ [ "DEFAULT", "single", 1 ], [ "DOUBLE", "double", 2 ] ]
+    },
     "flags": [ "IRREMOVABLE", "RELOAD_ONE", "NEVER_JAMS", "RELOAD_EJECT" ]
   },
   {
@@ -574,7 +583,14 @@
     "color": "light_red",
     "location": "underbarrel",
     "mod_target_category": [ [ "RIFLES" ], [ "MACHINE_GUNS" ], [ "GATLING_GUNS" ], [ "M_XBOWS" ] ],
-    "gun_data": { "ammo": "shot", "skill": "shotgun", "dispersion": 375, "durability": 10, "clip_size": 2 },
+    "gun_data": {
+      "ammo": "shot",
+      "skill": "shotgun",
+      "dispersion": 375,
+      "durability": 10,
+      "clip_size": 2,
+      "modes": [ [ "DEFAULT", "single", 1 ], [ "DOUBLE", "double", 2 ] ]
+    },
     "flags": [ "RELOAD_ONE" ]
   },
   {

--- a/data/json/items/ranged/spearguns.json
+++ b/data/json/items/ranged/spearguns.json
@@ -151,6 +151,7 @@
     "dispersion": 120,
     "durability": 7,
     "clip_size": 2,
+    "modes": [ [ "DEFAULT", "single", 1 ], [ "DOUBLE", "double", 2 ] ],
     "loudness": 5
   }
 ]


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

This allows different fire modes for a couple of guns where it might be interesting to permit.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. Allowed the 2-shot special to fire both barrels.
2. Allowed double-barreled flintlock carbine to fire both barrels, as that makes it a more interesting sidegrade to the rifled musket.
3. Permitted double speargun to fling both spears too.
4. Allowed combination gun shotgun and the two-shot underbarrel shotgun mod to have double-barrel firemode, as regular double-barrels are allowed to have that already.

## Describe alternatives you've considered

Bringing back burst fire for the repeating crossbow and changing its weapon skill to SMG again. Given there's a pistol skill crossbow, this might compliment the alternative suggested in https://github.com/cataclysmbnteam/Cataclysm-BN/pull/7068 in which we could hypothetically change the huge crossbow to use launcher skill for funsies.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected JSON for syntax and lint errors.
2. Load-tested in compiled test build.
3. Spawned in a combination gun, confirmed that switching through the mounted shotgun's firemodes actually works.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

![page05](https://github.com/user-attachments/assets/92d06829-1df0-4acd-8c33-3ba5779aa6f0)

~~Muzzleflash effects when~~

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
