### PR TITLE
docs: corrected changelog link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ who want what you have.
 Find a way to stop the Cataclysm ... or become one of its strongest monsters.
 
 > Cataclysm: Bright Nights is a fork of Cataclysm: Dark Days Ahead.
-> [see the differences from its ancestor.](https://docs.cataclysmbn.org/en/game/changelog/).
+> [see the differences from its ancestor.](https://docs.cataclysmbn.org/game/changelog/).
 
 ## Downloads
 


### PR DESCRIPTION
https://docs.cataclysmbn.org/en/game/changelog/ results in "Content not found."
https://docs.cataclysmbn.org/game/changelog/ is the stuff we want

<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

Visitors should be able to click on the link and read the information.

## Describe the solution (The How)

The hyperlink address has been changed.