### PR TITLE
fix(UI): Worn clothing conflicts to be displayed on all pages of `+` menu

### DIFF
--- a/src/armor_layers.cpp
+++ b/src/armor_layers.cpp
@@ -78,9 +78,6 @@ item_penalties get_item_penalties( const location_vector<item>::const_iterator &
     std::vector<std::set<std::string>> lists_of_bad_items_within;
 
     for( const bodypart_id &bp : c.get_all_body_parts() ) {
-        if( _bp->token && _bp.id().is_null() ) {
-            continue;
-        }
         if( !worn_item->covers( bp ) ) {
             continue;
         }


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
In `+` menu, worn clothing conflicts are only displayed for non-default pages (Torso, Arms, etc).
This is not great as the default menu should provide you with correct overview of your current wearables.

I have it on my wishlist #7462, so didn't create an additional bug for it.

## Describe the solution (The How)
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/9d91e418103e04fc4562a9b158543aaedb4b4ae1/src/armor_layers.cpp#L81
For unknown reasons, this loop completely skips checks for conflicts if page is All (i.e. null). 
I've read through the code and tried to figure out why this loop is being skipped in that case, but I don't see any reason for it.

## Describe alternatives you've considered
n/a
## Testing
spawned a player with two faux coats, checked without the changes, checked with the changes.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

