### PR TITLE
feat: bionic assisted professions

### DIFF
--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -651,24 +651,10 @@
     "name": "Bionic-Assisted Survivor",
     "description": "Besides a few basic bionics, some would say that there's nothing notable about you.  But you've survived, and that's more than most could say right now.",
     "points": 1,
-    "CBMs": [
-      "bio_batteries",
-      "bio_power_storage",
-      "bio_lighter"
-    ],
+    "CBMs": [ "bio_batteries", "bio_power_storage", "bio_lighter" ],
     "items": {
       "both": {
-        "items": [
-          "jeans",
-          "longshirt",
-          "socks",
-          "sneakers",
-          "mbag",
-          "pockknife",
-          "water_clean",
-          "smart_phone",
-          "wristwatch"
-        ]
+        "items": [ "jeans", "longshirt", "socks", "sneakers", "mbag", "pockknife", "water_clean", "smart_phone", "wristwatch" ]
       },
       "male": [ "boxer_shorts" ],
       "female": [ "bra", "panties" ]
@@ -2194,15 +2180,9 @@
     "name": "Bionic-Assisted Smoker",
     "description": "To spare yourself the effort of keeping a lighter on hand, you decided to install bionics. You're on the last pack however, and with Cataclysm going on, you may have difficulties in acquiring more.",
     "points": 0,
-    "CBMs": [
-      "bio_batteries",
-      "bio_power_storage",
-      "bio_lighter"
-    ],
+    "CBMs": [ "bio_batteries", "bio_power_storage", "bio_lighter" ],
     "items": {
-      "both": {
-        "items": [ "pants", "dress_shirt", "socks", "smart_phone", "dress_shoes", "knit_scarf", "cig", "wristwatch" ],
-      },
+      "both": { "items": [ "pants", "dress_shirt", "socks", "smart_phone", "dress_shoes", "knit_scarf", "cig", "wristwatch" ] },
       "male": [ "briefs" ],
       "female": [ "bra", "panties" ]
     },
@@ -2227,11 +2207,7 @@
     "name": "Bionic-Assisted Crackhead",
     "description": "Cocaine.  It is, indeed, a helluva drug.  Some odd-looking doctors offered you a deal at some point, with no obvious downsides.  How could anyone refuse?",
     "points": 0,
-    "CBMs": [
-      "bio_batteries",
-      "bio_power_storage",
-      "bio_lighter"
-    ],
+    "CBMs": [ "bio_batteries", "bio_power_storage", "bio_lighter" ],
     "items": {
       "both": [ "crackpipe", "crack", "crack", "tank_top" ],
       "male": [ "pants", "flip_flops" ],
@@ -2272,11 +2248,7 @@
     "description": "To at least pretend that your noteworthy alcohol consumption has some higher purpose, you accepted the offer to install ethanol burner and some bionics.  You probably won't be able to show gratitude to your benefactors, besides giving a toast to them...  Seems you're going to need more drinks anyway.",
     "points": 0,
     "starting_cash": 0,
-    "CBMs": [
-      "bio_ethanol",
-      "bio_power_storage",
-      "bio_lighter"
-    ],
+    "CBMs": [ "bio_ethanol", "bio_power_storage", "bio_lighter" ],
     "items": {
       "both": [
         "pants",
@@ -2331,24 +2303,11 @@
     "description": "You lived off what others threw away. You even managed to get a few working bionics this way. With the old world shattered, your skills should prove useful to help you survive.",
     "points": 2,
     "skills": [ { "level": 2, "name": "survival" }, { "level": 1, "name": "mechanics" } ],
-    "CBMs": [
-      "bio_batteries",
-      "bio_power_storage",
-      "bio_lighter"
-    ],
+    "CBMs": [ "bio_batteries", "bio_power_storage", "bio_lighter" ],
     "vehicle": "shopping_cart",
     "items": {
       "both": {
-        "items": [
-          "pants",
-          "gloves_light_fingerless",
-          "smart_phone",
-          "fanny",
-          "backpack",
-          "sneakers",
-          "water_clean",
-          "pockknife"
-        ],
+        "items": [ "pants", "gloves_light_fingerless", "smart_phone", "fanny", "backpack", "sneakers", "water_clean", "pockknife" ],
         "entries": [ { "group": "cannedfood", "count": 3 } ]
       },
       "male": [ "boxer_shorts" ],


### PR DESCRIPTION
- Adds a few bionic-assisted professions, tweaked default professions with a few barebones CBMs added.

## Purpose of change (The Why)

I found the bionic profession options to be very "swingy", especially if points are used - they are either offering game-changing options with a high price (bionic prepper, soldier), or have some serious drawbacks (failed/defective cyborg, bionic junkie/monster). I decided to add bionic-assisted alternatives to starting professions, which give a slight boost to them, while making the search for CBMs more worthwhile, as you already have a base to start with.

This also adds another sub-group of bionic users, if we list them, it would be this:
- Non-bionic, standard;
- **Bionic-Assisted** - group that is being added here;
- Bionic professionals;
- Cyborgs - they are more cyborgs in just name however, as their abilities, while game-changing, don't really change the underlying loop of searching for food and water.

## Describe the solution (The How)

Add bionic-assisted professions, to the main `professions.json`.

## Describe alternatives you've considered

Add them in a mod, rather than straight to `professions.json`.

## Testing

None.

## Additional context

Some of the professions with flaws (pillhead for example) don't have the bionic-assisted alternative. I have difficulties figuring out how available bionics in the list could... "help" their profession. I decided to not bother with it yet.

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [ ] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [ ] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

<!-- please remove checkboxes unrelated to this PR. -->
