### PR TITLE
chore: checkbox for PR scope

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-<!-- for small documentation fixes, it's okay to ignore the template -->
+<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->
 
 ## Purpose of change (The Why)
 
@@ -33,12 +33,12 @@ NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive
 - [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
 - [ ] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
 
-<!--
-please remove sections irrelevant to this PR.
-
 ### Optional
 
+<!-- please remove checkboxes unrelated to this PR. -->
+
 - [ ] This PR ports commits from DDA or other cataclysm forks.
+  - [ ] I have added [`port` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#port%3A-ports-from-dda-or-other-forks) to the PR title.
   - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
   - [ ] I have linked the URL of original PR(s) in the description.
 - [ ] This is a C++ PR that modifies JSON loading or behavior.
@@ -54,9 +54,10 @@ please remove sections irrelevant to this PR.
 - [ ] This is a PR that removes JSON entities.
   - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
 - [ ] This PR adds/removes a mod.
+  - [ ] I have added [`mod` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#mods-or-mods%2F<mod_id>%3A-mods) to the PR title.
+  - [ ] The `mod_name` in `data/mods/<mod_name>` matches `id` in `modinfo.json`.
   - [ ] I have committed the output of `deno task semantic`.
 - [ ] This PR modifies lua scripts or the lua API.
-  - [ ] I have added `lua` scope to the PR title.
+  - [ ] I have added [`lua` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#lua%3A-changes-to-lua-api) to the PR title.
   - [ ] I have added [type annotations](https://emmylua.github.io/annotation.html) to functions so that it's safe and easy to maintain.
   - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
--->


### PR DESCRIPTION

## Purpose of change (The Why)

so we don't forget to add relevant PR scope

## Checklist


### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

