### PR TITLE
fix: make rope ladders boardable to fix board_vehicle error

### DIFF
--- a/data/json/vehicleparts/ladders.json
+++ b/data/json/vehicleparts/ladders.json
@@ -6,7 +6,7 @@
     "symbol": "|",
     "color": "light_blue",
     "broken_symbol": "O",
-    "flags": [ "LADDER", "SHOCK_IMMUNE" ],
+    "flags": [ "LADDER", "SHOCK_IMMUNE", "BOARDABLE" ],
     "description": "A ladder that lets you down from heights."
   },
   {
@@ -20,7 +20,6 @@
     "requirements": { "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "60 m", "using": [  ] } },
     "durability": 60,
     "damage_modifier": 80,
-    "flags": [ "LADDER", "SHOCK_IMMUNE" ],
     "breaks_into": [ { "item": "string_6", "count": [ 10, 20 ] } ],
     "damage_reduction": { "bash": 10 }
   }


### PR DESCRIPTION
## Purpose of change (The Why)
fixes: #7486 

## Describe the solution (The How)
Make the rope ladder boardable to fix the error

## Describe alternatives you've considered
Check that it is boardable in c++ before letting you board

## Testing
Remove the aisle from the testing vehicle
Go up
Install ladder
Go down and up
No error anymore

## Additional context
How many people dont install aisles......

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.