### PR TITLE
fix(mods/aftershock): Aftershock vehicle parts now use integrated_tools

### DIFF
--- a/data/mods/Aftershock/vehicles/vehicle_parts.json
+++ b/data/mods/Aftershock/vehicles/vehicle_parts.json
@@ -124,13 +124,8 @@
       "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "vehicle_bolt", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 4 ] ], "time": "60 m", "using": [ [ "welding_standard", 5 ] ] }
     },
-    "flags": [ "CARGO", "OBSTACLE", "WELDRIG", "COVERED" ],
-    "integrated_tools": [
-      "forge",
-      "kiln",
-      "welder",
-      "soldering_iron"
-    ],
+    "flags": [ "CARGO", "OBSTACLE", "WELDRIG", "COVERED", "CRAFTER" ],
+    "integrated_tools": [ "forge", "kiln", "welder", "soldering_iron" ],
     "breaks_into": [
       { "item": "steel_lump", "count": [ 3, 6 ] },
       { "item": "steel_chunk", "count": [ 3, 6 ] },
@@ -161,14 +156,8 @@
       "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "vehicle_bolt", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 4 ] ], "time": "60 m", "using": [ [ "welding_standard", 5 ] ] }
     },
-    "flags": [ "CARGO", "OBSTACLE", "HOTPLATE", "FAUCET", "COVERED" ],
-    "integrated_tools": [
-      "chemistry_set",
-      "electrolysis_kit",
-      "pot",
-      "pan",
-      "hotplate"
-    ],
+    "flags": [ "CARGO", "OBSTACLE", "HOTPLATE", "FAUCET", "COVERED", "CRAFTER" ],
+    "integrated_tools": [ "chemistry_set", "electrolysis_kit", "pot", "pan", "hotplate" ],
     "breaks_into": [
       { "item": "steel_lump", "count": [ 6, 9 ] },
       { "item": "steel_chunk", "count": [ 6, 9 ] },
@@ -200,18 +189,8 @@
       "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "vehicle_bolt", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 4 ] ], "time": "60 m", "using": [ [ "welding_standard", 5 ] ] }
     },
-    "flags": [ "CARGO", "OBSTACLE", "HOTPLATE", "FAUCET", "WATER_PURIFIER", "COVERED" ],
-    "integrated_tools": [
-      "chemistry_set",
-      "electrolysis_kit",
-      "pot",
-      "pan",
-      "hotplate",
-      "dehydrator",
-      "vac_sealer",
-      "food_processor",
-      "press"
-    ],
+    "flags": [ "CARGO", "OBSTACLE", "HOTPLATE", "FAUCET", "WATER_PURIFIER", "COVERED", "CRAFTER" ],
+    "integrated_tools": [ "chemistry_set", "electrolysis_kit", "pot", "pan", "hotplate", "dehydrator", "vac_sealer", "food_processor", "press" ],
     "breaks_into": [
       { "item": "steel_lump", "count": [ 9, 18 ] },
       { "item": "steel_chunk", "count": [ 9, 18 ] },


### PR DESCRIPTION
## Purpose of change (The Why)
Aftershock should not break in vehicleland

## Describe the solution (The How)
Fix aftershock vehicleparts, because I did not know aftershock had vehicleparts

## Describe alternatives you've considered
screm

## Testing
Determine that it loads right

## Additional context
I really need to get more familiar with the totality of what I'm changing with, sorry to all affected

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.