### PR TITLE
fix: skip vehicle movement in sleep is now default off

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2230,7 +2230,7 @@ void options_manager::add_options_debug()
     [&]( auto & page_id ) {
         add( "SLEEP_SKIP_VEH", page_id, translate_marker( "Sleep Boost: Skip Vehicle Movement" ),
              translate_marker( "Turns off vehicle movement and autodrive while sleeping" ),
-             true );
+             false );
         add( "SLEEP_SKIP_SOUND", page_id, translate_marker( "Sleep Boost: Skip Sound Processing On Sleep" ),
              translate_marker( "Sounds are not processed while sleeping" ),
              false );


### PR DESCRIPTION
## Purpose of change (The Why)
Didn't think of people falling asleep while driving the vehicle when #7494 was updated to have that as default.
So it unexpectedly buffed some things

## Describe the solution (The How)
Make it default off rather then on

## Describe alternatives you've considered
None

## Testing
Looked
## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.