### PR TITLE
fix: set vehicle faction ownership on spawning, when applicable

### DIFF
--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -1424,6 +1424,7 @@ void construct::done_vehicle( const tripoint &p )
         return;
     }
     veh->name = name;
+    veh->set_owner( u );
     if( u.has_trait( trait_DEBUG_HS ) ) {
         // TODO: Allow DEBUG_HS to consume items that don't exist
         veh->install_part( point_zero, vpart_id( "frame_vertical_2" ) );

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -1703,6 +1703,7 @@ void debug()
                                                           false,
                                                           true );
                             if( veh != nullptr ) {
+                                veh->set_owner( u );
                                 m.board_vehicle( dest, &u );
                             }
                         }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -680,10 +680,11 @@ bool game::start_game()
         start_loc.prepare_map( omtstart );
 
         // Place vehicles spawned by scenario or profession, has to be placed very early to avoid bugs.
-        if( u.starting_vehicle
-            && !place_vehicle_nearby(
-                u.starting_vehicle, omtstart.xy(), 0, 30, std::vector<std::string> {} ) ) {
-            if( query_gen_failed() ) {
+        if( u.starting_vehicle ) {
+            auto veh = place_vehicle_nearby( u.starting_vehicle, omtstart.xy(), 0, 30, std::vector<std::string> {} );
+            if( veh ) {
+                veh->set_owner( u );
+            } else if( query_gen_failed() ) {
                 MAPBUFFER.clear();
                 overmap_buffer.clear();
                 omtstart = overmap::invalid_tripoint;

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -1047,9 +1047,13 @@ void spell_effect::spawn_summoned_vehicle( const spell &sp, Creature &caster,
         caster.add_msg_if_player( m_bad, _( "There is already a vehicle there." ) );
         return;
     }
-    if( vehicle *veh = here.add_vehicle( sp.summon_vehicle_id(), target, -90_degrees, 100, 0,
-                                         false, false, true ) ) {
+    vehicle *veh = here.add_vehicle( sp.summon_vehicle_id(), target, -90_degrees, 100, 0, false, false,
+                                     true );
+    if( veh ) {
         veh->magic = true;
+        if( caster.is_player() ) {
+            veh->set_owner( *caster.as_player() );
+        }
         const time_duration summon_time = sp.duration_turns();
         if( !sp.has_flag( spell_flag::PERMANENT ) ) {
             veh->summon_time_limit = summon_time;

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -2359,7 +2359,8 @@ bool vehicle::remove_carried_vehicle( const std::vector<int> &carried_parts )
                  to_degrees( face.dir() ), to_degrees( new_dir ) );
         return false;
     }
-
+    new_vehicle->owner = owner;
+    new_vehicle->old_owner = old_owner;
     std::vector<point> new_mounts;
     new_vehicle->name = veh_record.substr( vehicle_part::name_offset );
     for( auto carried_part : carried_parts ) {
@@ -2572,6 +2573,8 @@ bool vehicle::split_vehicles( const std::vector<std::vector <int>> &new_vehs,
                 // the split part was out of the map bounds.
                 continue;
             }
+            new_vehicle->owner = owner;
+            new_vehicle->old_owner = old_owner;
             new_vehicle->name = name;
             new_vehicle->move = move;
             new_vehicle->turn_dir = turn_dir;


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

Resolves #7517
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)

Some select places that spawn vehicles, did not set the vehicle faction when applicable.
Make it so vehicles are assigned to the interacting party faction when spawned.
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered

## Testing

* Create Vehicle from construction menu
* Immediately interact with it with `e` and try renaming it

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.