### PR TITLE
fix(UI): reduce comfort notification spam

### DIFF
--- a/src/character_functions.cpp
+++ b/src/character_functions.cpp
@@ -409,18 +409,14 @@ comfort_response_t base_comfort_value( const Character &who, const tripoint &p )
 
     if( comfort >= static_cast<int>( comfort_level::very_comfortable ) ) {
         comfort_response.level = comfort_level::very_comfortable;
-        add_msg( "You feel very comfortable." );
     } else if( comfort > static_cast<int>( comfort_level::comfortable ) ) {
         comfort_response.level = comfort_level::comfortable;
-        add_msg( "You feel comfortable." );
     } else if( comfort > static_cast<int>( comfort_level::slightly_comfortable ) ) {
         comfort_response.level = comfort_level::slightly_comfortable;
-        add_msg( "You feel slightly comfortable." );
     } else if( comfort == static_cast<int>( comfort_level::neutral ) ) {
         comfort_response.level = comfort_level::neutral;
     } else {
         comfort_response.level = comfort_level::uncomfortable;
-        add_msg( "You feel uncomfortable." );
     }
     return comfort_response;
 }
@@ -470,6 +466,18 @@ int rate_sleep_spot( const Character &who, const tripoint &p )
     } else {
         // Make it harder for insomniac to get around the trait
         sleepy -= current_stim;
+    }
+
+    if( one_in( 3 ) ) {
+        if( comfort_info.level >= comfort_level::very_comfortable ) {
+            add_msg( "You feel very comfortable." );
+        } else if( comfort_info.level >= comfort_level::comfortable ) {
+            add_msg( "You feel comfortable." );
+        } else if( comfort_info.level >= comfort_level::slightly_comfortable ) {
+            add_msg( "You feel slightly comfortable." );
+        } else {
+            add_msg( "You feel uncomfortable." );
+        }
     }
 
     return sleepy;


### PR DESCRIPTION
## Purpose of change (The Why)
Brosef on discord reported that the comfort notification spam is really bad.

## Describe the solution (The How)
Move the actual notification part to rate_sleep_spot instead of base_comfort_value. This makes it no longer spam while you are actively sleeping. Additionally, add a one in 3 roll of it messaging the player.

## Describe alternatives you've considered

## Testing
Spawned in a field, spawned in a bed and a few comfort items. Notice the spam when falling asleep is greatly reduced, and completely gone when sleeping.
## Additional context
<img width="644" height="384" alt="image" src="https://github.com/user-attachments/assets/38dc25b4-323e-4e4e-898b-294d465491d5" />
## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
