### PR TITLE
fix: planes and blimps as starting vehicles now properly function

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -880,7 +880,7 @@ vehicle *game::place_vehicle_nearby(
     std::vector<std::string> search_types = omt_search_types;
     if( search_types.empty() ) {
         vehicle veh( id );
-        if( veh.can_float() ) {
+        if( veh.can_float() && !veh.has_part( VPFLAG_BALLOON ) ) {
             search_types.emplace_back( "river_shore" );
             search_types.emplace_back( "lake_shore" );
             search_types.emplace_back( "lake_surface" );

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -6476,7 +6476,7 @@ std::unique_ptr<vehicle> map::add_vehicle_to_map(
     std::unique_ptr<vehicle> veh, const bool merge_wrecks )
 {
     //We only want to check once per square, so loop over all structural parts
-    std::vector<int> frame_indices = veh->all_parts_at_location( "structure" );
+    std::vector<int> frame_indices = veh->all_standalone_parts();
 
     //Check for boat type vehicles that should be placeable in deep water
     //WARNING: CURSED CODE
@@ -6514,7 +6514,7 @@ std::unique_ptr<vehicle> map::add_vehicle_to_map(
 
             // Hard wreck-merging limit: 200 tiles
             // Merging is slow for big vehicles which lags the mapgen
-            if( frame_indices.size() + other_veh->all_parts_at_location( "structure" ).size() > 200 ) {
+            if( frame_indices.size() + other_veh->all_standalone_parts().size() > 200 ) {
                 return nullptr;
             }
 


### PR DESCRIPTION
## Purpose of change (The Why)
fixes #7352 

## Describe the solution (The How)
Change yet another instance of all_parts_at_location( "structure" ) to all_standalone_parts() (the latter supports EXTENDABLE parts)
If the vehicle can float but has a balloon (a blimp per say?) don't permit it to try (and only hit the land) and spawn on river or lake tiles

## Describe alternatives you've considered
None

## Testing
The last flight scenario previously consistenly crashed when using a blimp
I no longer can replicate that

## Additional context
EXTENDABLE is starting to seem like more trouble then it was worth

## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.