### PR TITLE
feat(balance): make EXP reward from NPC skill training scale linearly with skill level

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -2160,7 +2160,7 @@ void activity_handlers::train_finish( player_activity *act, player *p )
         const Skill &skill = sk.obj();
         std::string skill_name = skill.name();
         int old_skill_level = p->get_skill_level( sk );
-        p->get_skill_level_object( sk ).train( 100, true );
+        p->get_skill_level_object( sk ).train( 100 * ( old_skill_level + 1 ), true );
         int new_skill_level = p->get_skill_level( sk );
         if( old_skill_level != new_skill_level ) {
             add_msg( m_good, _( "You finish training %s to level %d." ),

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -1555,7 +1555,7 @@ void dialogue::gen_responses( const talk_topic &the_topic )
             SkillLevel skill_level_obj = you.get_skill_level_object( trained );
             const int cur_level = skill_level_obj.level();
             const int cur_level_exercise = skill_level_obj.exercise();
-            skill_level_obj.train( 100, true );
+            skill_level_obj.train( 100 * ( cur_level + 1 ), true );
             const int next_level = skill_level_obj.level();
             const int next_level_exercise = skill_level_obj.exercise();
 


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

NPC training is generally increasingly worthless once you go past getting from level 0 to 1. While it's maybe reasonable to not have it grant a full level-up given the player can bully NPCs into providing training, a max of 100 EXP quickly becomes not worth the effort as a quest reward.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. In activity_handlers.cpp, the amount of EXP rewarded in `activity_handlers::train_finish` now goes up at a linear rate based on your initial level, multiplying it by the number of the target level. Can also be phrased as increasing the number of sessions to reach the next level by 1. Since EXP to next level increases by the square of the target level instead of linearly, this means NPC training will still fall off and become less effective for EXP gain, but will do so more slowly and thus make it stay worthwhile for early levels instead of instantly making the 1->2 step take the entire rest of an NPC's mission chain to get past.
2. In npctalk.cpp, updated skill training behavior in `dialogue::gen_responses` to be consistent with above change.

Goal Level | EXP Gain, Before | EXP Gain, After
--- | --- | ---
1 | 100% | 100%
2 | 25% | 50%
3 | ~11.11% | ~33.33%
4 | 6.25% | 25%
5 | 4% | 20%
6 | ~2.78% | ~16.67%
7 | ~2.04% | ~14.29%
8 | ~1.56% | 12.5%
9 | ~1.23% | ~11.11%
10 | 1% | 10%

## Describe alternatives you've considered

1. Adding a feature that defines in some way the value of the training provided, so mission rewards can be made more special than just badgering an NPC companion to train you. Given NPCs have a cooldown when asked to train and will usually tell you to fuck off most of the time, this seems minor to me.
2. Reverting wholesale and just letting you get a whole-ass levelup for each training session.
3. Going to bed instead because it's 5:20 AM currently and I haven't fucking gotten any sleep yet. :D

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Did the math. :<
3. Compiled and load-tested.
4. Injected 10s in all skills into my starter NPC, and set my skills to a variety of levels.
5. Mindfucked starter NPC into joining me and being willing to teach me shit, checked listed percentages match expectations.
6. Forced them to teach me the skill I had at level 9, checking my `@` screen correctly shows me at 10% of the way to next level instead of only 1%.
7. Made sure that teaching a level-zero skill still gets me to level 1 and thus isn't doing any kinda weird zeroing out of the EXP gain.

Skill spread showing projected EXP gain:
<img width="286" height="164" alt="image" src="https://github.com/user-attachments/assets/7c7f1a3b-d1de-40d2-9b86-e516a59dc2c3" />
Did indeed get 10% in my level-9 skill:
<img width="204" height="20" alt="image" src="https://github.com/user-attachments/assets/67e981a5-c14f-4595-84ea-369725726845" />
Did indeed go from level 0 melee to level 1:
<img width="208" height="25" alt="image" src="https://github.com/user-attachments/assets/ec88174d-33e6-471d-a841-bce7ded2a7c7" />

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

Reverts: "NPCs: only train at 100 practice at a time" by @mlangsdorf:  https://github.com/CleverRaven/Cataclysm-DDA/pull/31887

We could also fuck with training EXP for spells but I don't 100% know how that works relative to skill training, so left that untouched for now.

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
