### PR TITLE
fix: remove smoke effects from .44 smokeless paper rounds

### DIFF
--- a/data/json/items/ammo/44paper.json
+++ b/data/json/items/ammo/44paper.json
@@ -28,6 +28,6 @@
     "copy-from": "44army",
     "ammo_type": "44paper",
     "relative": { "damage": { "damage_type": "bullet", "amount": 5, "armor_penetration": 5 } },
-    "delete": { "flags": [ "BLACKPOWDER", "MUZZLE_SMOKE" ] }
+    "delete": { "effects": [ "BLACKPOWDER", "MUZZLE_SMOKE" ] }
   }
 ]


### PR DESCRIPTION
## Purpose of change (The Why)

Fixes #7500

## Describe the solution (The How)

Changed 'delete: flags' to 'delete: effects' 

## Testing

1. spawn lemat revolver
2. refill it with smokeless .44 paper rounds
3. fire it
4. no smokes are created

## Checklist


### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
