### PR TITLE
fix: don't allow plastic bags to act like buckets and spill solid contents

### DIFF
--- a/data/json/items/containers.json
+++ b/data/json/items/containers.json
@@ -143,7 +143,6 @@
     "symbol": ")",
     "color": "light_gray",
     "contains": "6 L",
-    "watertight": true,
     "flags": [ "TRADER_AVOID" ]
   },
   {
@@ -154,6 +153,7 @@
     "name": { "str": "resealable plastic bag" },
     "looks_like": "bag_plastic",
     "description": "A plastic bag with a zipper closure that lets it be resealed.  Essentially trash, though could carry liquids in a pinch.",
+    "watertight": true,
     "seals": true
   },
   {


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

What the fuck do you MEAN making a plastic bag watertight means it'll act like a bucket and spill contents even when the contents are SOLID GRAAAAAAAHHHH

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

Moved `watertight` from plastic bags to resealable plastic bags to kill bucket fuckery.

## Describe alternatives you've considered

Killing bucket code with my mind because REEEEE.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

Spawned in some bologna in default container, putting it in and out of inventory doen't try to make it spill anymore.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

<img width="500" height="426" alt="image" src="https://github.com/user-attachments/assets/1fae04f6-75ae-447c-9765-bcc7fb16626d" />

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
