### PR TITLE
perf(UI): add `maximum rendered explosions per turn` option

### DIFF
--- a/src/explosion_queue.h
+++ b/src/explosion_queue.h
@@ -51,6 +51,7 @@ class explosion_queue
 {
     private:
         std::deque<queued_explosion> elems;
+        int explosion_count = 0;
 
     public:
         void add( queued_explosion &&exp ) {
@@ -60,6 +61,8 @@ class explosion_queue
         void execute();
 
         void clear() { elems.clear(); }
+
+        auto get_count() const -> int { return explosion_count; }
 };
 
 explosion_queue &get_explosion_queue();

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1937,6 +1937,14 @@ void options_manager::add_options_graphics()
 
     get_option( "ANIMATION_DELAY" ).setPrerequisite( "ANIMATIONS" );
 
+    add( "SKIP_EXPLOSION_ANIMATION_AFTER", graphics,
+         translate_marker( "Maximum rendered explosions per turn" ),
+         translate_marker( "Skip rendering explosions after this many count per turn to prevent softlocks from chain reactions. Set to 0 to disable." ),
+         0, 100, 10
+       );
+
+    get_option( "SKIP_EXPLOSION_ANIMATION_AFTER" ).setPrerequisite( "ANIMATIONS" );
+
     add( "BULLETS_AS_LASERS", graphics, translate_marker( "Draw bullets as lines" ),
          translate_marker( "If true, bullets are drawn as lines of images, and the animation lasts only one frame." ),
          false


### PR DESCRIPTION

## Purpose of change (The Why)

<img width="1410" height="850" alt="image" src="https://github.com/user-attachments/assets/20452a52-a4bc-4e96-86c0-ea0207c3a4fe" />

fixes #7222

## Describe the solution (The How)

skips rendering explosion after specified times that is configurable on options.

## Testing

- Animations: True
- Animation delay: 3
- Made of explodium: 1

### Maximum rendered explosions per turn: 0 (disabled, previous behavior)

https://github.com/user-attachments/assets/4f157c8f-89e1-4015-8815-8bf53d9705f1

### Maximum rendered explosions per turn: 10

https://github.com/user-attachments/assets/4a1d0000-daec-40fc-93ee-4ecfca255d85


## Checklist


### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
