### PR TITLE
ci: Update macOS builds to macOS 15

### DIFF
--- a/.github/workflows/experimental-release.yml
+++ b/.github/workflows/experimental-release.yml
@@ -38,25 +38,25 @@ jobs:
             ext: tar.gz
             content: application/gzip
           - name: osx-curses-x64
-            os: macos-13
+            os: macos-15-intel
             tiles: 0
             artifact: osx-curses-x64
             ext: dmg
             content: application/x-apple-diskimage
           - name: osx-tiles-x64
-            os: macos-13
+            os: macos-15-intel
             tiles: 1
             artifact: osx-tiles-x64
             ext: dmg
             content: application/x-apple-diskimage
           - name: osx-curses-arm
-            os: macos-14
+            os: macos-15
             tiles: 0
             artifact: osx-curses-arm
             ext: dmg
             content: application/x-apple-diskimage
           - name: osx-tiles-arm
-            os: macos-14
+            os: macos-15
             tiles: 1
             artifact: osx-tiles-arm
             ext: dmg

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -68,25 +68,25 @@ jobs:
             ext: tar.gz
             content: application/gzip
           - name: osx-curses-x64
-            os: macos-13
+            os: macos-15-intel
             tiles: 0
             artifact: osx-curses-x64
             ext: dmg
             content: application/x-apple-diskimage
           - name: osx-tiles-x64
-            os: macos-13
+            os: macos-15-intel
             tiles: 1
             artifact: osx-tiles-x64
             ext: dmg
             content: application/x-apple-diskimage
           - name: osx-curses-arm
-            os: macos-14
+            os: macos-15
             tiles: 0
             artifact: osx-curses-arm
             ext: dmg
             content: application/x-apple-diskimage
           - name: osx-tiles-arm
-            os: macos-14
+            os: macos-15
             tiles: 1
             artifact: osx-tiles-arm
             ext: dmg

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -32,25 +32,25 @@ jobs:
       matrix:
         include:
           - name: osx-curses-x64
-            os: macos-13
+            os: macos-15-intel
             tiles: 0
             artifact: osx-curses-x64
             ext: dmg
             content: application/x-apple-diskimage
           - name: osx-tiles-x64
-            os: macos-13
+            os: macos-15-intel
             tiles: 1
             artifact: osx-tiles-x64
             ext: dmg
             content: application/x-apple-diskimage
           - name: osx-curses-arm
-            os: macos-14
+            os: macos-15
             tiles: 0
             artifact: osx-curses-arm
             ext: dmg
             content: application/x-apple-diskimage
           - name: osx-tiles-arm
-            os: macos-14
+            os: macos-15
             tiles: 1
             artifact: osx-tiles-arm
             ext: dmg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,25 +117,25 @@ jobs:
             ext: tar.gz
             content: application/gzip
           - name: osx-curses-x64
-            os: macos-13
+            os: macos-15-intel
             tiles: 0
             artifact: osx-curses-x64
             ext: dmg
             content: application/x-apple-diskimage
           - name: osx-tiles-x64
-            os: macos-13
+            os: macos-15-intel
             tiles: 1
             artifact: osx-tiles-x64
             ext: dmg
             content: application/x-apple-diskimage
           - name: osx-curses-arm
-            os: macos-14
+            os: macos-15
             tiles: 0
             artifact: osx-curses-arm
             ext: dmg
             content: application/x-apple-diskimage
           - name: osx-tiles-arm
-            os: macos-14
+            os: macos-15
             tiles: 1
             artifact: osx-tiles-arm
             ext: dmg


### PR DESCRIPTION
## Purpose of change (The Why)

macOS 13 runners are already having scheduled brownouts in preparation for them being retired entirely.

<img width="1646" height="199" alt="image" src="https://github.com/user-attachments/assets/3571e68a-cd4b-45cb-8568-d076e1f95158" />

While macOS 14 runners for the ARM builds aren't as close to retirement, it's a reasonable idea to try and unify the two builds on the same OS level.

## Describe the solution (The How)

Update macOS builds (both x86 and ARM) to use macOS 15

## Describe alternatives you've considered

- Wait for someone else to do it
- Drop x86 Mac support

We're probably going to have to drop x86 Mac support at *some point in the future*, given how the macos-15-intel runners are intended to be the last x86 macOS runners on Github, but that point is definitely not today.

## Testing

CI change, cannot be tested locally (very well), especially given I am not a Mac user

## Additional context

The mac users that exist will be very happy they can continue to play the game, I'm sure ^-^

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

