### PR TITLE
feat: allow trailing commas in JSON

### DIFF
--- a/src/json.cpp
+++ b/src/json.cpp
@@ -1484,10 +1484,6 @@ bool JsonIn::end_array()
 {
     eat_whitespace();
     if( peek() == ']' ) {
-        if( ate_separator ) {
-            uneat_whitespace();
-            error( "comma not allowed at end of array" );
-        }
         stream->get();
         end_value();
         return true;
@@ -1517,10 +1513,6 @@ bool JsonIn::end_object()
 {
     eat_whitespace();
     if( peek() == '}' ) {
-        if( ate_separator ) {
-            uneat_whitespace();
-            error( "comma not allowed at end of object" );
-        }
         stream->get();
         end_value();
         return true;


### PR DESCRIPTION
## Purpose of change (The Why)

don't you just hate when your legacy JSON formatter commits kil on touching _tRaIlInG CoMmAs?!!_

## Describe the solution (The How)

make JSON parser accept trailing commas.

## Describe alternatives you've considered

currently the formatter will remove trailing commas. i'd like them to insert trailing commas but that'll cause metric ton of diffs on existing files so no, it's out of scope

## Testing

1. add trailing commas in arrays and objects
2. try to load it into the game
3. the game loads without issues
4. try to format the file with `make style-all-json-parallel`
5. the file is correctly formatted

## Additional context

<img width="750" height="521" alt="image" src="https://github.com/user-attachments/assets/8abd0fde-4cc3-43ba-9aba-acf56081eff8" />

## Checklist


### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

