### PR TITLE
fix: temporary workaround for possible pathfinding issue

### DIFF
--- a/src/pathfinding.cpp
+++ b/src/pathfinding.cpp
@@ -1019,6 +1019,7 @@ std::vector<tripoint> Pathfinding::get_route_3d(
 
                 if( is_inf( best_distance ) ) {
                     // No trivial Z path exists, give up
+                    debugmsg( "Failed to find a trivial path across z-levels" );
                     return std::vector<tripoint>();
                 }
 


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

@RoyalFox2140 has random freezing and crashes with memory exhaustion.
Problem likely linked to Pathfinding.

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)

Summary examination points to a while loop inside pathfinding not exiting, and increasing a vector infinitely until a crash happens.

This adds a debugmsg guard and bail-out if pathfinding seems to be going out of control (1000+ z-level changes on path).

When the actual issue is actually tracked down, this check may be removed if necessary.

<!-- e.g nerfs monster A -->

## Describe alternatives you've considered

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<img width="352" height="227" alt="image" src="https://github.com/user-attachments/assets/7d312390-c347-46b3-b7bf-124e278be9ed" />

<img width="1918" height="1080" alt="image" src="https://github.com/user-attachments/assets/40a559e3-0abf-4f39-8f79-d85557132ba1" />


<details>
<summary>StackTrace</summary>

```
The program has crashed.
See the log file for a stack trace.
CRASH LOG FILE: ./config/crash.log
VERSION: 016b784
TYPE: Signal
MESSAGE: SIGABRT: Abnormal termination
STACK TRACE:

    /run/media/royalfox/Steam/Cataclysm/20250925/cataclysm-bn-tiles(debug_write_backtrace(std::ostream&)+0x42) [0x55d4137e65b5]
    /run/media/royalfox/Steam/Cataclysm/20250925/cataclysm-bn-tiles(+0x183d895) [0x55d4137c9895]
    /run/media/royalfox/Steam/Cataclysm/20250925/cataclysm-bn-tiles(+0x183db4b) [0x55d4137c9b4b]
    /lib64/libc.so.6(+0x1a070) [0x7f7addc28070]
    /run/media/royalfox/Steam/Cataclysm/20250925/cataclysm-bn-tiles(void std::vector<Pathfinding::ZLevelChange, std::allocator<Pathfinding::ZLevelChange> >::_M_realloc_append<Pathfinding::ZLevelChange const&>(Pathfinding::ZLevelChange const&)+0xb8) [0x55d413fb3266]
    /run/media/royalfox/Steam/Cataclysm/20250925/cataclysm-bn-tiles(Pathfinding::get_route_3d(tripoint, tripoint, PathfindingSettings, RouteSettings)+0x1118) [0x55d413fb2884]
    /run/media/royalfox/Steam/Cataclysm/20250925/cataclysm-bn-tiles(Pathfinding::route(tripoint, tripoint, std::optional<PathfindingSettings>, std::optional<RouteSettings>)+0x339) [0x55d413fb2cf1]
    /run/media/royalfox/Steam/Cataclysm/20250925/cataclysm-bn-tiles(monster::move()+0xecd) [0x55d413dbc15f]
    /run/media/royalfox/Steam/Cataclysm/20250925/cataclysm-bn-tiles(game::monmove()+0x39d) [0x55d41391fccf]
    /run/media/royalfox/Steam/Cataclysm/20250925/cataclysm-bn-tiles(game::do_turn()+0x79c) [0x55d4139387a0]
    /run/media/royalfox/Steam/Cataclysm/20250925/cataclysm-bn-tiles(main+0x1d3a) [0x55d412d755c2]
    /lib64/libc.so.6(+0x3575) [0x7f7addc11575]
    /lib64/libc.so.6(__libc_start_main+0x88) [0x7f7addc11628]
    /run/media/royalfox/Steam/Cataclysm/20250925/cataclysm-bn-tiles(_start+0x25) [0x55d412e6c2c5]
```
</details>


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR adds/removes a mod.
  - [ ] I have committed the output of `deno task semantic`.
- [ ] This PR modifies lua scripts or the lua API.
  - [ ] I have added `lua` scope to the PR title.
  - [ ] I have added [type annotations](https://emmylua.github.io/annotation.html) to functions so that it's safe and easy to maintain.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
