### PR TITLE
fix(UI): prevent ledge prompt & sinking when walking off a ladder

### DIFF
--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -443,9 +443,13 @@ bool avatar_action::move( avatar &you, map &m, const tripoint &d )
         return true;
     }
 
-    // Ladder
+    // Ladder - only try to climb up if:
+    // 1. Standing on a ladder
+    // 2. The destination at current z-level is impassable (blocked by something)
+    // 3. There's a valid destination above
     if( !is_riding
         && m.has_flag( flag_LADDER, you.pos() )
+        && !m.passable( dest_loc )
         && g->walk_move( dest_loc + tripoint_above ) ) {
         return true;
     }


### PR DESCRIPTION
## Purpose of change (The Why)

fixes #7453

## Describe the solution (The How)

The game tried to _always_ move up a tile when moving off a ladder, even when the floor in question was passable.

can't believe I spent like 3 hours preoccupied with going _down_ when it has always been going _up_.

## Describe alternatives you've considered

cri

## Testing

https://github.com/user-attachments/assets/226a2b3b-5c49-4698-a3d3-44712b91030e

## Additional context

who will moan for my 10 premium requests that lay waste?

## Checklist


### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
