### PR TITLE
feat: make NPC followers match player's movement speed

### DIFF
--- a/data/json/npcs/TALK_COMMON_ALLY.json
+++ b/data/json/npcs/TALK_COMMON_ALLY.json
@@ -701,6 +701,16 @@
               "no": "<ally_rule_forbid_engage_false_text>"
             }
           ]
+        },
+        {
+          "and": [
+            { "npc_override": "move_own_pace", "yes": "  OVERRIDE: ", "no": "  " },
+            {
+              "npc_rule": "move_own_pace",
+              "yes": "<ally_rule_move_own_pace_true_text>",
+              "no": "<ally_rule_move_own_pace_false_text>"
+            }
+          ]
         }
       ]
     },
@@ -758,6 +768,15 @@
         },
         "topic": "TALK_MISC_RULES",
         "effect": { "toggle_npc_rule": "ignore_noise" }
+      },
+      {
+        "truefalsetext": {
+          "condition": { "npc_rule": "move_own_pace" },
+          "true": "Match my movement speed when following.",
+          "false": "Move at your own pace."
+        },
+        "topic": "TALK_MISC_RULES",
+        "effect": { "toggle_npc_rule": "move_own_pace" }
       },
       { "text": "Set up pickup rules.", "topic": "TALK_MISC_RULES", "effect": "set_npc_pickup" },
       { "text": "Clear all overrides.", "topic": "TALK_MISC_RULES", "effect": "clear_overrides" },

--- a/data/json/npcs/talk_tags.json
+++ b/data/json/npcs/talk_tags.json
@@ -1599,5 +1599,15 @@
       "SpiRAAAAAAALS!",
       "Rotate!"
     ]
+  },
+  {
+    "type": "snippet",
+    "category": "<ally_rule_move_own_pace_true_text>",
+    "text": "<mypronoun> will move at their own pace when following."
+  },
+  {
+    "type": "snippet",
+    "category": "<ally_rule_move_own_pace_false_text>",
+    "text": "<mypronoun> will follow your movement speed when following."
   }
 ]

--- a/src/npc.h
+++ b/src/npc.h
@@ -283,24 +283,25 @@ const std::unordered_map<std::string, cbm_reserve_rule> cbm_reserve_strs = { {
     }
 };
 
-enum class ally_rule {
+enum class ally_rule : int {
     DEFAULT = 0,
-    use_guns = 1,
-    use_grenades = 2,
-    use_silent = 4,
-    avoid_friendly_fire = 8,
-    allow_pick_up = 16,
-    allow_bash = 32,
-    allow_sleep = 64,
-    allow_complain = 128,
-    allow_pulp = 256,
-    close_doors = 512,
-    follow_close = 1024,
-    avoid_doors = 2048,
-    hold_the_line = 4096,
-    ignore_noise = 8192,
-    forbid_engage = 16384,
-    follow_distance_2 = 32768
+    use_guns = 1 << 0,
+    use_grenades = 1 << 1,
+    use_silent = 1 << 2,
+    avoid_friendly_fire = 1 << 3,
+    allow_pick_up = 1 << 4,
+    allow_bash = 1 << 5,
+    allow_sleep = 1 << 6,
+    allow_complain = 1 << 7,
+    allow_pulp = 1 << 8,
+    close_doors = 1 << 9,
+    follow_close = 1 << 10,
+    avoid_doors = 1 << 11,
+    hold_the_line = 1 << 12,
+    ignore_noise = 1 << 13,
+    forbid_engage = 1 << 14,
+    follow_distance_2 = 1 << 15,
+    move_own_pace = 1 << 16,
 };
 
 struct ally_rule_data {
@@ -420,6 +421,13 @@ const std::unordered_map<std::string, ally_rule_data> ally_rule_strs = { {
                 ally_rule::follow_distance_2,
                 "<ally_rule_follow_distance_2_true_text>",
                 "<ally_rule_follow_distance_2_false_text>"
+            }
+        },
+        {
+            "move_own_pace", {
+                ally_rule::move_own_pace,
+                "<ally_rule_move_own_pace_true_text>",
+                "<ally_rule_move_own_pace_false_text>"
             }
         }
     }

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -1167,6 +1167,9 @@ void npc::execute_action( npc_action action )
         }
         case npc_follow_player:
             update_path( player_character.pos() );
+            move_mode = rules.has_flag( ally_rule::move_own_pace ) ?
+                        ( ( static_cast<int>( path.size() ) > follow_distance() * 4 ) ? CMM_RUN : CMM_WALK ) :
+                        player_character.get_movement_mode();
             if( static_cast<int>( path.size() ) <= follow_distance() &&
                 player_character.posz() == posz() ) { // We're close enough to u.
                 move_pause();
@@ -1180,6 +1183,9 @@ void npc::execute_action( npc_action action )
             break;
 
         case npc_follow_embarked: {
+            move_mode = rules.has_flag( ally_rule::move_own_pace ) ?
+                        ( ( static_cast<int>( path.size() ) > follow_distance() * 4 ) ? CMM_RUN : CMM_WALK ) :
+                        player_character.get_movement_mode();
             const optional_vpart_position vp = here.veh_at( player_character.pos() );
 
             if( !vp ) {


### PR DESCRIPTION

## Purpose of change (The Why)

having to wait NPCs to crawl to your position when you run does not spark joy.

## Testing

### NPCs will match player running/walking/crouching

https://github.com/user-attachments/assets/d45d0fa7-73f5-4645-9cf1-e7e830d1efe2

### Faraway NPC with `move_own_pace` will run to player if too far away

https://github.com/user-attachments/assets/6390ebbd-f29e-46b5-8639-af8d5c311781

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
