### PR TITLE
fix: ensure items are falling when dropped from roofs or flying vehicles

### DIFF
--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -735,6 +735,8 @@ void drop_activity_actor::do_turn( player_activity &, Character &who )
     put_into_vehicle_or_drop( who, item_drop_reason::deliberate,
                               dropped, pos, force_ground );
 
+    get_map().process_falling();
+
     if( items.empty() ) {
         who.cancel_activity();
     }


### PR DESCRIPTION
## Purpose of change (The Why)

- fixes #7519
- fixes #7520

When items were dropped, they were marked as 'dirty' for falling checks but only processed during the next turn's `process_falling()` call. This caused items to appear floating in air when dropped from roofs or flying vehicles.

## Describe the solution (The How)

Process falling immediately after dropping items to ensure they fall if there's no support.

## Testing

### on roof

https://github.com/user-attachments/assets/1f7bfab6-ff64-41cc-9634-35b3a62530b8

### from flying vehicle

https://github.com/user-attachments/assets/495359e0-2ac2-4c9b-b23c-ed0f72bac321

## Additional context

thx claude 4.5 sonnet for investigation

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
