### PR TITLE
fix: allow xlframe as component for foldframe recipe

### DIFF
--- a/data/json/recipes/other/vehicles.json
+++ b/data/json/recipes/other/vehicles.json
@@ -1146,7 +1146,7 @@
     "reversible": true,
     "autolearn": true,
     "using": [ [ "welding_standard", 6 ] ],
-    "components": [ [ [ "pipe", 4 ] ] ]
+    "components": [ [ [ "pipe", 4 ], [ "xlframe", 1 ] ] ]
   },
   {
     "type": "recipe",


### PR DESCRIPTION
## Purpose of change (The Why)

Fixes #7335

## Testing
<img width="1410" height="850" alt="image" src="https://github.com/user-attachments/assets/538c10cb-5719-4b78-bc66-8eb2a879fdd5" />

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
