### PR TITLE
feat(mods): add terrain_flag restrictions to flowerpot iuse_actors

### DIFF
--- a/data/mods/flowerpots_plus/items/planter_l.json
+++ b/data/mods/flowerpots_plus/items/planter_l.json
@@ -24,6 +24,7 @@
       "seeds_per_use": [ 1, 5 ],
       "fert_per_use": [ 0, 5 ],
       "fert_boost": 0.1,
+      "terrain": [ "PLANTABLE", "SHALLOW_WATER", "MUSHROOM_PLANTABLE" ],
       "stages": [
         "portable_planter_l",
         "portable_planter_l_seed",

--- a/data/mods/flowerpots_plus/items/planter_m.json
+++ b/data/mods/flowerpots_plus/items/planter_m.json
@@ -24,6 +24,7 @@
       "seeds_per_use": [ 1, 3 ],
       "fert_per_use": [ 0, 3 ],
       "fert_boost": 0.1,
+      "terrain": [ "PLANTABLE", "SHALLOW_WATER", "MUSHROOM_PLANTABLE" ],
       "stages": [
         "portable_planter_m",
         "portable_planter_m_seed",

--- a/data/mods/flowerpots_plus/items/planter_s.json
+++ b/data/mods/flowerpots_plus/items/planter_s.json
@@ -24,6 +24,7 @@
       "seeds_per_use": [ 1, 1 ],
       "fert_per_use": [ 0, 1 ],
       "fert_boost": 0.2,
+      "terrain": [ "PLANTABLE" ],
       "stages": [
         "portable_planter_s",
         "portable_planter_s_seed",

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -5948,6 +5948,10 @@ void iuse_flowerpot_plant::load( const JsonObject &jo )
     } else {
         fert_per_use = std::make_pair( 0, 1 );
     }
+
+    if( jo.has_array( "terrain" ) ) {
+        terrain = jo.get_tags<std::string>( "terrain" );
+    }
 }
 
 auto iuse_flowerpot_plant::clone() const -> std::unique_ptr<iuse_actor>
@@ -6116,10 +6120,21 @@ auto iuse_flowerpot_plant::on_use_plant( player &p, item &i, const tripoint & ) 
     const auto &[min_seed, max_seed] = seeds_per_use;
     const auto &[min_fert, max_fert] = fert_per_use;
 
-    const auto seed_entries = iexamine::get_seed_entries( seed_inv );
+    auto seed_entries = std::vector<seed_tuple> {};
+    std::ranges::copy_if( iexamine::get_seed_entries( seed_inv ),
+    std::back_inserter( seed_entries ), [&]( const seed_tuple & s ) {
+        const auto &[type, name, cnt] = s;
+        return terrain.contains( type->seed->required_terrain_flag );
+    } );
+
+    if( seed_entries.empty() ) {
+        add_msg( _( "You don't have seeds to plant in this." ) );
+        return 0;
+    }
+
     const int seed_index = iexamine::query_seed( seed_entries, min_seed );
 
-    if( seed_index < 0 || seed_index >= seed_entries.size() ) {
+    if( seed_index < 0 || std::cmp_greater_equal( seed_index, seed_entries.size() ) ) {
         add_msg( _( "You saved your seeds for later." ) );
         return 0;
     }
@@ -6394,34 +6409,51 @@ auto iuse_flowerpot_collect::use( player &who, item &, bool, const tripoint & ) 
         return 0;
     }
 
+    const auto actor = dynamic_cast<const iuse_flowerpot_plant *>( target_pot.value()->get_use(
+                           iuse_flowerpot_plant::IUSE_ACTOR )->get_actor_ptr() );
+    if( !actor ) {
+        debugmsg( "Invalid iuse_actor" );
+        return 0;
+    }
+
+    auto stack = get_map().i_at( source_pos );
+
+    constexpr auto is_seed = []( const item * it ) { return it->is_seed(); };
+    const auto seed_it = std::ranges::find_if( stack, is_seed );
+    if( seed_it == stack.end() ) {
+        debugmsg( "Missing seed" );
+        return 0;
+    }
+
+    const item *seed = *seed_it;
+    if( !actor->terrain.contains( seed->type->seed->required_terrain_flag ) ) {
+        add_msg( "You can't collect that into this planter." );
+        return 0;
+    }
+
     // TODO: make an activity actor?
     who.moves -= to_turns<int>( 30_seconds );
-    transfer_map_to_flowerpot( source_pos, *target_pot.value() );
+    transfer_map_to_flowerpot( source_pos, *target_pot.value(), actor, seed->typeId() );
 
     return 0;
 }
 
