### PR TITLE
fix(UI): Maximum Buoyancy display now includes the balloon lift modifier

### DIFF
--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -2533,7 +2533,7 @@ void veh_interact::display_stats() const
     if( is_boat ) {
         // convert newton to kg.
         units::mass buoyancy_as_mass = units::from_newton(
-                                           veh->max_buoyancy() );
+                                           veh->max_buoyancy() + veh->total_balloon_lift() );
         print_stat(
             _( "Maximum Buoyancy: <color_light_blue>%5.0f</color> %s" ),
             convert_weight( buoyancy_as_mass ),


### PR DESCRIPTION
## Purpose of change (The Why)
followup: #7244 
In that PR I added a modifier for balloon lift applying to buoyancy
I forgot to add it to veh_interact...

## Describe the solution (The How)
Add veh->total_balloon_lift() to the buoyancy display

## Describe alternatives you've considered
Instead change max_buoyancy() to include total_balloon_lift

## Testing
Spawn any water vehicle
Install a blimp balloon
Both counters increment 30

## Additional context
I saw https://www.reddit.com/r/cataclysmbn/comments/1oplj27/airship_suggestions/

Then scrungled really hard because I already added the first feature suggested :P

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.