### PR TITLE
fix(mods/MagicalNights): remove `9x18` from m47a1 ammo

### DIFF
--- a/data/mods/MagicalNights/items/enchanted/enchanted_ranged.json
+++ b/data/mods/MagicalNights/items/enchanted/enchanted_ranged.json
@@ -13,7 +13,7 @@
     "material": [ "steel", "wood" ],
     "symbol": "(",
     "color": "dark_gray",
-    "ammo": [ "9mm", "9x18", "380", "357mag", "38" ],
+    "ammo": [ "9mm", "380", "357mag", "38" ],
     "ranged_damage": { "damage_type": "bullet", "amount": 0 },
     "dispersion": 558,
     "durability": 7,


### PR DESCRIPTION
## Purpose of change (The Why)

The mod currently throws evil red errors into the world loading process if you don't use Exotic Ammo

## Describe the solution (The How)

Remove 9x18 from the m47a1's list of ammo types

## Describe alternatives you've considered

- add Exotic Ammo as a dependency instead

Magical Nights doesn't really depend on it, and I don't think it makes sense to make such a dependency

## Testing

It's what the game complains about on loading my words, and it lints after the change.

## Additional context

The fact that no-one has complained is a sign that a lot of people are probably running Exotic Ammo already if they're running MN ;P

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
