### PR TITLE
fix: soda machine now has the right category

### DIFF
--- a/data/json/items/tool/cooking.json
+++ b/data/json/items/tool/cooking.json
@@ -503,7 +503,7 @@
   {
     "id": "soda_machine",
     "type": "TOOL",
-    "category": "tools",
+    "category": "tools_cooking",
     "name": { "str": "soda machine" },
     "looks_like": "coffeemaker",
     "description": "This is a kitchen appliance capable of creating carbonated beverages.",
@@ -529,7 +529,7 @@
   {
     "id": "atomic_soda_machine",
     "type": "TOOL",
-    "category": "tools",
+    "category": "tools_cooking",
     "name": { "str": "atomic soda machine" },
     "looks_like": "atomic_coffeepot",
     "description": "This is a Curie-G soda machine, a follow-up to the infamous coffeepot by CuppaTech.  It uses the same miniature RTG core to chill and carbonate beverages.  Normally, it dispenses standard fizzy drinks using stored CO₂ and coolant, but with a twist of the dial, it can cycle irradiated condensation from the RTG chamber into the mix.  Like its predecessor, the atomic soda machine is banned in most regions.",


### PR DESCRIPTION
## Purpose of change (The Why)
Need to keep the issue counts low, and this extremely easy
fixes: #7344 

## Describe the solution (The How)
Both the atomic and normal soda machine now use the tools_cooking category

## Describe alternatives you've considered
Drain my brainpower digging around all the json files to find other miscategorized things
All I know is no other tool is tools_cooking is miscategorized

## Testing
Load the game
Look at a soda machine item in the debug menu
It has the right category
Or you could just eyeball it

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.