### PR TITLE
feat: added in-repo mod that blacklist cockroach type enemies

### DIFF
--- a/data/mods/No_Cockroaches/modinfo.json
+++ b/data/mods/No_Cockroaches/modinfo.json
@@ -17,5 +17,9 @@
       "mon_skittering_plague",
       "mon_plague_vector"
     ]
+  },
+  {
+    "type": "ITEM_BLACKLIST",
+    "items": [ "egg_roach", "egg_roach_plague", "feces_roach" ]
   }
 ]


### PR DESCRIPTION
## Purpose of change (The Why)

Being entomophobic, I have a severe issue with cockroaches, even in games. 

We already have insect blacklists for wasps, spiders, and ants, but not for cockroaches. Thus, I found it was permissible, and perhaps desirable by other entomophobes, to add another in-repo mod to remove them as well.

## Describe the solution (The How)

Added an in-repo mod for blacklisting any cockroach type enemies, currently six:
- giant cockroach
- pregnant giant cockroach
- giant cockroach nymph
- giant plague nymph 
- skittering plague
- plague vector

As well as blacklisting their eggs and waste

## Describe alternatives you've considered

N/A

## Testing

Tested on latest version of nightly on a regular playthrough, monsters successfully blacklisted even after having been spawned and within line of sight of player, no issues encountered.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.