### PR TITLE
fix: Make spawned ethereal items unsalvagable

### DIFF
--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -892,7 +892,7 @@ void spell_effect::spawn_ethereal_item( const spell &sp, Creature &caster, const
     if( !granted->is_comestible() && !( sp.has_flag( spell_flag::PERMANENT ) ) ) {
         granted->set_var( "ethereal", to_turns<int>( sp.duration_turns() ) );
         granted->set_flag( flag_id( "ETHEREAL_ITEM" ) );
-        granted->set_flag( flag_id("NO_SALVAGE"));
+        granted->set_flag( flag_id( "NO_SALVAGE" ) );
     }
     if( granted->count_by_charges() && sp.damage() > 0 ) {
         granted->charges = sp.damage();


### PR DESCRIPTION
## Purpose of change (The Why)

Fixes #7380 
You shouldn't be able to salvage or disassemble a temporary item to get permanent materials.

## Describe the solution (The How)

Just adds `NO_SALVAGE` to any items spawned that already get the flag to be Ethereal

## Describe alternatives you've considered

- Specify it at the item level
- Make all spawned items not salvageable

## Testing

It compiles, it correctly prevents me from salvaging an MN-spawned plate armor

## Additional context

1 line change, let's gooo

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
