### PR TITLE
fix(mods/aftershock): add missing robot disassembly recipes

### DIFF
--- a/data/mods/Aftershock/recipes/deconstruction/robot.json
+++ b/data/mods/Aftershock/recipes/deconstruction/robot.json
@@ -21,5 +21,500 @@
       [ [ "robot_controls", 1 ] ],
       [ [ "turret_chassis", 1 ] ]
     ]
+  },
+  {
+    "result": "broken_migoturret_whately",
+    "type": "uncraft",
+    "copy-from": "broken_afs_mon_migoturret",
+    "//": "Same as brain blaster but Whately family variant"
+  },
+  {
+    "result": "broken_utilibot",
+    "type": "uncraft",
+    "skill_used": "electronics",
+    "difficulty": 4,
+    "time": "1 h 30 m",
+    "using": [ [ "soldering_standard", 15 ], [ "welding_standard", 5 ] ],
+    "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "SAW_M", "level": 1 } ],
+    "components": [
+      [ [ "ai_module", 1 ] ],
+      [ [ "sensor_module", 1 ] ],
+      [ [ "memory_module", 1 ] ],
+      [ [ "pathfinding_module", 1 ] ],
+      [ [ "identification_module", 1 ] ],
+      [ [ "omni_wheel", 1 ] ],
+      [ [ "android_chassis", 1 ] ],
+      [ [ "android_arms", 1 ] ],
+      [ [ "power_supply", 3 ] ],
+      [ [ "medium_storage_battery", 1 ] ]
+    ]
+  },
+  {
+    "result": "broken_hazmatbot",
+    "type": "uncraft",
+    "copy-from": "broken_utilibot"
+  },
+  {
+    "result": "broken_utilibot_butler",
+    "type": "uncraft",
+    "copy-from": "broken_utilibot"
+  },
+  {
+    "result": "broken_utilibot_const",
+    "type": "uncraft",
+    "copy-from": "broken_utilibot",
+    "difficulty": 5,
+    "components": [
+      [ [ "ai_module", 1 ] ],
+      [ [ "sensor_module", 1 ] ],
+      [ [ "memory_module", 1 ] ],
+      [ [ "pathfinding_module", 1 ] ],
+      [ [ "identification_module", 1 ] ],
+      [ [ "omni_wheel", 1 ] ],
+      [ [ "android_chassis", 1 ] ],
+      [ [ "android_arms", 1 ] ],
+      [ [ "power_supply", 3 ] ],
+      [ [ "medium_storage_battery", 1 ] ],
+      [ [ "welder", 1 ] ],
+      [ [ "nailgun", 1 ] ],
+      [ [ "jackhammer", 1 ] ]
+    ]
+  },
+  {
+    "result": "broken_utilibot_fire",
+    "type": "uncraft",
+    "copy-from": "broken_utilibot",
+    "components": [
+      [ [ "ai_module", 1 ] ],
+      [ [ "sensor_module", 1 ] ],
+      [ [ "memory_module", 1 ] ],
+      [ [ "pathfinding_module", 1 ] ],
+      [ [ "identification_module", 1 ] ],
+      [ [ "omni_wheel", 1 ] ],
+      [ [ "android_chassis", 1 ] ],
+      [ [ "android_arms", 1 ] ],
+      [ [ "power_supply", 4 ] ],
+      [ [ "medium_storage_battery", 1 ] ],
+      [ [ "watercannon", 1 ] ]
+    ]
+  },
+  {
+    "result": "broken_utilibot_beehive",
+    "type": "uncraft",
+    "copy-from": "broken_utilibot",
+    "components": [
+      [ [ "ai_module", 1 ] ],
+      [ [ "sensor_module", 1 ] ],
+      [ [ "memory_module", 1 ] ],
+      [ [ "pathfinding_module", 1 ] ],
+      [ [ "identification_module", 1 ] ],
+      [ [ "omni_wheel", 1 ] ],
+      [ [ "android_chassis", 1 ] ],
+      [ [ "android_arms", 1 ] ],
+      [ [ "power_supply", 3 ] ],
+      [ [ "medium_storage_battery", 1 ] ],
+      [ [ "metal_tank_little", 2 ] ],
+      [ [ "crossbow", 1 ] ]
+    ]
+  },
+  {
+    "result": "broken_medibot",
+    "type": "uncraft",
+    "skill_used": "electronics",
+    "difficulty": 5,
+    "time": "2 h",
+    "using": [ [ "soldering_standard", 15 ], [ "welding_standard", 5 ] ],
+    "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "SAW_M", "level": 1 } ],
+    "components": [
+      [ [ "ai_module_advanced", 1 ] ],
+      [ [ "self_monitoring_module", 1 ] ],
+      [ [ "sensor_module", 1 ] ],
+      [ [ "memory_module", 1 ] ],
+      [ [ "pathfinding_module", 1 ] ],
+      [ [ "identification_module", 1 ] ],
+      [ [ "android_legs", 1 ] ],
+      [ [ "android_chassis", 1 ] ],
+      [ [ "android_arms", 1 ] ],
+      [ [ "medium_storage_battery", 1 ] ],
+      [ [ "scalpel", 2 ] ],
+      [ [ "syringe", 2 ] ]
+    ]
+  },
+  {
+    "result": "broken_skitterbot_rat",
+    "type": "uncraft",
+    "skill_used": "electronics",
+    "difficulty": 3,
+    "time": "1 h",
+    "using": [ [ "soldering_standard", 10 ] ],
+    "qualities": [ { "id": "SCREW", "level": 1 } ],
+    "components": [
+      [ [ "ai_module", 1 ] ],
+      [ [ "small_storage_battery", 1 ] ],
+      [ [ "scrap", 3 ] ],
+      [ [ "spidery_legs_small", 1 ] ],
+      [ [ "sensor_module", 1 ] ],
+      [ [ "memory_module", 1 ] ],
+      [ [ "pathfinding_module", 1 ] ],
+      [ [ "identification_module", 1 ] ],
+      [ [ "power_supply", 1 ] ],
+      [ [ "tazer", 1 ] ]
+    ]
+  },
+  {
+    "result": "broken_skitterbot_grab",
+    "type": "uncraft",
+    "copy-from": "broken_skitterbot_rat",
+    "components": [
+      [ [ "ai_module", 1 ] ],
+      [ [ "small_storage_battery", 1 ] ],
+      [ [ "scrap", 3 ] ],
+      [ [ "spidery_legs_small", 1 ] ],
+      [ [ "sensor_module", 1 ] ],
+      [ [ "memory_module", 1 ] ],
+      [ [ "pathfinding_module", 1 ] ],
+      [ [ "identification_module", 1 ] ],
+      [ [ "power_supply", 1 ] ]
+    ]
+  },
+  {
+    "result": "broken_skitterbot_hunter",
+    "type": "uncraft",
+    "copy-from": "broken_skitterbot_rat",
+    "components": [
+      [ [ "ai_module", 1 ] ],
+      [ [ "small_storage_battery", 1 ] ],
+      [ [ "scrap", 3 ] ],
+      [ [ "spidery_legs_small", 1 ] ],
+      [ [ "sensor_module", 1 ] ],
+      [ [ "memory_module", 1 ] ],
+      [ [ "pathfinding_module", 1 ] ],
+      [ [ "identification_module", 1 ] ],
+      [ [ "power_supply", 1 ] ],
+      [ [ "gun_module", 1 ] ],
+      [ [ "rm103a_pistol", 1 ] ]
+    ]
+  },
+  {
+    "result": "broken_eyebot_heater",
+    "type": "uncraft",
+    "skill_used": "electronics",
+    "difficulty": 2,
+    "time": "30 m",
+    "using": [ [ "soldering_standard", 3 ] ],
+    "qualities": [ { "id": "SCREW", "level": 1 } ],
+    "components": [
+      [ [ "ai_module", 1 ] ],
+      [ [ "identification_module", 1 ] ],
+      [ [ "pathfinding_module", 1 ] ],
+      [ [ "sensor_module", 1 ] ],
+      [ [ "memory_module", 1 ] ],
+      [ [ "small_storage_battery", 1 ] ],
+      [ [ "RAM", 1 ] ],
+      [ [ "processor", 1 ] ],
+      [ [ "scrap", 1 ] ],
+      [ [ "quad_rotors", 1 ] ],
+      [ [ "element", 4 ] ],
+      [ [ "sheet_metal_small", 12 ] ]
+    ]
+  },
+  {
+    "abstract": "broken_defbot_base",
+    "type": "uncraft",
+    "skill_used": "electronics",
+    "difficulty": 5,
+    "time": "1 h 30 m",
+    "using": [ [ "soldering_standard", 15 ], [ "welding_standard", 5 ] ],
+    "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "SAW_M", "level": 1 } ],
+    "components": [
+      [ [ "ai_module", 1 ] ],
+      [ [ "sensor_module", 1 ] ],
+      [ [ "memory_module", 1 ] ],
+      [ [ "pathfinding_module", 1 ] ],
+      [ [ "targeting_module", 1 ] ],
+      [ [ "identification_module", 1 ] ],
+      [ [ "omni_wheel", 1 ] ],
+      [ [ "copbot_chassis", 1 ] ],
+      [ [ "power_supply", 4 ] ],
+      [ [ "solar_cell", 2 ] ]
+    ]
+  },
+  {
+    "result": "broken_defbot_disarmed",
+    "type": "uncraft",
+    "copy-from": "broken_defbot_base"
+  },
+  {
+    "result": "broken_defbot_shot",
+    "type": "uncraft",
+    "copy-from": "broken_defbot_base",
+    "components": [
+      [ [ "ai_module", 1 ] ],
+      [ [ "sensor_module", 1 ] ],
+      [ [ "memory_module", 1 ] ],
+      [ [ "pathfinding_module", 1 ] ],
+      [ [ "targeting_module", 1 ] ],
+      [ [ "identification_module", 1 ] ],
+      [ [ "omni_wheel", 1 ] ],
+      [ [ "copbot_chassis", 1 ] ],
+      [ [ "gun_module", 1 ] ],
+      [ [ "power_supply", 4 ] ],
+      [ [ "solar_cell", 2 ] ],
+      [ [ "m1014", 1 ] ],
+      [ [ "tazer", 1 ] ]
+    ]
+  },
+  {
+    "abstract": "broken_milbot_base",
+    "type": "uncraft",
+    "skill_used": "electronics",
+    "difficulty": 6,
+    "time": "2 h",
+    "using": [ [ "soldering_standard", 20 ], [ "welding_standard", 5 ] ],
+    "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "SAW_M", "level": 1 } ],
+    "components": [
+      [ [ "ai_module", 1 ] ],
+      [ [ "sensor_module", 1 ] ],
+      [ [ "memory_module", 1 ] ],
+      [ [ "pathfinding_module", 1 ] ],
+      [ [ "targeting_module", 1 ] ],
+      [ [ "identification_module", 1 ] ],
+      [ [ "omni_wheel", 1 ] ],
+      [ [ "copbot_chassis", 1 ] ],
+      [ [ "power_supply", 5 ] ],
+      [ [ "plut_cell", 1 ] ]
+    ]
+  },
+  {
+    "result": "broken_milbot_disarmed",
+    "type": "uncraft",
+    "copy-from": "broken_milbot_base"
+  },
+  {
+    "result": "broken_milbot_556",
+    "type": "uncraft",
+    "copy-from": "broken_milbot_base",
+    "components": [
+      [ [ "ai_module", 1 ] ],
+      [ [ "sensor_module", 1 ] ],
+      [ [ "memory_module", 1 ] ],
+      [ [ "pathfinding_module", 1 ] ],
+      [ [ "targeting_module", 1 ] ],
+      [ [ "identification_module", 1 ] ],
+      [ [ "omni_wheel", 1 ] ],
+      [ [ "copbot_chassis", 1 ] ],
+      [ [ "gun_module", 1 ] ],
+      [ [ "power_supply", 5 ] ],
+      [ [ "plut_cell", 1 ] ],
+      [ [ "acr", 1 ] ],
+      [ [ "tazer", 1 ] ]
+    ]
+  },
+  {
+    "result": "broken_milbot_308",
+    "type": "uncraft",
+    "copy-from": "broken_milbot_base",
+    "components": [
+      [ [ "ai_module", 1 ] ],
+      [ [ "sensor_module", 1 ] ],
+      [ [ "memory_module", 1 ] ],
+      [ [ "pathfinding_module", 1 ] ],
+      [ [ "targeting_module", 1 ] ],
+      [ [ "identification_module", 1 ] ],
+      [ [ "omni_wheel", 1 ] ],
+      [ [ "copbot_chassis", 1 ] ],
+      [ [ "gun_module", 1 ] ],
+      [ [ "power_supply", 5 ] ],
+      [ [ "plut_cell", 1 ] ],
+      [ [ "fn_fal", 1 ] ],
+      [ [ "tazer", 1 ] ]
+    ]
+  },
+  {
+    "result": "broken_milbot_8x40mm",
+    "type": "uncraft",
+    "copy-from": "broken_milbot_base",
+    "components": [
+      [ [ "ai_module", 1 ] ],
+      [ [ "sensor_module", 1 ] ],
+      [ [ "memory_module", 1 ] ],
+      [ [ "pathfinding_module", 1 ] ],
+      [ [ "targeting_module", 1 ] ],
+      [ [ "identification_module", 1 ] ],
+      [ [ "omni_wheel", 1 ] ],
+      [ [ "copbot_chassis", 1 ] ],
+      [ [ "gun_module", 1 ] ],
+      [ [ "power_supply", 5 ] ],
+      [ [ "plut_cell", 1 ] ],
+      [ [ "rm2000_smg", 1 ] ],
+      [ [ "tazer", 1 ] ]
+    ]
+  },
+  {
+    "result": "broken_milbot_needle",
+    "type": "uncraft",
+    "copy-from": "broken_milbot_base",
+    "components": [
+      [ [ "ai_module", 1 ] ],
+      [ [ "sensor_module", 1 ] ],
+      [ [ "memory_module", 1 ] ],
+      [ [ "pathfinding_module", 1 ] ],
+      [ [ "targeting_module", 1 ] ],
+      [ [ "identification_module", 1 ] ],
+      [ [ "omni_wheel", 1 ] ],
+      [ [ "copbot_chassis", 1 ] ],
+      [ [ "gun_module", 1 ] ],
+      [ [ "power_supply", 5 ] ],
+      [ [ "plut_cell", 1 ] ],
+      [ [ "needlegun", 1 ] ],
+      [ [ "tazer", 1 ] ]
+    ]
+  },
+  {
+    "result": "broken_milbot_40mm",
+    "type": "uncraft",
+    "copy-from": "broken_milbot_base",
+    "components": [
+      [ [ "ai_module", 1 ] ],
+      [ [ "sensor_module", 1 ] ],
+      [ [ "memory_module", 1 ] ],
+      [ [ "pathfinding_module", 1 ] ],
+      [ [ "targeting_module", 1 ] ],
+      [ [ "identification_module", 1 ] ],
+      [ [ "omni_wheel", 1 ] ],
+      [ [ "copbot_chassis", 1 ] ],
+      [ [ "gun_module", 1 ] ],
+      [ [ "power_supply", 5 ] ],
+      [ [ "plut_cell", 1 ] ],
+      [ [ "m320", 1 ] ],
+      [ [ "tazer", 1 ] ]
+    ]
+  },
+  {
+    "result": "broken_milbot_flame",
+    "type": "uncraft",
+    "copy-from": "broken_milbot_base",
+    "components": [
+      [ [ "ai_module", 1 ] ],
+      [ [ "sensor_module", 1 ] ],
+      [ [ "memory_module", 1 ] ],
+      [ [ "pathfinding_module", 1 ] ],
+      [ [ "targeting_module", 1 ] ],
+      [ [ "identification_module", 1 ] ],
+      [ [ "omni_wheel", 1 ] ],
+      [ [ "copbot_chassis", 1 ] ],
+      [ [ "gun_module", 1 ] ],
+      [ [ "power_supply", 5 ] ],
+      [ [ "plut_cell", 1 ] ],
+      [ [ "flamethrower", 1 ] ],
+      [ [ "tazer", 1 ] ]
+    ]
+  },
+  {
+    "abstract": "broken_advbot_base",
+    "type": "uncraft",
+    "skill_used": "electronics",
+    "difficulty": 7,
+    "time": "2 h 30 m",
+    "using": [ [ "soldering_standard", 25 ], [ "welding_standard", 10 ] ],
+    "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "SAW_M", "level": 1 } ],
+    "components": [
+      [ [ "ai_module_advanced", 1 ] ],
+      [ [ "self_monitoring_module", 1 ] ],
+      [ [ "sensor_module", 1 ] ],
+      [ [ "memory_module", 1 ] ],
+      [ [ "pathfinding_module", 1 ] ],
+      [ [ "targeting_module", 1 ] ],
+      [ [ "identification_module", 1 ] ],
+      [ [ "omni_wheel", 1 ] ],
+      [ [ "copbot_chassis", 1 ] ],
+      [ [ "power_supply", 5 ] ],
+      [ [ "plut_cell", 2 ] ]
+    ]
+  },
+  {
+    "result": "broken_advbot_disarmed",
+    "type": "uncraft",
+    "copy-from": "broken_advbot_base"
+  },
+  {
+    "result": "broken_advbot_laser",
+    "type": "uncraft",
+    "copy-from": "broken_advbot_base",
+    "components": [
+      [ [ "ai_module_advanced", 1 ] ],
+      [ [ "self_monitoring_module", 1 ] ],
+      [ [ "sensor_module", 1 ] ],
+      [ [ "memory_module", 1 ] ],
+      [ [ "pathfinding_module", 1 ] ],
+      [ [ "targeting_module", 1 ] ],
+      [ [ "identification_module", 1 ] ],
+      [ [ "omni_wheel", 1 ] ],
+      [ [ "copbot_chassis", 1 ] ],
+      [ [ "gun_module", 1 ] ],
+      [ [ "power_supply", 5 ] ],
+      [ [ "plut_cell", 2 ] ],
+      [ [ "laser_rifle", 1 ] ]
+    ]
+  },
+  {
+    "result": "broken_advbot_plasma",
+    "type": "uncraft",
+    "copy-from": "broken_advbot_base",
+    "components": [
+      [ [ "ai_module_advanced", 1 ] ],
+      [ [ "self_monitoring_module", 1 ] ],
+      [ [ "sensor_module", 1 ] ],
+      [ [ "memory_module", 1 ] ],
+      [ [ "pathfinding_module", 1 ] ],
+      [ [ "targeting_module", 1 ] ],
+      [ [ "identification_module", 1 ] ],
+      [ [ "omni_wheel", 1 ] ],
+      [ [ "copbot_chassis", 1 ] ],
+      [ [ "gun_module", 1 ] ],
+      [ [ "power_supply", 5 ] ],
+      [ [ "plut_cell", 2 ] ],
+      [ [ "plasma_ejector", 1 ] ]
+    ]
+  },
+  {
+    "result": "broken_advbot_rail",
+    "type": "uncraft",
+    "copy-from": "broken_advbot_base",
+    "components": [
+      [ [ "ai_module_advanced", 1 ] ],
+      [ [ "self_monitoring_module", 1 ] ],
+      [ [ "sensor_module", 1 ] ],
+      [ [ "memory_module", 1 ] ],
+      [ [ "pathfinding_module", 1 ] ],
+      [ [ "targeting_module", 1 ] ],
+      [ [ "identification_module", 1 ] ],
+      [ [ "omni_wheel", 1 ] ],
+      [ [ "copbot_chassis", 1 ] ],
+      [ [ "gun_module", 1 ] ],
+      [ [ "power_supply", 5 ] ],
+      [ [ "plut_cell", 2 ] ],
+      [ [ "railgun", 1 ] ]
+    ]
+  },
+  {
+    "result": "broken_advbot_emp",
+    "type": "uncraft",
+    "copy-from": "broken_advbot_base",
+    "components": [
+      [ [ "ai_module_advanced", 1 ] ],
+      [ [ "self_monitoring_module", 1 ] ],
+      [ [ "sensor_module", 1 ] ],
+      [ [ "memory_module", 1 ] ],
+      [ [ "pathfinding_module", 1 ] ],
+      [ [ "targeting_module", 1 ] ],
+      [ [ "identification_module", 1 ] ],
+      [ [ "omni_wheel", 1 ] ],
+      [ [ "copbot_chassis", 1 ] ],
+      [ [ "gun_module", 1 ] ],
+      [ [ "power_supply", 5 ] ],
+      [ [ "plut_cell", 2 ] ],
+      [ [ "emp_gun", 1 ] ]
+    ]
   }
 ]


### PR DESCRIPTION
## Purpose of change (The Why)

Closes #5918

## Describe the solution (The How)

gave AI (claude 4.5 opus) relevant context to produce missing uncrafts. i'm no balance expert but generated uncrafts generally seemed to be in line with their recipes (if exists)

## Describe alternatives you've considered

feel free to change the values

## Testing
<img width="1410" height="1570" alt="image" src="https://github.com/user-attachments/assets/27398afd-e458-48dc-b6c4-745932e95ca8" />

loads without issue

## Checklist


### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
