### PR TITLE
fix: Fix item destruction from repair.

### DIFF
--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -3434,6 +3434,18 @@ static bool damage_item( player &pl, item *fix )
     pl.add_msg_if_player( m_bad, _( "You damage your %s!  ( %s-> %s)" ), fix->tname( 1, false ),
                           startdurability, resultdurability );
     if( destroyed ) {
+
+        // Dump its contents on the ground
+        // Destroy irremovable mods, if any
+        fix->contents.remove_top_items_with( []( detached_ptr<item> &&mod ) {
+            if( mod->is_gunmod() && !mod->is_irremovable() ) {
+                return detached_ptr<item>();
+            }
+            return std::move( mod );
+        } );
+
+        fix->contents.spill_contents( fix->position() );
+
         pl.add_msg_if_player( m_bad, _( "You destroy it!" ) );
         if( fix->where() == item_location_type::character ) {
             pl.i_rem_keep_contents( pl.get_item_position( fix ) );


### PR DESCRIPTION
## Purpose of change (The Why)

@chaosvolt alerted Developers in Discord to an issue where holsters were not correctly emptying their items when destroyed during repair activities. Checked and the code for destruction does not in fact have an unload segment like say melee damage code.

## Describe the solution (The How)

Copies the block of code from melee damaging items to the damage function for the activity.

## Describe alternatives you've considered

- Make a universal function for damaging items that will take everything into account instead of us having to update multiple points and places whenever something changes
  - Too much going on at the moment, this fixes it so I'll leave it alone.

## Testing

- [x] Spawn holster, spawn beretta m9, spawn tailoring kit, spawn leather patches.
  - [x] Load beretta into holster.
  - [x] Uncheck the tailoring skill from the character menu so player stops gaining exp to the skill. Repair until item is destroyed
  - [x] Confirm that beretta is dropped.

## Additional context

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