-void iuse_flowerpot_collect::transfer_map_to_flowerpot( const tripoint &pos, item &flowerpot )
+void iuse_flowerpot_collect::transfer_map_to_flowerpot(
+    const tripoint &map_pos, item &flowerpot, const iuse_flowerpot_plant *actor,
+    const itype_id &seed_type )
 {
     auto &m = get_map();
 
-    const auto furn_id = m.furn( pos );
-
-    const auto actor = dynamic_cast<const iuse_flowerpot_plant *>( flowerpot.get_use(
-                           iuse_flowerpot_plant::IUSE_ACTOR )->get_actor_ptr() );
-    if( !actor ) {
-        debugmsg( "Invalid iuse_actor" );
-        return;
-    }
+    const auto furn_id = m.furn( map_pos );
 
     if( !furn_id->plant ) {
         debugmsg( "Invalid plant_data" );
         return;
     }
 
-    auto stack = m.i_at( pos );
+    auto stack = m.i_at( map_pos );
 
-    constexpr auto is_seed = []( const item * it ) { return it->is_seed(); };
+    const auto is_seed = [&]( const item * it ) { return it->typeId() == seed_type; };
     const auto seed_it = std::ranges::find_if( stack, is_seed );
     if( seed_it == stack.end() ) {
         debugmsg( "Missing seed" );
@@ -6434,21 +6466,21 @@ void iuse_flowerpot_collect::transfer_map_to_flowerpot( const tripoint &pos, ite
 
     std::vector<detached_ptr<item>> comps;
     stack.remove_top_items_with( [&]( detached_ptr<item> &&it ) {
-        if( max_seeds > 0 && it->typeId() == seed->typeId() ) {
+        if( max_seeds > 0 && it->typeId() == seed_type ) {
             // Move the seeds
-            return item::use_charges( std::move( it ), seed->typeId(), max_seeds, comps, pos );
+            return item::use_charges( std::move( it ), seed_type, max_seeds, comps, map_pos );
         }
         if( max_fert > 0 && it->typeId() == itype_fertilizer ) {
             // Clone the fertilizer
             auto tmp = item::spawn( *it );
-            item::use_charges( std::move( tmp ), itype_fertilizer, max_fert, comps, pos );
+            item::use_charges( std::move( tmp ), itype_fertilizer, max_fert, comps, map_pos );
         }
         return std::move( it );
     } );
 
     // Erase fertilizer and reset furniture if no more seeds
     if( std::ranges::find_if( stack, is_seed ) == stack.end() ) {
-        m.furn_set( pos, furn_id->plant->base );
+        m.furn_set( map_pos, furn_id->plant->base );
         stack.remove_top_items_with( []( detached_ptr<item> &&it ) {
             if( it->typeId() == itype_fertilizer )
                 return detached_ptr<item> {};

--- a/src/iuse_actor.h
+++ b/src/iuse_actor.h
@@ -1448,6 +1448,7 @@ class iuse_flowerpot_plant final : public iuse_actor
         float harvest_mult = 1;
         float growth_rate = 1;
         float fert_boost = 0.25;
+        std::set<std::string> terrain = { "PLANTABLE" };
 };
 
 class iuse_flowerpot_collect final : public iuse_actor
@@ -1463,5 +1464,8 @@ class iuse_flowerpot_collect final : public iuse_actor
                       const tripoint & ) const -> ret_val<bool> override;
         auto clone() const -> std::unique_ptr<iuse_actor> override;
     private:
-        static void transfer_map_to_flowerpot( const tripoint &map_pos, item &flowerpot );
+        static void transfer_map_to_flowerpot( const tripoint &map_pos,
+                                               item &flowerpot,
+                                               const iuse_flowerpot_plant *actor,
+                                               const itype_id &seed_type );
 };


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

Flowerpots currently ignore seed terrain restriction flags.

>  I just realized, your planters work with cattails don't they? I don't think that's a problem but they likely don't use the flag based farming

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)

Add terrain flags to flowerpot plant actors.

For now, the advanced planter variants can plant aquatic and mushroom seeds. 
The standard planter can only plant regular soil based seeds.

Eventually, cattails and mushrooms might get their own hydroponic / mushroom log planter variants.

<!-- e.g nerfs monster A -->

## Describe alternatives you've considered

## Testing

Try planting / collecting cattail seeds onto a basic and advanced planter, only the advanced one should allow it.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR adds/removes a mod.
  - [ ] I have committed the output of `deno task semantic`.
- [ ] This PR modifies lua scripts or the lua API.
  - [ ] I have added `lua` scope to the PR title.
  - [ ] I have added [type annotations](https://emmylua.github.io/annotation.html) to functions so that it's safe and easy to maintain.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
