### PR TITLE
chore: disable clang-tidy operator parentheses warning

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -91,6 +91,7 @@ Checks: >
   -readability-identifier-naming,
 
   -readability-avoid-nested-conditional-operator,
+  -readability-math-missing-parentheses,
   -bugprone-unchecked-optional-access,
   -bugprone-chained-comparison,
   -bugprone-easily-swappable-parameters,


### PR DESCRIPTION
## Purpose of change (The Why)

<img width="1748" height="598" alt="image" src="https://github.com/user-attachments/assets/a41ee399-d7d3-48da-b79b-6ffa4c831359" />

1. it's highly annoying
2. there's already too much missing parentheses
3. not much benefit in fixing them all taking the huge diff toll

## Describe the solution (The How)

disable https://clang.llvm.org/extra/clang-tidy/checks/readability/math-missing-parentheses.html

## Describe alternatives you've considered

lose safety awareness by ignoring genuinely useful clang-tidy warnings

## Testing

not needed

## Checklist


### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

