### PR TITLE
fix: make `onboard chemistry lab` able to heat food

### DIFF
--- a/data/json/vehicleparts/utilities.json
+++ b/data/json/vehicleparts/utilities.json
@@ -123,7 +123,7 @@
     "description": "A small chemistry station, including a hotplate and electrolysis setup powered by the vehicle's batteries.  'e'xamine the tile with the chemistry lab to access the water faucet or to heat up food with the hotplate.  If you attempt to craft an item that needs one of the chemistry lab's functions, it will automatically be selected as a tool.",
     "durability": 80,
     "flags": [ "CARGO", "OBSTACLE", "CRAFTER", "FAUCET", "COVERED" ],
-    "integrated_tools": [ "chemistry_set", "electrolysis_kit" ],
+    "integrated_tools": [ "chemistry_set", "electrolysis_kit", "hotplate" ],
     "item": "chemlab",
     "location": "center",
     "looks_like": "f_workbench",


### PR DESCRIPTION
## Testing

<img width="1410" height="850" alt="image" src="https://github.com/user-attachments/assets/bbe5e657-7f84-45f5-9767-f0289a04248a" />

## Checklist


### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
