### PR TITLE
fix: MULTIINSTALL bionic colors now show up properly

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -4435,7 +4435,7 @@ nc_color item::color_in_inventory( const player &p ) const
     } else if( has_own_flag( flag_DIRTY ) ) {
         ret = c_brown;
     } else if( is_bionic() ) {
-        if( !p.has_bionic( type->bionic->id ) ) {
+        if( !p.has_bionic( type->bionic->id ) || type->bionic->id->has_flag( flag_MULTIINSTALL ) ) {
             ret = p.bionic_installation_issues( type->bionic->id ).empty() ? c_green : c_red;
         } else if( !has_fault( fault_bionic_nonsterile ) ) {
             ret = c_dark_gray;


### PR DESCRIPTION
## Purpose of change (The Why)
> hm shouldn't the power storage cbm always be green

## Describe the solution (The How)
Add an or check for MULTIINSTALL

## Describe alternatives you've considered
Make it purple instead for the fun of it

## Testing
Loaded in, grabbed one it was green
Installed one grabbed a second it was also green

## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.