### PR TITLE
fix(UI): fix punctuation for sounds

### DIFF
--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -369,6 +369,19 @@ void sounds::process_sounds()
     recent_sounds.clear();
 }
 
+// Ensure description ends with punctuation, using a preferred character if missing
+static auto ensure_punctuation = []( const std::string &desc, char preferred )
+{
+    if( desc.empty() ) {
+        return desc;
+    }
+    char last = desc.back();
+    if( last == '.' || last == '!' || last == '?' ) {
+        return desc;
+    }
+    return desc + preferred;
+};
+
 // skip some sounds to avoid message spam
 static bool describe_sound( sounds::sound_t category, bool from_player_position )
 {
@@ -512,7 +525,8 @@ void sounds::process_sound_markers( Character *who )
         if( !sound.ambient && ( pos != who->pos() ) && !get_map().pl_sees( pos, distance_to_sound ) ) {
             if( !who->activity->is_distraction_ignored( distraction_type::noise ) &&
                 !get_safemode().is_sound_safe( sound.description, distance_to_sound ) ) {
-                const std::string query = string_format( _( "Heard %s!" ), description );
+                const std::string final_description = ensure_punctuation( description, '!' );
+                const std::string query = string_format( _( "Heard %s" ), final_description );
                 g->cancel_activity_or_ignore_query( distraction_type::noise, query );
             }
         }
@@ -523,14 +537,17 @@ void sounds::process_sound_markers( Character *who )
             if( sound.category == sound_t::combat || sound.category == sound_t::alarm ) {
                 severity = m_warning;
             }
+
+            std::string final_description = ensure_punctuation( description, '.' );
+
             // if we can see it, don't print a direction
             if( pos == who->pos() ) {
-                add_msg( severity, _( "From your position you hear %1$s" ), description );
+                add_msg( severity, _( "From your position you hear %1$s" ), final_description );
             } else if( who->sees( pos ) ) {
-                add_msg( severity, _( "You hear %1$s" ), description );
+                add_msg( severity, _( "You hear %1$s" ), final_description );
             } else {
                 std::string direction = direction_name( direction_from( who->pos(), pos ) );
-                add_msg( severity, _( "From the %1$s you hear %2$s" ), direction, description );
+                add_msg( severity, _( "From the %1$s you hear %2$s" ), direction, final_description );
             }
         }
 


### PR DESCRIPTION
## Purpose of change (The Why)
Sounds will print to the message log missing punctuation.
For example: a sound defined as "a dry crackle" (skeleton footsteps) will print as "You hear a dry crackle" when it should be "You hear a dry crackle." Additionally, if it does have punctuation, when waiting it will print as "You hear a dry crackle.! Stop waiting?"
## Describe the solution (The How)
Removes any hardcoded punctuation in the messages, and runs it through a helper function ensure_punctuation before displaying.
## Describe alternatives you've considered
Waiting for Wishduck to do it
## Testing
Tent test. Spawned a tent in a subway, spawned 1000 skeletons, noticed that the punctuation in chat is fixed and also displays properly in the "stop waiting?" menu.
## Additional context
<img width="1920" height="1070" alt="image" src="https://github.com/user-attachments/assets/56f3c3ae-7a4a-4f1f-a909-6c1a5cc51415" />
Example:
<img width="882" height="350" alt="image" src="https://github.com/user-attachments/assets/71d2f0ba-ce97-4563-a35f-eff229ff41d1" />

## Checklist
### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
