### PR TITLE
fix: mutations that remove clothing remove dependant worn items

### DIFF
--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -332,12 +332,12 @@ void Character::mutation_effect( const trait_id &mut )
 
             //get dependant worn items only checks for powerarmor helmets or powerarmor mods
             //so this just removes those if powerarmor is also removed
-            const auto deps = get_dependent_worn_items( *armor);
+            const auto deps = get_dependent_worn_items( *armor );
             for( const auto &it : deps ) {
                 add_msg_player_or_npc( m_bad,
-                               _( "Your %s is pushed off!" ),
-                               _( "<npcname>'s %s is pushed off!" ),
-                               it->tname() );
+                                       _( "Your %s is pushed off!" ),
+                                       _( "<npcname>'s %s is pushed off!" ),
+                                       it->tname() );
 
                 it->on_takeoff( *this );
                 detached_ptr<item> det = worn.remove( it );


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

fixes #7187 

removal of clothing from mutating doesnt account for clothing items that are dependant on other clothing items
(i.e power armor)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
grab a list of dependant worn items and also remove those
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
figuring out some other way of doing this? idk


## Testing

spawn in power armor, a power armor helmet and one of every power armor mod
wear them all and debug apply the long tail mutation
check that everything correctly falls to the ground
repeated power armor tests with freakishly huge, lupine muzzle, broad paws, rabbit feet and leg tentacles
also tested freakishly huge with regular clothing to verify that still works fine

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<img width="1920" height="1080" alt="2025-09-13-09:31:43" src="https://github.com/user-attachments/assets/038a1c69-d6c5-4b21-89e9-5457e8648aae" />
seems to work?

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
