### PR TITLE
feat: autopriority for healing consumables

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -6394,6 +6394,13 @@ float Character::get_hit_base() const
 namespace
 {
 
+struct healable_bp {
+    mutable bool allowed;
+    bodypart_id bp;
+    std::string name; // Translated name as it appears in the menu.
+    int bonus;
+};
+
 auto get_best_selection_index( const Character &c, const std::vector<healable_bp> &parts,
                                float bandage_power, float disinfectant_power ) -> int
 {
@@ -6660,7 +6667,7 @@ bodypart_str_id Character::body_window( const std::string &menu_header,
         bmenu.text = _( "No limb would benefit from it." );
         bmenu.addentry( parts.size(), true, 'q', "%s", _( "Cancel" ) );
     } else {
-        const int preferred_index = get_best_selection_index( this, parts, bandage_power,
+        const int preferred_index = get_best_selection_index( *this, parts, bandage_power,
                                     disinfectant_power );
         bmenu.selected = preferred_index;
     }


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
I'm annoyed by need to select bandage target manually, especially earlygame when wounds are often and healing is sparse

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)

<!-- e.g nerfs monster A -->
when health menu is shown, it pre-selects a target for bandage/antiseptic
highest priority is currently bleeding wounds/infected wounds
next are wounds with most hp lost
next are wounds where healing power can be improved 
if none are selected, defaults to head (previous default)


## Describe alternatives you've considered
not doing it
## Testing
spawned character, got some wounds, spawned bandages, tried to `e`at them

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

<!-- please remove checkboxes unrelated to this PR. -->

