### PR TITLE
fix: NPC swap & wielded items pointers

### DIFF
--- a/src/locations.cpp
+++ b/src/locations.cpp
@@ -141,7 +141,7 @@ void npc_mission_item_location::attach( detached_ptr<item> &&obj )
 detached_ptr<item> wield_item_location::detach( item *it )
 {
     for( std::pair<const bodypart_str_id, bodypart> &part : holder->get_body() ) {
-        if( part.second.wielding.wielded->typeId() == it->typeId() ) {
+        if( &*part.second.wielding.wielded == it ) {
             detached_ptr<item> d = part.second.wielding.wielded.release();
             return d;
         }


### PR DESCRIPTION
## Purpose of change (The Why)
> I craaaave a fix for the wielded weapon glitch pwz

fixes: #7360 

## Describe the solution (The How)
Swappy the location ptr thingy
Like in creature::load

## Describe alternatives you've considered
Keep it broken
Screm

## Testing
Control the NPC drop the weapon
It drop

## Additional context
I eepy

## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.