### PR TITLE
fix: Lamia mutation category ID uses consistent casing

### DIFF
--- a/data/mods/Monster_Girls/categories.json
+++ b/data/mods/Monster_Girls/categories.json
@@ -112,7 +112,7 @@
   },
   {
     "type": "mutation_category",
-    "id": "Lamia",
+    "id": "LAMIA",
     "name": "Lamia",
     "threshold_mut": "THRESH_LAMIA",
     "mutagen_message": "You feel a slithering feeling.",


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

I did an oopsie with the ID for monstergirl mutation's lamia category, causing the Lamia category to not have any valid mutations and its mutagen from working.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

ALL CAPS

## Describe alternatives you've considered

SCREAMING

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

Used my eyes to confirm I held down shift this time.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

![aaaa-dragon](https://github.com/user-attachments/assets/64eccf7d-158b-4b9c-a2d8-8507e1b91eac)

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
