### PR TITLE
fix: ankle sheath can now be used with hooves

### DIFF
--- a/data/json/items/armor/sheath.json
+++ b/data/json/items/armor/sheath.json
@@ -81,7 +81,7 @@
       "draw_cost": 150,
       "flags": [ "SHEATH_KNIFE" ]
     },
-    "flags": [ "BELTED", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS", "WATER_FRIENDLY" ]
+    "flags": [ "BELTED", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS", "WATER_FRIENDLY", "ALLOWS_HOOVES" ]
   },
   {
     "id": "wristsheath",


### PR DESCRIPTION
## Purpose of change (The Why)
> Possibly dumb question: is there a reason the ankle holster and ankle magazine pouch can be worn with foot mutations, while the ankle sheath cannot?

## Describe the solution (The How)
Add ALLOWS_HOOVES flag to ankle sheath

## Describe alternatives you've considered
Remove the flag from the other two

## Testing
Eyes

## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.