### PR TITLE
fix: make huge mana crystals mineable

### DIFF
--- a/data/mods/MagicalNights/furniture.json
+++ b/data/mods/MagicalNights/furniture.json
@@ -167,7 +167,7 @@
     "coverage": 75,
     "required_str": -1,
     "looks_like": "f_boulder_large",
-    "flags": [ "TRANSPARENT", "EMITTER" ],
+    "flags": [ "TRANSPARENT", "EMITTER", "MINEABLE" ],
     "emissions": [ "emit_glimmer" ],
     "light_emitted": 12,
     "bash": {


### PR DESCRIPTION
## Purpose of change (The Why)

Fixes #7492

## Testing

https://github.com/user-attachments/assets/ed91c3ac-47ed-4a6a-8171-379dfa12f686

1. spawn huge mana crystal
2. spawn pickaxe
3. it's mineable

## Checklist


### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
