### PR TITLE
feat(balance, mods): add `cbm_slots` to default modslist

### DIFF
--- a/data/mods/default.json
+++ b/data/mods/default.json
@@ -8,5 +8,6 @@
   "udp_redux",
   "pride_flags",
   "tablet_ebook",
-  "change_hairstyle"
+  "change_hairstyle",
+  "cbm_slots"
 ]


### PR DESCRIPTION
## Purpose of change (The Why)

CBMs currently are in a very powerful state, with practically no downsides or real costs associated with them a lot of the time. As such, adding in an opportunity cost by default ought to make them a bit more sane.

Players that do not wish to play with bionic slots can simply remove the mod from their list.

## Describe the solution (The How)

Adds `cbm_slots` to the default mods list

## Describe alternatives you've considered

- Do this later around the time of the proposed mutation rework
- Give other people some time to rework how the slots are handled in the first place

## Testing

The game indeed loads just fine with this mod, and the vanilla scenarios don't seem to exceed any of the slot limits (although defective cyborg does *meet* a few of the limits)

## Additional context

Quick and simple way to add some sort of restriction on CBMs without getting into a whole bionics rework.

This also helps remind people that this feature exists, given that otherwise it's hiding in a corner of the mod menu and is rarely turned on.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
