### PR TITLE
fix: use explicit integer types for LUNA_DOC primitives

### DIFF
--- a/src/catalua_luna_doc.h
+++ b/src/catalua_luna_doc.h
@@ -92,10 +92,12 @@ using volume = quantity<int, volume_in_milliliter_tag>;
 
 // These definitions help the doc generator
 LUNA_DOC( bool, "bool" );
-LUNA_DOC( int, "int" );
-LUNA_DOC( unsigned int, "int" );
+LUNA_DOC( std::int16_t, "int" );
+LUNA_DOC( std::uint16_t, "int" );
+LUNA_DOC( std::int32_t, "int" );
+LUNA_DOC( std::uint32_t, "int" );
 LUNA_DOC( std::int64_t, "int" );
-LUNA_DOC( size_t, "int" );
+LUNA_DOC( std::uint64_t, "int" );
 LUNA_DOC( float, "double" );
 LUNA_DOC( double, "double" );
 LUNA_DOC( void, "nil" );


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

Fixes android AAB bundle build

Followup of 
* 9e77bc6
* #7386 

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)

Use explicit sized integer types, to avoid redefinitions from aliases

<!-- e.g nerfs monster A -->

## Describe alternatives you've considered

N/A

## Testing

N/A

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
