### PR TITLE
fix: super light cars now spawn correctly for professions

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -880,7 +880,7 @@ vehicle *game::place_vehicle_nearby(
     std::vector<std::string> search_types = omt_search_types;
     if( search_types.empty() ) {
         vehicle veh( id );
-        if( veh.can_float() && !veh.has_part( VPFLAG_BALLOON ) ) {
+        if( veh.can_float() && veh.has_part( VPFLAG_FLOATS ) ) {
             search_types.emplace_back( "river_shore" );
             search_types.emplace_back( "lake_shore" );
             search_types.emplace_back( "lake_surface" );


### PR DESCRIPTION
## Purpose of change (The Why)
Ultralight essence cars had too much trouble spawning
So I smartened a fix I did last time

## Describe the solution (The How)
Swap !veh.has_part( VPFLAG_BALLOON ) check (to prevent floating blimps from spawning in water)
to veh.has_part( VPFLAG_FLOATS ) (Which is all boats)
For checks on spawning in water

## Describe alternatives you've considered
Add a flag to the vehicle or profession itself for weather it should spawn in water or not

## Testing
Spawn the Essence ultralight car it works
Spawn the castaway it works

## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.