### PR TITLE
build: enable non-finite math to support INFINITY

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -249,7 +249,7 @@ if (NOT MSVC)
     if (NOT "${CMAKE_SYSTEM_NAME}" MATCHES "Windows")
         set(CATA_WARNINGS "${CATA_WARNINGS} -Wredundant-decls")
     endif ()
-    set(CATA_OTHER_FLAGS "${CATA_OTHER_FLAGS} -fsigned-char -fno-builtin-std-forward_like")
+    set(CATA_OTHER_FLAGS "${CATA_OTHER_FLAGS} -fsigned-char -fno-builtin-std-forward_like -fno-finite-math-only")
     # Add debug symbols for non-release builds or when backtrace is enabled
     if (BACKTRACE OR NOT RELEASE)
         set(CATA_OTHER_FLAGS "${CATA_OTHER_FLAGS} -g1")


### PR DESCRIPTION


## Purpose of change (The Why)

```
    
In file included from src/mtype.h:20:
src/pathfinding.h:37:24: warning: use of infinity via a macro is undefined behavior due to the currently enabled floating-point options [-Wnan-infinity-disabled]
   37 |     float climb_cost = INFINITY;
      |                        ^
src/pathfinding.h:43:28: warning: use of infinity via a macro is undefined behavior due to the currently enabled floating-point options [-Wnan-infinity-disabled]
   43 |     float door_open_cost = INFINITY;
      |                            ^
src/pathfinding.h:117:33: warning: use of infinity via a macro is undefined behavior due to the currently enabled floating-point options [-Wnan-infinity-disabled]
  117 |     float search_radius_coeff = INFINITY;
      |                                 ^
src/pathfinding.h:153:25: warning: use of infinity via a macro is undefined behavior due to the currently enabled floating-point options [-Wnan-infinity-disabled]
  153 |     float max_s_coeff = INFINITY;
      |                         ^
src/pathfinding.h:160:25: warning: use of infinity via a macro is undefined behavior due to the currently enabled floating-point options [-Wnan-infinity-disabled]
  160 |     float max_f_coeff = INFINITY;
      |                         ^
src/pathfinding.h:163:22: warning: use of infinity via a macro is undefined behavior due to the currently enabled floating-point options [-Wnan-infinity-disabled]
  163 |     float max_dist = INFINITY;
      |                      ^
6 warnings generated.
```

Pathfinding logic requires `INFINITY`, but `-ffast-math` disables it, triggering `-Wnan-infinity-disabled` warnings.


## Describe the solution (The How)

add `-fno-finite-math-only` flag

## Describe alternatives you've considered

can't use `std::numeric_limits<float>::max()` as code explicitly checks whether a float is INFINITY

https://github.com/scarf005/Cataclysm-BN/blob/762e72b1eb216fa88a8fdaf7feeb9b0617725eef/src/pathfinding.cpp#L38-L57

## Testing

idk should work

## Additional context


## Checklist


### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
