### PR TITLE
fix: Remove duplicate coldproof documentation

### DIFF
--- a/docs/en/mod/json/reference/json_flags.md
+++ b/docs/en/mod/json/reference/json_flags.md
@@ -1061,7 +1061,6 @@ Multiple death functions can be used. Not all combinations make sense.
 - `CBM_TECH` May produce a CBM or two from 'bionics_tech' item group and a power CBM when butchered.
 - `CHITIN` May produce chitin when butchered.
 - `CLIMBS` Can climb.
-- `COLDROOF` Immune to cold damage.
 - `CURRENT` this water is flowing.
 - `DESTROYS` Bashes down walls and more. (2.5x bash multiplier, where base is the critter's max
   melee bashing)


### PR DESCRIPTION
## Purpose of change (The Why)

A few lines up COLDPROOF is defined correctly. This is removed as it states 'COLDROOF' which is incorrect. I must've missed it since it was typo'd.

## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.