### PR TITLE
feat: add dreams for rabbit mutation tree

### DIFF
--- a/data/json/dreams.json
+++ b/data/json/dreams.json
@@ -136,6 +136,12 @@
   },
   {
     "type": "dream",
+    "messages": [ "You have a strange dream about carrots.", "Your dreams give you a strange fuzzy, hopping feeling." ],
+    "category": "RABBIT",
+    "strength": 1
+  },
+  {
+    "type": "dream",
     "messages": [
       "You dream of a strange quest for a bush that grows gray apples.",
       "You feel like you're cracking a combination lock.",
@@ -317,6 +323,12 @@
     "type": "dream",
     "messages": [ "You dream of… sneaking.", "You dream of a cold winter night.  Your jacket is too big to put on." ],
     "category": "MOUSE",
+    "strength": 2
+  },
+  {
+    "type": "dream",
+    "messages": [ "You dream of nibbling on fresh carrots in a moonlit garden.", "You dream of digging a cozy burrow in soft earth." ],
+    "category": "RABBIT",
     "strength": 2
   },
   {
@@ -510,6 +522,15 @@
   },
   {
     "type": "dream",
+    "messages": [
+      "You have an unsettling dream where your ears twitch at every distant sound.",
+      "You dream of fleeing through tall grass, your powerful legs carrying you to safety."
+    ],
+    "category": "RABBIT",
+    "strength": 3
+  },
+  {
+    "type": "dream",
     "messages": [ "You are terrified by a dream of becoming an ape hybrid.", "You blissfully recall days spent lounging in the sun." ],
     "category": "LIZARD",
     "strength": 4
@@ -696,6 +717,15 @@
       "You hear the sirens again, but this time you stay in your hole in the wall.  Nobody will think to look there!"
     ],
     "category": "MOUSE",
+    "strength": 4
+  },
+  {
+    "type": "dream",
+    "messages": [
+      "You dream vividly of life as a rabbit, every sense alert for predators.",
+      "In your dream, you thump your foot in warning as a shadow passes overhead."
+    ],
+    "category": "RABBIT",
     "strength": 4
   },
   {


### PR DESCRIPTION
## Purpose of change (The Why)

Closes #6826

## Describe alternatives you've considered

feel free to change messages

## Testing

loads without issues.

## Additional context

this PR (and thus, dreams) is AI-generated (claude opus 4.5)

## Checklist


### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
