### PR TITLE
refactor(lua): rename `on_char_death` to `on_character_death`

### DIFF
--- a/data/mods/Test_for_Lua_hooks/main.lua
+++ b/data/mods/Test_for_Lua_hooks/main.lua
@@ -6,6 +6,7 @@ local mod = game.mod_runtime[game.current_mod]
 mod.chicken_death = function(params)
   local killed = params.mon
   local killer = params.killer
+  if killer == nil then return end
   if killer:is_avatar() then
     if killed:get_type():str() == "mon_chicken" then
       gdebug.log_info("Good job. You killed it.")

--- a/data/raw/generate_types.lua
+++ b/data/raw/generate_types.lua
@@ -324,7 +324,7 @@ on_mapgen_postprocess = {}
 
 ---@class OnMonDeathParams
 ---@field mon Monster
----@field killer Character
+---@field killer Character?
 on_mon_death = {}
 ]]
 

--- a/docs/en/mod/lua/reference/lua.md
+++ b/docs/en/mod/lua/reference/lua.md
@@ -6662,6 +6662,7 @@ Function `( Volume, Volume ) -> bool`
 - `MATT_FOLLOW` = `5`
 - `MATT_ATTACK` = `6`
 - `MATT_ZLAVE` = `7`
+- `MATT_UNKNOWN` = `8`
 
 ## MonsterFactionAttitude
 
@@ -7166,7 +7167,7 @@ Function `()`
 Called when character stat gets reset
 Function `()`
 
-#### on_char_death
+#### on_character_death
 
 Called when a character is dead
 Function `()`

--- a/lua_annotations.lua
+++ b/lua_annotations.lua
@@ -25,7 +25,7 @@ on_mapgen_postprocess = {}
 
 ---@class OnMonDeathParams
 ---@field mon Monster
----@field killer Character
+---@field killer Character?
 on_mon_death = {}
 --================---- Classes ----================
 
@@ -1845,8 +1845,8 @@ gdebug = {}
 
 --- Documentation for hooks
 ---@class hooks
+---@field on_character_death fun() @Called when a character is dead
 ---@field on_character_reset_stats fun() @Called when character stat gets reset
----@field on_char_death fun() @Called when a character is dead
 ---@field on_creature_blocked fun() @Called when a character successfully blocks
 ---@field on_creature_dodged fun() @Called when a character successfully dodges
 ---@field on_creature_melee_attacked fun() @Called after a character has attacked in melee
@@ -2131,7 +2131,8 @@ MonsterAttitude = {
 	MATT_IGNORE = 4,
 	MATT_FOLLOW = 5,
 	MATT_ATTACK = 6,
-	MATT_ZLAVE = 7
+	MATT_ZLAVE = 7,
+	MATT_UNKNOWN = 8
 }
 
 ---@enum MonsterFactionAttitude

--- a/src/catalua_bindings.cpp
+++ b/src/catalua_bindings.cpp
@@ -692,7 +692,7 @@ void cata::detail::reg_hooks_examples( sol::state &lua )
     DOC( "Called when character stat gets reset" );
     luna::set_fx( lib, "on_character_reset_stats", []() {} );
     DOC( "Called when a character is dead" );
-    luna::set_fx( lib, "on_char_death", []() {} );
+    luna::set_fx( lib, "on_character_death", []() {} );
     DOC( "Called when a monster is dead" );
     luna::set_fx( lib, "on_mon_death", []() {} );
     DOC( "Called every in-game period" );

--- a/src/catalua_hooks.cpp
+++ b/src/catalua_hooks.cpp
@@ -11,7 +11,7 @@ constexpr auto hook_names = std::array
     "on_game_started",
     "on_character_reset_stats",
     "on_mon_death",
-    "on_char_death",
+    "on_character_death",
     "on_creature_dodged",
     "on_creature_blocked",
     "on_creature_performed_technique",

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -4192,7 +4192,7 @@ void Character::die( Creature *nkiller )
     }
     mission::on_creature_death( *this );
 
-    cata::run_hooks( "on_char_death", [ &, this]( auto & params ) {
+    cata::run_hooks( "on_character_death", [ &, this]( auto & params ) {
         params["char"] = this;
         params["killer"] = get_killer();
     } );


### PR DESCRIPTION
## Purpose of change (The Why)

Closes #7250

## Describe the solution (The How)

- also adds null check for `on_mon_death`

## Describe alternatives you've considered

this could be a breaking change but i think there's only single usage of on_char_death: https://github.com/graysonchao/CBN-Sky-Island (@graysonchao pls update)

## Testing

game loads without issues

## Checklist


### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

- [x] This PR modifies lua scripts or the lua API.
  - [x] I have added [`lua` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#lua%3A-changes-to-lua-api) to the PR title.
  - [x] I have added [type annotations](https://emmylua.github.io/annotation.html) to functions so that it's safe and easy to maintain.
  - [x] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
