### PR TITLE
fix(i18n): make pot extraction work again

### DIFF
--- a/lang/extract_json_strings.py
+++ b/lang/extract_json_strings.py
@@ -1206,7 +1206,7 @@ def assert_num_args(node, args, n):
 
 def get_string_literal(node, args, pos):
     if isinstance(args[pos], astnodes.String):
-        return args[pos].s
+        return args[pos].s.decode('utf-8')
     else:
         raise Exception(f"argument to translation call should be string. Error source:   {ast.to_lua_source(node)}")
 


### PR DESCRIPTION
## Purpose of change (The Why)

luaparser>=4 changes type of `astnodes.String.s` from `str` to `bytes`, but script expectes `str`, causing error.

see: https://github.com/boolangery/py-lua-parser/pull/65

## Describe the solution (The How)

decode into utf-8

## Describe alternatives you've considered

pin to 3.3.1?

## Testing

<img width="1246" height="1244" alt="image" src="https://github.com/user-attachments/assets/452b7ef3-0985-450b-94aa-87b5cec7d6e7" />

result of running `lang/update_pot.sh` looks alright to me.

## Additional context

## Checklist


### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
