### PR TITLE
fix: pathfinding error

### DIFF
--- a/src/pathfinding.cpp
+++ b/src/pathfinding.cpp
@@ -1019,7 +1019,7 @@ std::vector<tripoint> Pathfinding::get_route_3d(
 
             z_path.push_back( best_z_change );
             cur_origin = best_z_change.from;
-			cur_origin_point = cur_origin.xy();
+            cur_origin_point = cur_origin.xy();
         }
     }
 


### PR DESCRIPTION
## Purpose of change (The Why)

Just something I saw while glancing at the pathfinding code. As it goes around its loop it updates cur_origin on each iteration, but forgets to update cur_origin_point as well. 

## Describe the solution (The How)

Update them both.

## Testing

Test suite and a little bit of trial, seems to work.

## Additional context

We have a number of open issues related to crashes during pathfinding but I haven't reproduced any of them. It's hard to say if this is related so I won't mark it as a fix but it would be good to retest them. 

## Checklist

### Mandatory

- [x ] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [ x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [ x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

