### PR TITLE
feat(balance, mods/MagicalNights): give MN classes crystalize mana spell

### DIFF
--- a/data/mods/MagicalNights/traits/classes.json
+++ b/data/mods/MagicalNights/traits/classes.json
@@ -8,7 +8,7 @@
     "starting_trait": false,
     "purifiable": false,
     "valid": false,
-    "spells_learned": [ [ "create_rune_magus", 1 ] ],
+    "spells_learned": [ [ "create_rune_magus", 1 ], [ "crystallize_mana", 1 ] ],
     "mana_modifier": 500,
     "mana_regen_multiplier": 1.2
   },
@@ -21,7 +21,7 @@
     "starting_trait": false,
     "purifiable": false,
     "valid": false,
-    "spells_learned": [ [ "create_rune_animist", 1 ] ],
+    "spells_learned": [ [ "create_rune_animist", 1 ], [ "crystallize_mana", 1 ] ],
     "mana_modifier": 500,
     "mana_regen_multiplier": 1.2
   },
@@ -34,7 +34,7 @@
     "starting_trait": false,
     "purifiable": false,
     "valid": false,
-    "spells_learned": [ [ "create_rune_kelvinist", 1 ] ],
+    "spells_learned": [ [ "create_rune_kelvinist", 1 ], [ "crystallize_mana", 1 ] ],
     "mana_modifier": 500,
     "mana_regen_multiplier": 1.2
   },
@@ -47,7 +47,7 @@
     "starting_trait": false,
     "purifiable": false,
     "valid": false,
-    "spells_learned": [ [ "create_rune_stormshaper", 1 ] ],
+    "spells_learned": [ [ "create_rune_stormshaper", 1 ], [ "crystallize_mana", 1 ] ],
     "mana_modifier": 500,
     "mana_regen_multiplier": 1.2
   },
@@ -60,7 +60,7 @@
     "starting_trait": false,
     "purifiable": false,
     "valid": false,
-    "spells_learned": [ [ "create_rune_technomancer", 1 ] ],
+    "spells_learned": [ [ "create_rune_technomancer", 1 ], [ "crystallize_mana", 1 ] ],
     "mana_modifier": 500,
     "mana_regen_multiplier": 1.2
   },
@@ -73,7 +73,7 @@
     "starting_trait": false,
     "purifiable": false,
     "valid": false,
-    "spells_learned": [ [ "create_rune_earthshaper", 1 ] ],
+    "spells_learned": [ [ "create_rune_earthshaper", 1 ], [ "crystallize_mana", 1 ] ],
     "mana_modifier": 500,
     "mana_regen_multiplier": 1.2
   },
@@ -86,7 +86,7 @@
     "starting_trait": false,
     "purifiable": false,
     "valid": false,
-    "spells_learned": [ [ "create_rune_biomancer", 1 ] ],
+    "spells_learned": [ [ "create_rune_biomancer", 1 ], [ "crystallize_mana", 1 ] ],
     "mana_modifier": 500,
     "mana_regen_multiplier": 1.2
   },
@@ -99,7 +99,7 @@
     "starting_trait": false,
     "purifiable": false,
     "valid": false,
-    "spells_learned": [ [ "create_rune_druid", 1 ] ],
+    "spells_learned": [ [ "create_rune_druid", 1 ], [ "crystallize_mana", 1 ] ],
     "mana_modifier": 500,
     "mana_regen_multiplier": 1.2
   },


### PR DESCRIPTION
## Purpose of change (The Why)

This spell is otherwise a pain in the ass to search for and find.

## Describe the solution (The How)

Give all the classes the spell by default

## Describe alternatives you've considered

- Make it craftable easily
- Somehow make mana be able to be directly used as a crafting material

## Testing

It lints and works

It TECHNICALLY misbehaves once you get more than one class with the spell, but all it does is increase the level more and more despite the spell having a max level of 0. I consider this so minor as to not be worth addressing at this time.

## Additional context

Quick and simple PR go brr

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
