### PR TITLE
fix: fix map memory rendering

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -2656,7 +2656,7 @@ auto get_map_memory_of_at<vpart_info>( const tripoint &p ) -> std::optional<memo
     return t;
 }
 
-auto cata_tiles::has_memory_at( const tripoint &p )
+bool cata_tiles::has_memory_at( const tripoint &p )
 {
     if( !g->u.should_show_map_memory() ) {
         return false;
@@ -2666,22 +2666,22 @@ auto cata_tiles::has_memory_at( const tripoint &p )
     return !t.tile.empty();
 }
 
-auto cata_tiles::get_terrain_memory_at( const tripoint &p )
+auto cata_tiles::get_ter_memory_at( const tripoint &p ) -> std::optional<memorized_terrain_tile>
 {
     return get_map_memory_of_at<ter_t>( p );
 }
 
-auto cata_tiles::get_furniture_memory_at( const tripoint &p )
+auto cata_tiles::get_furn_memory_at( const tripoint &p ) -> std::optional<memorized_terrain_tile>
 {
     return get_map_memory_of_at<furn_t>( p );
 }
 
-auto cata_tiles::get_trap_memory_at( const tripoint &p )
+auto cata_tiles::get_trap_memory_at( const tripoint &p ) -> std::optional<memorized_terrain_tile>
 {
     return get_map_memory_of_at<trap>( p );
 }
 
-auto cata_tiles::get_vpart_memory_at( const tripoint &p )
+auto cata_tiles::get_vpart_memory_at( const tripoint &p ) -> std::optional<memorized_terrain_tile>
 {
     return get_map_memory_of_at<vpart_info>( p );
 }
@@ -2789,7 +2789,7 @@ bool cata_tiles::draw_terrain( const tripoint &p, const lit_level ll, int &heigh
         }
     } else if( invisible[0] ) {
         // try drawing memory if invisible and not overridden
-        const auto ret = get_terrain_memory_at( p );
+        const auto ret = get_ter_memory_at( p );
         if( ret.has_value() ) {
             const auto& [tile, subtile, rotation] = ret.value();
             return draw_from_id_string( tile, C_TERRAIN, empty_string, p, subtile, rotation,
@@ -2881,7 +2881,7 @@ bool cata_tiles::draw_furniture( const tripoint &p, const lit_level ll, int &hei
         }
     } else if( invisible[0] ) {
         // try drawing memory if invisible and not overridden
-        const auto ret = get_furniture_memory_at( p );
+        const auto ret = get_furn_memory_at( p );
         if( ret.has_value() ) {
             const auto& [tile, subtile, rotation] = ret.value();
             return draw_from_id_string( tile, C_FURNITURE, empty_string, p, subtile, rotation,

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -538,10 +538,10 @@ class cata_tiles
 
         /** Map memory */
         static bool has_memory_at( const tripoint &p );
-        static std::optional<memorized_terrain_tile> get_terrain_memory_at( const tripoint &p );
-        static std::optional<memorized_terrain_tile> get_furniture_memory_at( const tripoint &p );
-        static std::optional<memorized_terrain_tile> get_trap_memory_at( const tripoint &p );
-        static std::optional<memorized_terrain_tile> get_vpart_memory_at( const tripoint &p );
+        static auto get_ter_memory_at( const tripoint &p ) -> std::optional<memorized_terrain_tile>;
+        static auto get_furn_memory_at( const tripoint &p ) -> std::optional<memorized_terrain_tile>;
+        static auto get_trap_memory_at( const tripoint &p ) -> std::optional<memorized_terrain_tile>;
+        static auto get_vpart_memory_at( const tripoint &p ) -> std::optional<memorized_terrain_tile>;
 
         /** Drawing Layers */
         bool would_apply_vision_effects( visibility_type visibility ) const;


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

Modded terrains, mostly, don't get rendered in map memory.

Map memory was string checking only, and tiles would only be rendered in memory if their ids started with:
* Terrain: `t_`
* Furniture: `f_`
* Vehicle parts: `vp_`
* Traps: `tr_`

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)

Made the checks test for a valid `string_id<T>` instead of blind prefix check.

Needs profiling for performance issues before merging.

<!-- e.g nerfs monster A -->

## Describe alternatives you've considered

Leave it stringly typed, document the need for ids to follow that convention.

## Testing

Load Game with modded terrain
Map memory should now work
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

Essence2200 wasteland soil:
<img width="2048" height="1087" alt="image" src="https://github.com/user-attachments/assets/c9ded972-84b1-48a2-9433-6d16c4a7dca1" />

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR adds/removes a mod.
  - [ ] I have committed the output of `deno task semantic`.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
  - [ ] I have added `lua` scope to the PR title.
-->
