### PR TITLE
feat(UI): prioritize reachable targets on aiming 

### DIFF
--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -2891,8 +2891,14 @@ void target_ui::update_target_list()
         targets = ranged::targetable_creatures( *you, range );
     }
 
-    std::sort( targets.begin(), targets.end(), [&]( const Creature * lhs, const Creature * rhs ) {
-        return rl_dist_exact( lhs->pos(), you->pos() ) < rl_dist_exact( rhs->pos(), you->pos() );
+    map &here = get_map();
+    const auto player_pos = you->pos();
+
+    std::ranges::sort( targets, {}, [&]( const Creature * c ) -> std::tuple<bool, bool, int> {
+        const auto target_pos = c->pos();
+        const bool same_z = player_pos.z == target_pos.z;
+        const bool has_los = here.sees( player_pos, target_pos, range );
+        return { !has_los, !same_z, rl_dist_exact( target_pos, player_pos ) };
     } );
 }
 


### PR DESCRIPTION
## Purpose of change (The Why)

resolves #4279. mostly applies to debug clairvoyance artifact

## Describe the solution (The How)

prioritize targeting by following order
1. reachable (uses map.sees to ignore clairvoyance artifact)
2. same z-level (usu. you wanna shoot mobs that are visible-on-screen)
3. then by distance

## Testing

https://github.com/user-attachments/assets/62f3c016-dd86-4a72-9fd6-c3a14de4f3e2

works well without clairvoyance artifact too

## Additional context

driveby PRs using AI go brrrrrrrrrrr

## Checklist


### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
