### PR TITLE
feat: Add two configs to disable skill buffs

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -4183,14 +4183,16 @@ char_encumbrance_data Character::calc_encumbrance( const item &new_item ) const
     mut_cbm_encumb( enc );
 
     // Get swimming skill level
-    int swim_skill = get_skill_level( skill_swimming );
+    if( get_option<bool>( "althletics_encumbrance_buff" ) ) {
+        int swim_skill = get_skill_level( skill_swimming );
 
-    // Reduce encumbrance for each body part based on swimming skill
-    for( auto &iter : enc.elems ) {
-        encumbrance_data &edata = iter.second;
+        // Reduce encumbrance for each body part based on swimming skill
+        for( auto &iter : enc.elems ) {
+            encumbrance_data &edata = iter.second;
 
-        // Reduce encumbrance by swim_skill, clamped at 0
-        edata.encumbrance = std::max( 0, edata.encumbrance - swim_skill );
+            // Reduce encumbrance by swim_skill, clamped at 0
+            edata.encumbrance = std::max( 0, edata.encumbrance - swim_skill );
+        }
     }
 
     return enc;

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -245,7 +245,7 @@ static int compute_default_effective_kcal( const item &comest, const Character &
         kcal *= 0.75f;
     }
 
-    if( comest.get_kcal_mult() > 1 ) {
+    if( get_option<bool>( "cooking_kcal_buff" ) && comest.get_kcal_mult() > 1 ) {
         kcal *= comest.get_kcal_mult();
     }
     if( you.has_trait( trait_GIZZARD ) ) {

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2449,6 +2449,21 @@ void options_manager::add_options_world_default()
 
     add_empty_line();
 
+    add_option_group( world_default, Group( "skill_buff_category",
+                                            to_translation( "Enabled Skill Buffs" ),
+                                            to_translation( "Enable or disable major skill buffs" ) ),
+    [&]( const std::string & page_id ) {
+        add( "cooking_kcal_buff", page_id, "Cooking Calories Buff",
+             "Include the scaling calories from cooking buff?",
+             true );
+        add( "althletics_encumbrance_buff", page_id, "Althletics Encumbrance Buff",
+             "Include the reduce all encumbrance per level of althletics buff?",
+             true );
+    }
+                    );
+
+    add_empty_line();
+
     add( "ITEM_SPAWNRATE", world_default,
          "Item spawn scaling factor",
          "A scaling factor that determines density of item spawns. A higher number means more items.",


### PR DESCRIPTION
## Purpose of change (The Why)
Apparently the cooking feature has a critic
And I'm assuming the encumbrance reducer has a similar critic
This wipes their criticism out of existence I hope

## Describe the solution (The How)
Add a new World Options Section: skill_buff_category
Within this section currently lies the cooking_kcal_buff and althletics_encumbrance_buff configs

## Describe alternatives you've considered
Remove the config entirely
Remove either of the options from being included in the config

## Testing
Turn off the world options, they prevent the *"issue"*
Still works as expected when on
I tested a world that already existed, it defaults to true.

## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.