### PR TITLE
feat(balance): prevent purifying mutations in your thresh category

### DIFF
--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -979,15 +979,15 @@ static void do_purify( player &p )
         if( p.has_trait( traits_iter.id ) && !p.has_base_trait( traits_iter.id ) ) {
             //Looks for active mutation
             bool threshlocked = false;
-            for (auto cat : traits_iter.category) {
-                if ( ( cat == p.get_highest_category() ) && p.crossed_threshold() ) {
+            for( auto cat : traits_iter.category ) {
+                if( ( cat == p.get_highest_category() ) && p.crossed_threshold() ) {
                     // We shouldn't be able to get rid of mutations that we have a threshold from
                     // Mostly applies to pre-thresh in vanilla because most post-thresh aren't purifiable anyway
                     threshlocked = true;
                     break;
                 }
             }
-            if (!threshlocked) {
+            if( !threshlocked ) {
                 valid.push_back( traits_iter.id );
             }
         }
@@ -1033,15 +1033,15 @@ int iuse::purify_iv( player *p, item *it, bool, const tripoint & )
         if( p->has_trait( traits_iter.id ) && !p->has_base_trait( traits_iter.id ) ) {
             //Looks for active mutation
             bool threshlocked = false;
-            for (auto cat : traits_iter.category) {
-                if ( ( cat == p->get_highest_category() ) && p->crossed_threshold() ) {
+            for( auto cat : traits_iter.category ) {
+                if( ( cat == p->get_highest_category() ) && p->crossed_threshold() ) {
                     // We shouldn't be able to get rid of mutations that we have a threshold from
                     // Mostly applies to pre-thresh in vanilla because most post-thresh aren't purifiable anyway
                     threshlocked = true;
                     break;
                 }
             }
-            if (!threshlocked){
+            if( !threshlocked ) {
                 valid.push_back( traits_iter.id );
             }
         }
@@ -1089,15 +1089,15 @@ int iuse::purify_smart( player *p, item *it, bool, const tripoint & )
             traits_iter.id->purifiable ) {
             //Looks for active mutation
             bool threshlocked = false;
-            for (auto cat : traits_iter.category) {
-                if ( ( cat == p->get_highest_category() ) && p->crossed_threshold() ) {
+            for( auto cat : traits_iter.category ) {
+                if( ( cat == p->get_highest_category() ) && p->crossed_threshold() ) {
                     // We shouldn't be able to get rid of mutations that we have a threshold from
                     // Mostly applies to pre-thresh in vanilla because most post-thresh aren't purifiable anyway
                     threshlocked = true;
                     break;
                 }
             }
-            if (!threshlocked) {
+            if( !threshlocked ) {
                 valid.push_back( traits_iter.id );
                 valid_names.push_back( traits_iter.id->name() );
             }


### PR DESCRIPTION
## Purpose of change (The Why)

I realized in the process of starting work on tiered thresholds that we don't actually prevent you from purifying away the pre-threshold mutations of the category you've got a threshold in. I feel like this is a bit of an oversight, as it doesn't really make sense to be able to do that.

This is also a necessary feature for my plans regarding a potential collaborative mutation rework where we'd be having a kemonomimi threshold to lock in status as a catgirl as opposed to a doggirl.

## Describe the solution (The How)

Makes the purifiers check if one of the mutation's listed categories is your highest category, and if you've gone post-thresh. If so, it doesn't purify those mutations away.

## Describe alternatives you've considered

- Include this as part of the tiered thresholds PR instead of doing it separately
- Instead cause the threshold to set its pre-threshold mutations as base traits

This would work too, but I don't think it's nice to overload that functionality for this. I am very open to doing it this way though (although I would need to find the right function that handles crossing thresholds to do so)

## Testing

Compiled, loaded into a world, made myself a feline mutant, and then tried downing purifiers (including some serum and smart shots). The game no-longer purifies away mutations that have the same category as my threshold.

## Additional context

I'm not entirely sure the game doesn't have a similar issue with pre-threshes from different trees cancelling each other (i.e. that downing a canine mutagen when you're a feline post-thresh could still replace feline ears with canine ears), but we'll cross that bridge when we get to it.

Also, because of how the intermediary requirements act for mutations like feline tail, some slightly weird behavior can be observed with the purifier still removing stubby tail from a feline mutant because it isn't a full feline tail yet. This is, however, very possible to solve in JSON.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
