### PR TITLE
feat: craftable cranberry and orange juices

### DIFF
--- a/data/json/recipes/food/drinks.json
+++ b/data/json/recipes/food/drinks.json
@@ -1723,5 +1723,33 @@
     "qualities": [ { "id": "BOIL", "level": 1 }, { "id": "CUT", "level": 1 } ],
     "tools": [ [ [ "water_boiling_heat", 2, "LIST" ] ] ],
     "components": [ [ [ "dry_rice", 1 ] ], [ [ "barley", 1 ] ], [ [ "water", 1 ], [ "water_clean", 1 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "result": "cranberry_juice",
+    "byproducts": [ [ "juice_pulp", 2 ] ],
+    "category": "CC_FOOD",
+    "subcategory": "CSC_FOOD_DRINKS",
+    "skill_used": "cooking",
+    "difficulty": 1,
+    "time": "5 m",
+    "autolearn": true,
+    "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "CONTAIN", "level": 1 } ],
+    "tools": [ [ [ "rag", -1 ] ] ],
+    "components": [ [ [ "cranberries", 2 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "result": "oj",
+    "byproducts": [ [ "juice_pulp", 2 ] ],
+    "category": "CC_FOOD",
+    "subcategory": "CSC_FOOD_DRINKS",
+    "skill_used": "cooking",
+    "difficulty": 1,
+    "time": "5 m",
+    "autolearn": true,
+    "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "CONTAIN", "level": 1 } ],
+    "tools": [ [ [ "rag", -1 ] ] ],
+    "components": [ [ [ "orange", 2 ] ] ]
   }
 ]


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

I wanted to become a cranberry farmer and make a bunch of crispy cranberry, but I could only make normal juice.
There's also no way to make orange juice

## Describe the solution (The How)

Add recipes for cranberry juice and orange juice

## Describe alternatives you've considered

Obsolete cranberry, orange , apple, etc juices and instead allow recipees to require conditional name items.

## Testing

Spawned in
Juiced my cranberries
Juiced my oranges
Results were satisfying and refreshing

## Additional context

Can recipes already require conditional name items? 
Are they even recognized as unique entities?

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

