### PR TITLE
perf: options to stop some actions while the player is sleeping

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1486,10 +1486,9 @@ bool game::do_turn()
     if( is_game_over() ) {
         return cleanup_at_end();
     }
-    const auto skipforperf = get_option<bool>( "SLEEP_PERF" ) && u.in_sleep_state();
-    const auto vehperf = get_option<bool>( "SKIP_VEH" );
-    const auto soundperf = get_option<bool>( "SKIP_SOUND" );
-    const auto monperf = get_option<bool>( "SKIP_MON" );
+    const auto vehperf = get_option<bool>( "SLEEP_SKIP_VEH" );
+    const auto soundperf = get_option<bool>( "SLEEP_SKIP_SOUND" );
+    const auto monperf = get_option<bool>( "SLEEP_SKIP_MON" );
     // Actual stuff
     if( new_game ) {
         new_game = false;
@@ -1548,7 +1547,7 @@ bool game::do_turn()
     perhaps_add_random_npc();
     process_voluntary_act_interrupt();
     process_activity();
-    if( !skipforperf || !soundperf ) {
+    if( !soundperf ) {
         // Process NPC sound events before they move or they hear themselves talking
         for( npc &guy : all_npcs() ) {
             if( rl_dist( guy.pos(), u.pos() ) < MAX_VIEW_DISTANCE ) {
@@ -1570,7 +1569,7 @@ bool game::do_turn()
                 cleanup_dead();
                 mon_info_update();
                 // Process any new sounds the player caused during their turn.
-                if( !skipforperf || !soundperf ) {
+                if( !soundperf ) {
                     for( npc &guy : all_npcs() ) {
                         if( rl_dist( guy.pos(), u.pos() ) < MAX_VIEW_DISTANCE ) {
                             sounds::process_sound_markers( &guy );
@@ -1631,7 +1630,7 @@ bool game::do_turn()
     // We need floor cache before checking falling 'n stuff
     m.build_floor_caches();
 
-    if( !skipforperf || !vehperf ) {
+    if( !vehperf ) {
         m.process_falling();
         autopilot_vehicles();
         m.vehmove();
@@ -1646,7 +1645,7 @@ bool game::do_turn()
     // Update vision caches for monsters. If this turns out to be expensive,
     // consider a stripped down cache just for monsters.
     m.build_map_cache( get_levz(), true );
-    if( !skipforperf || !monperf ) {
+    if( !monperf ) {
         monmove();
     }
     if( calendar::once_every( 5_minutes ) ) {

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2228,17 +2228,14 @@ void options_manager::add_options_debug()
     add_option_group( debug, Group( "rem_act_perf", to_translation( "Performance" ),
                                     to_translation( "Configure performance settings that can detract from the game." ) ),
     [&]( auto & page_id ) {
-        add( "SKIP_VEH", debug, translate_marker( "Skip Vehicle Movement" ),
-             translate_marker( "Turns off vehicle movement and autodrive when perf boost is on" ),
+        add( "SLEEP_SKIP_VEH", page_id, translate_marker( "Sleep Boost: Skip Vehicle Movement" ),
+             translate_marker( "Turns off vehicle movement and autodrive while sleeping" ),
+             true );
+        add( "SLEEP_SKIP_SOUND", page_id, translate_marker( "Sleep Boost: Skip Sound Processing On Sleep" ),
+             translate_marker( "Sounds are not processed while sleeping" ),
              false );
-        add( "SKIP_SOUND", debug, translate_marker( "Skip Sound Processing" ),
-             translate_marker( "Sounds are not processed when perf boost is on" ),
-             false );
-        add( "SKIP_MON", debug, translate_marker( "Skip Monster Movement" ),
+        add( "SLEEP_SKIP_MON", page_id, translate_marker( "Sleep Boost: Skip Monster Movement" ),
              translate_marker( "Monsters do not move while sleeping" ),
-             false );
-        add( "SLEEP_PERF", debug, translate_marker( "Sleep Boost" ),
-             translate_marker( "Boost performance while sleeping" ),
              false );
     } );
 


### PR DESCRIPTION
## Purpose of change (The Why)
Android players especially have difficulty doing long time actions like sleeping or crafting
This proposes the initial solution for sleep performance by preventing certain actions from running both while sleeping and trying to sleep.
All of this is behind the new performance category in debug options
- I plan to add more options to the category; hence why it is a category

## Describe the solution (The How)
Prevent the following things from running while sleeping or trying to sleep:
- Sound Processing (Already doesn't happen while asleep)
- Vehicle Movement & Autodrive (Vehicles aren't going to be moving while asleep I would think)
- Monster movement

## Describe alternatives you've considered
Not including this debug option

## Testing
Ran with options on and off; Performance was below
Did not crash in either case

## Additional context
<img width="1920" height="1080" alt="NewPerf" src="https://github.com/user-attachments/assets/fdc90fee-890c-4998-b481-9c92df73a76e" />
<img width="1920" height="1080" alt="OldPerf" src="https://github.com/user-attachments/assets/88c12247-f97d-4514-907f-4be6ebc8fc63" />

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.