### PR TITLE
fix: Parts with the EXTENDABLE flag cannot split vehicles

### DIFF
--- a/data/json/vehicleparts/wings.json
+++ b/data/json/vehicleparts/wings.json
@@ -2,7 +2,7 @@
   {
     "abstract": "wing",
     "type": "vehicle_part",
-    "location": "structural",
+    "location": "structure",
     "symbol": "|",
     "color": "light_blue",
     "looks_like": "cloth_halfboard",

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1586,13 +1586,15 @@ bool vehicle::can_unmount( const int p, std::string &reason ) const
     }
 
     //Structural parts have extra requirements
-    if( part_info( p ).location == part_location_structure ) {
+    if( part_info( p ).location == part_location_structure ||
+        part_info( p ).has_flag( VPFLAG_EXTENDABLE ) ) {
 
         std::vector<int> parts_in_square = parts_at_relative( parts[p].mount, false );
         /* To remove a structural part, there can be only structural parts left
          * in that square (might be more than one in the case of wreckage) */
         for( auto &elem : parts_in_square ) {
-            if( part_info( elem ).location != part_location_structure ) {
+            if( part_info( elem ).location != part_location_structure &&
+                !part_info( elem ).has_flag( VPFLAG_EXTENDABLE ) ) {
                 reason = _( "Remove all other attached parts first." );
                 return false;
             }
@@ -1688,7 +1690,8 @@ bool vehicle::is_connected( const vehicle_part &to, const vehicle_part &from,
             std::vector<int> parts_there = parts_at_relative( next, true );
 
             if( !parts_there.empty() && !parts[ parts_there[ 0 ] ].removed &&
-                part_info( parts_there[ 0 ] ).location == "structure" &&
+                ( part_info( parts_there[ 0 ] ).location == "structure" ||
+                  part_info( parts_there[ 0 ] ).has_flag( VPFLAG_EXTENDABLE ) ) &&
                 !part_info( parts_there[ 0 ] ).has_flag( "PROTRUSION" ) ) {
                 //Only add the part if we haven't been here before
                 bool found = false;

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -1097,8 +1097,6 @@ bool vehicle::check_heli_descend( Character &who )
         debugmsg( "A vehicle is somehow flying without being an aircraft" );
         return true;
     }
-    int count = 0;
-    int air_count = 0;
     map &here = get_map();
     for( const tripoint &pt : get_points( true ) ) {
         tripoint below( pt.xy(), pt.z - 1 );
@@ -1114,10 +1112,6 @@ bool vehicle::check_heli_descend( Character &who )
                                    _( "It would be unsafe to try and land when there are obstacles below you." ) );
             return false;
         }
-        if( here.has_flag_ter_or_furn( TFLAG_NO_FLOOR, below ) ) {
-            air_count++;
-        }
-        count++;
     }
     return true;
 


### PR DESCRIPTION
## Purpose of change (The Why)
Little mistake came through

## Describe the solution (The How)
1: Make wings actually use "structure"
2: Check for VPFLAG_EXTENDABLE in addition to being in the structure position
3: Resolve two warnings that came through (sorry scarf, I get other random ones so I miss them sometimes)

## Describe alternatives you've considered
None

## Testing
Spawn a vehicle, spawn 2 wings and 2 balloons, place them down, you can no longer have balloons separated from the vehicle

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.