### PR TITLE
fix: Assign correct quality to bearings recipe

### DIFF
--- a/data/json/recipes/ammo/other.json
+++ b/data/json/recipes/ammo/other.json
@@ -49,7 +49,7 @@
     "autolearn": true,
     "book_learn": [ [ "textbook_fabrication", 1 ] ],
     "using": [ [ "forging_standard", 5 ] ],
-    "qualities": [ { "id": "CASING_FORMING", "level": 2 }, { "id": "CONTAIN_HOT", "level": 1 } ],
+    "qualities": [ { "id": "CASING_PRESSING", "level": 2 }, { "id": "CONTAIN_HOT", "level": 1 } ],
     "components": [ [ [ "weights", 34, "LIST" ], [ "steel_tiny", 2, "LIST" ] ] ]
   },
   {


### PR DESCRIPTION
## Purpose of change (The Why)

Wrong quality assigned, not caught in reviewing.

## Describe the solution (The How)

Assign pressing instead of forming.

## Describe alternatives you've considered

pressing 1 or forming 1

## Testing

Checked for all CASING_FORMING recipes to be ONLY 1 to make sure

## Additional context
## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.