### PR TITLE
feat(balance): music gives comfort instead of morale while sleeping

### DIFF
--- a/src/character_functions.cpp
+++ b/src/character_functions.cpp
@@ -278,6 +278,7 @@ comfort_response_t base_comfort_value( const Character &who, const tripoint &p )
                     ( who.has_trait( trait_WEB_WEAVER ) ) );
     bool in_shell = who.has_active_mutation( trait_SHELL2 );
     bool watersleep = who.has_trait( trait_WATERSLEEP );
+    bool music = who.has_active_item_with_action( "MP3_ON" );
 
     map &here = get_map();
     const optional_vpart_position vp = here.veh_at( p );
@@ -406,7 +407,10 @@ comfort_response_t base_comfort_value( const Character &who, const tripoint &p )
             comfort = static_cast<int>( comfort_level::impossible );
         }
     }
-
+    // If you are listening to music, give a small buff to comfort
+    if( music ) {
+        comfort += 2;
+    }
     if( comfort >= static_cast<int>( comfort_level::very_comfortable ) ) {
         comfort_response.level = comfort_level::very_comfortable;
     } else if( comfort >= static_cast<int>( comfort_level::comfortable ) ) {

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -3700,7 +3700,7 @@ void iuse::play_music( player &p, const tripoint &source, const int volume, cons
 {
     // TODO: what about other "player", e.g. when a NPC is listening or when the PC is listening,
     // the other characters around should be able to profit as well.
-    const bool do_effects = p.can_hear( source, volume );
+    const bool do_effects = p.can_hear( source, volume ) && !p.has_effect( effect_sleep );
     std::string sound = "music";
     if( calendar::once_every( 1_hours ) ) {
         // Every 5 minutes, describe the music


### PR DESCRIPTION
## Purpose of change (The Why)
This was a proposed problem by Royalfox
> Guys
> MP3 iuse doesn't prevent sleep and atomic smartphones run indefinitely
> So add sleep comfort but make it so you don't gain music morale while sleeping since you're asleep

Additionally MP3 Morale takes little time to ramp up, so removing it while asleep if not too bad

## Describe the solution (The How)
Remove MP3 Morale while asleep, but add 2 comfort for listening to music

## Describe alternatives you've considered
Make the comfort boost even higher

## Testing
No longer functions while sleeping, but you get a small comfort buff

## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.