### PR TITLE
feat: prospector profession, time travel scenario

### DIFF
--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -812,14 +812,29 @@
     "//": "one point for the skills, three points for the survival gear and useful items",
     "items": {
       "both": {
-        "items": [ "oil_lamp", "coffee_raw", "jerky", "hardtack", "dynamite", "shelter_kit", "pickaxe", "propick_alpha", "makeshift_hammer", "shovel_short", "socks_wool", "mocassins", "bandana", "technician_pants_gray", "bindle", "jacket_flannel", "backpack_leather", "straw_hat" ]
+        "items": [
+          "oil_lamp",
+          "coffee_raw",
+          "jerky",
+          "hardtack",
+          "dynamite",
+          "shelter_kit",
+          "pickaxe",
+          "propick_alpha",
+          "makeshift_hammer",
+          "shovel_short",
+          "socks_wool",
+          "mocassins",
+          "bandana",
+          "technician_pants_gray",
+          "bindle",
+          "jacket_flannel",
+          "backpack_leather",
+          "straw_hat"
+        ]
       }
     },
-    "skills": [
-      { "level": 3, "name": "survival" },
-      { "level": 2, "name": "swimming" },
-      { "level": 1, "name": "cooking" }
-    ],
+    "skills": [ { "level": 3, "name": "survival" }, { "level": 2, "name": "swimming" }, { "level": 1, "name": "cooking" } ],
     "traits": [ "ANTIJUNK", "STRONGSTOMACH", "UNSTYLISH" ]
   },
   {

--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -235,11 +235,7 @@
     "description": "A temporal distortion has hurled you into this collapsing world. You arrive carrying only the few items that mattered most to you - the things tied to who you are, or who you were meant to become.",
     "start_name": "Wilderness",
     "allowed_locs": [ "sloc_forest", "sloc_field" ],
-    "professions": [ 
-      "churl",
-      "prospector",
-      "knight"
-     ],
+    "professions": [ "churl", "prospector", "knight" ],
     "flags": [ "CHALLENGE", "LONE_START" ]
   },
   {


### PR DESCRIPTION
## Purpose of change (The Why)
The Medieval Peasant scenario is too limiting in scope, and reflavoring it as a generic time travel scenario allows for much more freedom in regards to profession additions to the scenario.
## Describe the solution (The How)
Renames "Challenge - Medieval Peasant" to "Challenge - Temporal Anomaly."

Adds a prospector profession, intended to be isekai'd from some time in the 1800s-1850s.
## Describe alternatives you've considered
Different name for the scenario?
Different clothing/gear for the prospector?
## Testing
Spawned in as a prospector. Seemed to work fine.
## Additional context
<img width="1636" height="1021" alt="image" src="https://github.com/user-attachments/assets/50809274-f014-443d-bb48-9d9904834aa7" />
<img width="164" height="190" alt="image" src="https://github.com/user-attachments/assets/d9df9b92-39c1-491d-92fc-2355b386d5c1" />


## Checklist

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.