### PR TITLE
fix: android now has special keybinds for aircraft up and down

### DIFF
--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -2861,6 +2861,10 @@ static void CheckMessages()
                                 if( cargopart >= 0 && ( !veh->get_items( cargopart ).empty() ) ) {
                                     actions.insert( ACTION_PICKUP );
                                 }
+                                if( g->u.controlling_vehicle && veh->has_sufficient_lift() ) {
+                                    actions.insert( ACTION_MOVE_UP );
+                                    actions.insert( ACTION_MOVE_DOWN );
+                                }
                             }
                         }
 


### PR DESCRIPTION
## Purpose of change (The Why)
Fixy fixy

## Describe the solution (The How)
Check for controlling a vehicle with lift
If yes add the two keybinds

## Describe alternatives you've considered
Not do this and get my name tied in with android

## Testing
None yet
I can't even compile right now
Github is doing that part for me in the PR

## Additional context
I cannot guarrentee that I will ever touch android again

## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.