### PR TITLE
feat(port): port DDA military professions

### DIFF
--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -6928,7 +6928,6 @@
           "boots_combat",
           "mask_gas",
           "gloves_tactical",
-          "gloves_tactical",
           "helmet_army",
           "jacket_army",
           "webbing_belt",


### PR DESCRIPTION
## Purpose of change (The Why)

This ports over some professions from C:DDA into C:BN. The professions ported are: Major General, Military Corpse Disposal, and Hazmat Unit. These are fun professions, and also the Military Corpse Disposal makes sense to exist, especially since it was removed from C:DDA (after burners got removed).

## Describe the solution (The How)

It just is ported and slightly modified.

## Describe alternatives you've considered

Not porting them, or making them from scratch.

## Testing

Tested just fine on Arch Linux.

## Additional context

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/e42b0d94-efc0-48f5-aa16-3dbe6d72398b" />

## Checklist

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

- [X] This PR ports commits from DDA or other cataclysm forks.
  - [X] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [X] I have linked the URL of original PR(s) in the description.
