### PR TITLE
fix: don't segault on triggering traps with thrown items

### DIFF
--- a/src/trap.cpp
+++ b/src/trap.cpp
@@ -256,7 +256,7 @@ bool trap::can_see( const tripoint &pos, const Character &p ) const
 void trap::trigger( const tripoint &pos, Creature *creature, item *item ) const
 {
     const bool is_real_creature = creature != nullptr && !creature->is_hallucination();
-    if( ( is_real_creature && !creature->has_effect(dashing_effect) ) || item != nullptr ) {
+    if( ( is_real_creature && !creature->has_effect( dashing_effect ) ) || item != nullptr ) {
         bool triggered = act( pos, creature, item );
         if( triggered && is_real_creature ) {
             if( Character *ch = creature->as_character() ) {


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

Explode your mines, explode your minds, explode your pants even, but we don't wanna explode your game with a segfault.

Fixes https://github.com/cataclysmbnteam/Cataclysm-BN/issues/7310

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

In trap.cpp, reordered the checks in `trap::trigger` so that being set off by a thrown item (where the creature setting it off is considered to be `nullptr`) doesn't cause a segfault, via bundling the checks for "is this being set off by a real creature" and "is" together such that it'll bail out of that part of the check and go on to checking for an item before it can try to feed a nullptr to `creature::has_effect`.

## Describe alternatives you've considered

Changing `drop_or_embed_projectile` in ballistics.cpp to just pin the blame for the trap on a fake NPC like `map::smash_trap` does, which was why shooting a landmine with a gun wasn't triggering this issue. We already have `nulltpr` protection in `trap::trigger` anyway so it's not essential.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Compiled and load-tested.
2. Hurled a javelin at a landmine with 100 strength, it sets it off without segfaulting anymore.
3. Used magical night's dash spell, doesn't set the trap off.
4. Walked into an undiscovered one with zero perception, sets it off as expected.
5. Zombies also still explode as intended.
6. Shot a landmine for good measure, still works as expected.
7. Set off some dynamite on top of mines, explosions set off explosions properly.

<img width="1355" height="639" alt="image" src="https://github.com/user-attachments/assets/bd9c47ac-68b9-42c7-a3bf-06dee45b650f" />

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
