### PR TITLE
feat(mods/MagicalNights,balance): buff wizard tower magic recipe book spawns

### DIFF
--- a/data/mods/MagicalNights/itemgroups/itemgroups.json
+++ b/data/mods/MagicalNights/itemgroups/itemgroups.json
@@ -116,11 +116,12 @@
     "//": "Stuff you would find in an average wizard's workshop or other place where someone stores magical goodies.",
     "subtype": "collection",
     "items": [
-      { "group": "tools_common", "prob": 60 },
+      { "group": "tools_common", "prob": 40 },
       { "group": "jewelry_safe", "prob": 10 },
       { "group": "jewelry_front", "prob": 8 },
       { "group": "potions_common", "prob": 15 },
       { "group": "magical_reagents", "prob": 20 },
+      { "group": "magic_recipe_basic", "prob": 20 },
       {
         "distribution": [
           { "group": "enchanted_wands_lesser", "prob": 15 },
@@ -132,7 +133,6 @@
         ],
         "prob": 15
       },
-      { "item": "bone_human", "prob": 60, "count-min": 1, "count-max": 5 },
       [ "toolbox", 10 ]
     ]
   },

--- a/data/mods/MagicalNights/worldgen/wizard-towers.json
+++ b/data/mods/MagicalNights/worldgen/wizard-towers.json
@@ -149,7 +149,11 @@
         { "item": "allclothes", "chance": 10, "repeat": [ 1, 3 ] },
         { "item": "enchanted_misc", "chance": 25 }
       ],
-      "b": [ { "item": "novels", "chance": 50, "repeat": [ 1, 15 ] }, { "item": "homebooks", "chance": 25, "repeat": [ 1, 5 ] } ],
+      "b": [
+        { "item": "novels", "chance": 50, "repeat": [ 1, 15 ] },
+        { "item": "homebooks", "chance": 25, "repeat": [ 1, 5 ] },
+        { "item": "mansion_books", "chance": 15, "repeat": [ 1, 3 ] }
+      ],
       "B": { "item": "bed", "chance": 20 },
       "c": { "item": "kitchen_counters", "chance": 5, "repeat": [ 1, 3 ] },
       "C": { "item": "snacks", "chance": 10, "repeat": [ 1, 2 ] },
@@ -159,7 +163,7 @@
       "F": [ { "item": "SUS_fridge", "chance": 95 }, { "item": "potions_common", "chance": 25, "repeat": [ 1, 3 ] } ],
       "i": [ { "item": "SUS_office_filing_cabinet", "chance": 30 }, { "item": "office", "chance": 50, "repeat": [ 1, 4 ] } ],
       "I": { "item": "SUS_dishwasher", "chance": 50 },
-      "m": { "item": "magic_tools_and_loot", "chance": 60 },
+      "m": { "item": "magic_tools_and_loot", "chance": 60, "repeat": [ 1, 3 ] },
       "o": { "item": "SUS_oven", "chance": 70 },
       "r": { "item": "a_television", "chance": 100 },
       "R": { "item": "shoes", "chance": 20, "repeat": [ 1, 4 ] },
@@ -167,7 +171,7 @@
       "V": [
         { "item": "tools_general", "chance": 60, "repeat": [ 1, 3 ] },
         { "item": "mischw", "chance": 10 },
-        { "item": "magic_tools_and_loot", "chance": 20 }
+        { "item": "magic_tools_and_loot", "chance": 30, "repeat": [ 1, 3 ] }
       ],
       "Y": [ { "item": "coat_rack", "chance": 70 }, { "item": "magic_shop_clothes", "chance": 60 } ],
       "1": [ { "item": "SUS_dishes", "chance": 100 }, { "item": "SUS_kitchen_misc", "chance": 100 } ],
@@ -177,7 +181,7 @@
       "5": { "item": "SUS_kitchen_sink", "chance": 100 },
       "6": { "item": "SUS_pantry", "chance": 100 },
       "7": [ { "item": "SUS_breakfast_cupboard", "chance": 50 }, { "item": "SUS_coffee_cupboard", "chance": 50 } ],
-      "8": [ { "item": "homebooks", "chance": 45, "repeat": [ 1, 5 ] }, { "item": "spellbook_loot_1", "chance": 20 } ],
+      "8": [ { "item": "homebooks", "chance": 45, "repeat": [ 1, 5 ] }, { "item": "spellbook_loot_1", "chance": 30 } ],
       "9": [
         { "item": "homebooks", "chance": 45, "repeat": [ 1, 5 ] },
         { "item": "spellbook_loot_1", "chance": 40 },


### PR DESCRIPTION
## Purpose of change (The Why)

Getting magical recipe books sucked and people really wanted me to buff the rates

## Describe the solution (The How)

- Added basic recipe books to `magic_tools_and_loot`
- Buffed the rates of items from `magic_tools_and_loot` spawning in wizard towers
- Added mansion books itemgroup to normal bookshelf spawns in the towers for a small chance at cool books
- Also slightly buffed spellbook spawns for good measure

## Describe alternatives you've considered

- Customize the itemgroups further

## Testing

The game doesn't yell at me (for this change at least), it lints, and the books seem to show up often enough.

## Additional context

I did discover a tiny PR for later in this

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
