### PR TITLE
fix(UI): simplify passive CBM examination instructions

### DIFF
--- a/src/bionics_ui.cpp
+++ b/src/bionics_ui.cpp
@@ -925,8 +925,8 @@ void show_bionics_ui( Character &who )
                     continue;
                 } else {
                     popup( _( "You can not activate %s!\n"
-                              "To read a description of %s, press '%s', then '%c'." ), bio_data.name,
-                           bio_data.name, ctxt.get_desc( "TOGGLE_EXAMINE" ), tmp->invlet );
+                              "To read a description of %s, press '%s'" ), bio_data.name,
+                           bio_data.name, ctxt.get_desc( "TOGGLE_EXAMINE" ) );
                 }
             } else if( menu_mode == EXAMINING ) {
                 // Describing bionics, allow user to jump to description key

--- a/src/mutation_ui.cpp
+++ b/src/mutation_ui.cpp
@@ -442,8 +442,8 @@ detail::mutations_ui_result detail::show_mutations_ui_internal( Character &who )
                             }
                         } else {
                             popup( _( "You cannot activate %s!  To read a description of "
-                                      "%s, press '!', then '%c'." ),
-                                   mut_data.name(), mut_data.name(), who.my_mutations[*mut_id].key );
+                                      "%s, press '!'." ),
+                                   mut_data.name(), mut_data.name() );
                         }
                         break;
                     }
@@ -607,8 +607,8 @@ detail::mutations_ui_result detail::show_mutations_ui_internal( Character &who )
                                 }
                             } else {
                                 popup( _( "You cannot activate %s!  To read a description of "
-                                          "%s, press '!', then '%c'." ),
-                                       mut_data.name(), mut_data.name(), who.my_mutations[mut_id].key );
+                                          "%s, press '!'." ),
+                                       mut_data.name(), mut_data.name() );
                             }
                             break;
                         }


### PR DESCRIPTION
## Purpose of change (The Why)

Fixes #7493

## Testing

<img width="1410" height="850" alt="image" src="https://github.com/user-attachments/assets/100e7fa0-df0a-4059-acf5-28b40b065536" />

## Checklist


### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

