### PR TITLE
fix(i18n): translate unread book recipes

### DIFF
--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -805,7 +805,7 @@ static void skim_book_msg( const item &book, avatar &u )
         if( elem.is_hidden() && !u.knows_recipe( elem.recipe ) ) {
             continue;
         }
-        recipe_list.push_back( elem.name );
+        recipe_list.push_back( elem.name.translated() );
     }
     if( !recipe_list.empty() ) {
         std::string recipe_line =

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -3167,9 +3167,9 @@ void item::book_info( std::vector<iteminfo> &info, const iteminfo_query *parts, 
             const std::string name = elem.recipe->result_name();
             recipe_list.push_back( "<bold>" + name + "</bold>" );
         } else if( !can_learn ) {
-            recipe_list.push_back( "<color_brown>" + elem.name + "</color>" );
+            recipe_list.push_back( "<color_brown>" + elem.name.translated() + "</color>" );
         } else {
-            recipe_list.push_back( "<dark>" + elem.name + "</dark>" );
+            recipe_list.push_back( "<dark>" + elem.name.translated() + "</dark>" );
         }
     }
 

--- a/src/itype.h
+++ b/src/itype.h
@@ -390,7 +390,7 @@ struct islot_book {
         /**
          * The name for the recipe as it appears in the book.
          */
-        std::string name;
+        translation name;
         /**
          * Hidden means it does not show up in the description of the book.
          */

--- a/src/recipe_dictionary.cpp
+++ b/src/recipe_dictionary.cpp
@@ -449,8 +449,13 @@ void recipe_dictionary::finalize()
 
         for( const auto &bk : r.booksets ) {
             const itype *booktype = &*bk.first;
-            int req = bk.second > 0 ? bk.second : std::max( booktype->book->req, r.difficulty );
-            islot_book::recipe_with_description_t desc{ &r, req, r.result_name(), false };
+            const int req = bk.second > 0 ? bk.second : std::max( booktype->book->req, r.difficulty );
+            const auto desc = islot_book::recipe_with_description_t {
+                .recipe = &r,
+                .skill_level = req,
+                .name = translation::to_translation( r.result_name() ),
+                .hidden = false
+            };
             const_cast<islot_book &>( *booktype->book ).recipes.insert( desc );
         }
 

--- a/tests/reading_test.cpp
+++ b/tests/reading_test.cpp
@@ -409,6 +409,22 @@ TEST_CASE( "Learning recipes from books", "[reading][book][recipe]" )
     }
 }
 
+TEST_CASE( "Book recipe entries expose translations", "[reading][book][translation]" )
+{
+    clear_all_state();
+
+    detached_ptr<item> det = item::spawn( "recipe_alpha" );
+    const item &alpha = *det;
+
+    REQUIRE( alpha.type->book );
+    const islot_book::recipe_list_t &book_recipes = alpha.type->book->recipes;
+
+    REQUIRE_FALSE( book_recipes.empty() );
+    const islot_book::recipe_with_description_t &entry = *book_recipes.begin();
+
+    CHECK_FALSE( entry.name.translated().empty() );
+}
+
 static void destroyed_book_test_helper( avatar &u, item *loc )
 {
     std::vector<std::string> reasons_cant_read;


### PR DESCRIPTION
## Purpose of change (The Why)

- fixes #3129

## Describe the solution (The How)

used olanti's solution in https://github.com/cataclysmbnteam/Cataclysm-BN/issues/3129#issuecomment-1712994940

## Testing

| before | after |
| - | - |
|<img width="1410" height="1570" alt="image" src="https://github.com/user-attachments/assets/d229834b-cea2-4156-9daf-d889285d9c91" /> | <img width="1410" height="1570" alt="image" src="https://github.com/user-attachments/assets/ba877fd4-7c55-4408-a198-40c959e558cf" /> |

1. set language to English 
2. install [item_translation_error_reproduction.zip](https://github.com/user-attachments/files/23757553/item_translation_error_reproduction.zip) mod
3. spawn `streetfighter's sidekick`
4. check that unlearned recipes are translated

## Additional context

_gpt-5-codex so slow, will not use again_

## Checklist


### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
