### PR TITLE
fix: sheer drop halfway down query now works right

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -10946,7 +10946,7 @@ std::optional<tripoint> game::find_or_make_stairs( map &mp, const int z_after, b
             return std::nullopt;
         }
     } else if( !can_fly ) {
-        if( query_yn( _( "There is a sheer drop halfway down.  Jump?" ) ) ) {
+        if( !query_yn( _( "There is a sheer drop halfway down.  Jump?" ) ) ) {
             return std::nullopt;
         }
     }


### PR DESCRIPTION
## Purpose of change (The Why)
I can do at least one of the two needed fixes for Relgar today
fixes #7354 

## Describe the solution (The How)
Previously:
- Exit the window: Oh you really want to jump down
- Say no: Clearly that means jump down
- Say yes: No you don't want to go down

Thus as you can see, boolean no makes you jump, boolean yes does not
That makes little sense, so append a not statement to that
Like all the other if statements in the region

## Describe alternatives you've considered
Changing the wording of the window in true cataclysm fashion (oh you want to jump because you left the popup duh)

## Testing
Spawn stairs down somewhere there are no stairs, but open space below
Now the menu works right
Before it didn't

## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.