### PR TITLE
fix(UI): scaling factor for high-dpi displays

### DIFF
--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -3490,6 +3490,7 @@ static std::pair<float, float> get_display_scale( int display_index )
     float scale_h = lh ? static_cast<float>( ph ) / static_cast<float>( lh ) : 1.0f;
     return std::make_pair( scale_w, scale_h );
 #else
+    ( void )display_index; // avoid unused parameter lint
     return std::make_pair( 1.0f, 1.0f );
 #endif
 }
@@ -3540,8 +3541,9 @@ static void init_term_size_and_scaling_factor()
 
             } else {
                 // For fullscreen or window borderless maximum size is the display size
-                max_width = current_display.w;
-                max_height = current_display.h;
+                auto [ dpi_scale_w, dpi_scale_h ] = get_display_scale( current_display_id );
+                max_width = dpi_scale_w * current_display.w;
+                max_height = dpi_scale_h * current_display.h;
             }
         } else {
             dbg( DL::Warn ) << "Failed to get current Display Mode, assuming infinite display size.";


### PR DESCRIPTION
#### Summary
This PR fixes the scaling factor for high-dpi displays. 

#### Purpose of change

The number of pixels returned by `SDL_GetWindowSize` do not take into account dpi scaling, like on Apple Retina displays. Thankfully SDL2 provides a `SDL_GetWindowSizeInPixels` for accounting for exactly this.

Additionally, even in full screen mode the dimensions of `SDL_DisplayMode` are incorrect due to `SDL_GetDesktopDisplayMode` similarly not factoring in dpi scale.

#### Describe the solution

Switch to `SDL_GetWindowSizeInPixels` and implement a new `get_display_scale` function for measuring the dpi scaling ratios. The measurement creates a small, hidden window to quickly measure the horizontal and vertical stretch necessary to account for dpi. On failure the return values are 1x, ensuring no logical change.

#### Describe alternatives you've considered

One could perhaps imagine a larger refactor where we always perform window measurements, but even in this case we'd want precisely the same affordance provided by `get_display_scale`. This keeps things minimal and known to not break other platforms.

#### Testing

| before | after |
| - | - |
| <img width="1726" height="1116" alt="image" src="https://github.com/user-attachments/assets/71b30793-c44f-434b-a90e-4a4254745850" /> | <img alt="image" src="https://github.com/user-attachments/assets/c62bff9a-cf7d-45ef-83d5-9d5f9fc991f3" /> |


I've tested this on my MacBook in each mode, though given it's backend agnostic it should work cross-platform. A friend has also on Windows and I'll soon be on Linux with an intentionally out-dated SDL version too.

 **EDIT**: Confirmed it works on Linux with and without old versions of SDL (pre 2022)
 
 Resolves #7437 