### PR TITLE
chore(UI): do not show debugmsg prompts for disabled log levels

### DIFF
--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -477,6 +477,10 @@ void realDebugmsg( const char *filename, const char *line, const char *funcname,
         return;
     }
 
+    if( !debugLevel.test( debug_level ) ) {
+        return;
+    }
+
     // Show excessive repetition prompt once per excessive set
     bool excess_repetition = rep_folder.repeat_count == repetition_folder::repetition_threshold;
 


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

debugmsg user-facing prompt ignores the debug level settings, and shows the message regardless
* Followup of #7449

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)

Do not display error messages if the debug level of said message is disabled in settings, the same way as it is not written to the log file.

<!-- e.g nerfs monster A -->

## Describe alternatives you've considered

Remove the pathfinding failure debugmsg from
* #7438 
* #7449

## Testing
 
* Trigger a DL::Debug level message with the setting disabled
* Doesn't block game user interface with Debug level logging disabled.
* Other error levels should still show normally.

Currently, there is only one source: "Failed to find a trivial path across z-levels" when pathfinding fails from above temporary crashfix

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
