### PR TITLE
feat(balance): make Henry Big Boy `RELOAD_ONE`

### DIFF
--- a/data/json/items/gun/44.json
+++ b/data/json/items/gun/44.json
@@ -51,6 +51,7 @@
     "ranged_damage": { "damage_type": "bullet", "amount": 2 },
     "dispersion": 180,
     "clip_size": 10,
+    "flags": [ "RELOAD_ONE" ],
     "valid_mod_locations": [
       [ "accessories", 2 ],
       [ "barrel", 1 ],


### PR DESCRIPTION
## Purpose of change (The Why)

fixes #7177

This makes sense to reload one round at a time unless we introduce tube speedloaders.

## Describe the solution (The How)

add `RELOAD_ONE` flag

## Describe alternatives you've considered

- Increase the time to accurately represent reloading the entire tube at once

## Testing

The game loads and the flag seems to apply just fine

## Additional context

I love cleaning up small issues that are just sitting around like this.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
