### PR TITLE
feat(balance): add `FOLDABLE` to wooden plane and gyro parts

### DIFF
--- a/data/json/vehicleparts/propellers.json
+++ b/data/json/vehicleparts/propellers.json
@@ -48,6 +48,8 @@
     "damage_modifier": 80,
     "breaks_into": [ { "item": "scrap", "count": [ 8, 15 ] }, { "item": "splinter", "count": [ 5, 10 ] } ],
     "damage_reduction": { "all": 15 },
+    "extend": { "flags": [ "FOLDABLE" ] },
+    "folded_volume": "20 L",
     "color": "brown"
   }
 ]

--- a/data/json/vehicleparts/rotor.json
+++ b/data/json/vehicleparts/rotor.json
@@ -73,6 +73,8 @@
       { "item": "steel_chunk", "count": [ 1, 4 ] },
       { "item": "splinter", "count": [ 15, 30 ] }
     ],
+    "extend": { "flags": [ "FOLDABLE" ] },
+    "folded_volume": "50 L",
     "damage_reduction": { "all": 10 }
   },
   {

--- a/data/json/vehicleparts/wings.json
+++ b/data/json/vehicleparts/wings.json
@@ -161,7 +161,8 @@
       "removal": { "skills": [ [ "mechanics", 3 ] ], "using": [ [ "vehicle_nail_removal", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 4 ] ], "time": "10 m", "using": [ [ "sewing_standard", 1 ], [ "fabric_standard", 1 ] ] }
     },
-    "flags": [ "WING", "SHOCK_RESISTANT" ],
+    "flags": [ "WING", "SHOCK_RESISTANT", "FOLDABLE" ],
+    "folded_volume": "15 L",
     "damage_reduction": { "all": 28 }
   },
   {


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

I figured that one way to add utility to the lighter and less powerful plane/gyro parts would be to make folding vehicles possible using them.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

Added `FOLDABLE` flag to wooden propellers, gyrocopter rotors, and wooden wings, with `folded_volume` specified for each matching the base item's volume.

## Describe alternatives you've considered

Not making foldable wooden planes.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Load-tested in compiled test build.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
