### PR TITLE
docs: Re-word melee_skill description to be accurate

### DIFF
--- a/docs/en/mod/json/reference/creatures/monsters.md
+++ b/docs/en/mod/json/reference/creatures/monsters.md
@@ -244,7 +244,7 @@ mount is capable of carrying riders weighing <= 30% of the mount's weight.
 
 (integer, optional)
 
-Monster melee skill, ranges from 0 - 10 in base game generally, with 4 being an average mob. Past 10 is likely magic or anomalous 
+Monster melee skill, ranges from 0 - 10 in base game generally, with 4 being an average mob. Past 10 is likely magic or anomalous
 See GAME_BALANCE.txt for more examples
 
 ## "dodge"


### PR DESCRIPTION
## Purpose of change (The Why)

I tested and made sure you can set melee_skill and dodge on monsters higher than 10. The docs claim melee_skill ranges 0 to 10 which is misleading. It's useful for mods to know they can go past 10 if they think they can balance that.

It's also more clear now that the base game should range from between 0 and 10, and not go past 10 generally, which hasn't become a problem yet because we don't lean too hard on the SCP and eldritch side of monsters.

## Describe the solution (The How)

Updates description.
 
## Describe alternatives you've considered

## Testing

This monster does not error. 
<img width="605" height="249" alt="image" src="https://github.com/user-attachments/assets/d68f77a9-bf2b-420a-9b51-a761b505f770" />
## Checklist



### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.