### PR TITLE
fix: sleep comfort gained from sleep aid quality is no longer halved

### DIFF
--- a/src/character_functions.cpp
+++ b/src/character_functions.cpp
@@ -302,8 +302,8 @@ comfort_response_t base_comfort_value( const Character &who, const tripoint &p )
                     int sleep_quality = items_it->get_quality( qual_SLEEP_AID );
                     if( sleep_quality >= 0 ) {
                         // uncomfortable = -7, neutral = 0, comfortable = 5+, very comfortable = 10
-                        // Note: BED (5) + BOXERS/NAKED (1) + PILLOW/BLANKET (1) = 7 pts (when snuggled, 9 pts)
-                        comfort += ( sleep_quality * 0.5 );
+                        // Note: BED + LEVEL 2 SLEEP_AID = 7 pts, or 3 pt below very_comfortable
+                        comfort += sleep_quality;
                         comfort_response.aid.push_back( items_it );
                     }
                 }
@@ -339,8 +339,8 @@ comfort_response_t base_comfort_value( const Character &who, const tripoint &p )
             for( item *items_it : items ) {
                 int sleep_quality = items_it->get_quality( qual_SLEEP_AID );
                 if( sleep_quality >= 0 ) {
-                    // Note: BED + LEVEL 2 SLEEP_AID = 9 pts, or 1 pt below very_comfortable
-                    comfort += ( sleep_quality * 0.5 ) + static_cast<int>( comfort_level::neutral );
+                    // Note: BED + LEVEL 2 SLEEP_AID = 7 pts, or 3 pt below very_comfortable
+                    comfort += sleep_quality;
                     comfort_response.aid.push_back( items_it );
                 }
             }
@@ -354,21 +354,21 @@ comfort_response_t base_comfort_value( const Character &who, const tripoint &p )
             // check wearing bonus (sleep aid clothing is worth double when worn, similar to snuggling)
             int sleep_quality = it->get_quality( qual_SLEEP_AID );
             if( sleep_quality >= 0 ) {
-                comfort += sleep_quality + static_cast<int>( comfort_level::neutral );
+                comfort += sleep_quality;
                 comfort_response.aid.push_back( it );
             }
         }
 
         // bonus if player is wearing only skintight clothing (pajamas/boxers), oversized clothing (big hoodies, blankets, etc) or naked
         if( skintight_or_naked ) {
-            comfort += 1 + static_cast<int>( comfort_level::neutral );
+            comfort += 1;
         }
 
         // bonus if player is snuggling with a specific item
         for( item *it : who.wielded_items() ) {
             if( it->has_quality( qual_SLEEP_AID ) ) {
                 // don't add to the aid array, because we print special mesage here
-                comfort += it->get_quality( qual_SLEEP_AID ) + static_cast<int>( comfort_level::neutral );
+                comfort += it->get_quality( qual_SLEEP_AID ) * 2;
                 comfort_response.aid.push_back( it );
             }
         }


### PR DESCRIPTION
## Purpose of change (The Why)
> Ah I think I found the comfort problem
> It was previously 1 + 3 comfort for a pillow or such
> Now it's 1 for a basic pillow, or 2 for the body pillow
> Don't think the / 2 was needed on the comfort to real comfort

## Describe the solution (The How)
Remove all divisions by 2 on sleep comfort, cuddling things now gives double comfort (as it previously just gave equal)

## Describe alternatives you've considered
Instead add slightly_comfortable to each, so +3, so modders are endlessly confused on how the value worked. As that was the missing piece from before

## Testing
Car seats worked fine, but all other comfort values were massively nerfed, this fixes that
So you still need a pillow to sleep in a seat, but not multiple pillows

## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.