### PR TITLE
fix: e-ink tablet now uses 10 charges per book scanned

### DIFF
--- a/data/mods/ebook_lua/main.lua
+++ b/data/mods/ebook_lua/main.lua
@@ -191,7 +191,7 @@ mod.ebook_scan = function(user, device)
               if count2 >= dev_limit then break end
             end
             gapi.add_msg(MsgType.good, string.format(locale.gettext("You scanned %d book(s)."), dev_limit))
-            return dev_limit
+            return dev_limit * 10
           else --selected NO
             return -1
           end
@@ -200,7 +200,7 @@ mod.ebook_scan = function(user, device)
             mod.insert_lib2(device, t_str)
           end
           gapi.add_msg(MsgType.good, string.format(locale.gettext("You scanned %d book(s)."), num_found))
-          return num_found
+          return num_found * 10
         end
       else --selected Cancel or pressed ESC
         return -1


### PR DESCRIPTION
## Purpose of change (The Why)

Fixes #7505.

## Describe the solution (The How)

scanning function now returns book_count * 10 to properly consume 10 charges per book instead of 1 charge per book.

## Testing

https://github.com/user-attachments/assets/94533631-0e6e-47e0-83a9-72548c17ea5d

## Additional context

fixed with claude 4.5 sonnet

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
