### PR TITLE
refactor: use projection in min_by/max_by

### DIFF
--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -3193,15 +3193,14 @@ bool find_auto_consume( player &p, const consume_type type )
 
     using namespace cata::ranges;
 
-    const auto compare = []( const item * a, const item * b ) {
-        return a->spoilage_sort_order() < b->spoilage_sort_order();
-    };
+    auto get_spoil = []( const item * a ) { return a->spoilage_sort_order(); };
+
     std::optional<item *> stalest = mgr.get_near( consume_type_zone, here.getabs( pos ),
                                     ACTIVITY_SEARCH_DISTANCE )
                                     | views::filter( [&]( const auto & loc ) -> bool { return loc.z == p.pos().z; } )
                                     | flat_map( get_items_at )
                                     | views::filter( ok_to_consume )
-                                    | min_by( compare );
+                                    | min_by( get_spoil );
     if( !stalest ) {
         return false;
     }

--- a/tests/algo_test.cpp
+++ b/tests/algo_test.cpp
@@ -104,16 +104,23 @@ TEST_CASE( "max_by", "[ranges]" )
 
     SECTION( "general case" ) {
         auto input = std::vector{ foo{ 1 }, foo{ 2 }, foo{ 3 } };
-        auto output = input | max_by( std::less{} );
+        auto output = input | max_by( []( const foo & f ) { return f.i; } );
 
         CHECK( output.value() == foo{3} );
     }
 
     SECTION( "empty input" ) {
         auto input = std::vector<int> {};
-        auto output = input | max_by( std::less{} );
+        auto output = input | max_by( []( int x ) { return x; } );
 
         CHECK( !output.has_value() );
+    }
+
+    SECTION( "reverse order selector" ) {
+        auto input = std::vector{ foo{ 1 }, foo{ 2 }, foo{ 3 } };
+        auto output = input | max_by( []( const foo & f ) { return -f.i; } );
+
+        CHECK( output.value() == foo{1} );
     }
 }
 
@@ -141,16 +148,23 @@ TEST_CASE( "min_by", "[ranges]" )
 
     SECTION( "general case" ) {
         auto input = std::vector{ foo{ 1 }, foo{ 2 }, foo{ 3 } };
-        auto output = input | min_by( std::less{} );
+        auto output = input | min_by( []( const foo & f ) { return f.i; } );
 
         CHECK( output.value() == foo{1} );
     }
 
     SECTION( "empty input" ) {
         auto input = std::vector<int> {};
-        auto output = input | min_by( std::less{} );
+        auto output = input | min_by( []( int x ) { return x; } );
 
         CHECK( !output.has_value() );
+    }
+
+    SECTION( "reverse order selector" ) {
+        auto input = std::vector{ foo{ 1 }, foo{ 2 }, foo{ 3 } };
+        auto output = input | min_by( []( const foo & f ) { return -f.i; } );
+
+        CHECK( output.value() == foo{3} );
     }
 }
 


### PR DESCRIPTION

## Purpose of change (The Why)

resolves #7204

## Describe the solution (The How)

uses projection over comparator like https://en.cppreference.com/w/cpp/algorithm/ranges/find

## Describe alternatives you've considered

## Testing

<img width="1410" height="850" alt="image" src="https://github.com/user-attachments/assets/d1de87d1-31c1-4af9-82a9-290c7b285a7c" />

1. placed pizza (shelf life 2 days) and pine corn (shelf life infinite) on auto-eat zone
2. debugged player to be hungry
3. player ate pizza first, the one with the shorter shelf life.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

