### PR TITLE
fix: always spawn mission items

### DIFF
--- a/data/json/items/generic.json
+++ b/data/json/items/generic.json
@@ -2740,7 +2740,8 @@
     "material": "plastic",
     "weight": "6 g",
     "volume": "5 ml",
-    "to_hit": -3
+    "to_hit": -3,
+    "flags": [ "MISSION_ITEM" ]
   },
   {
     "id": "gasdiscount_silver",

--- a/docs/en/mod/json/reference/json_flags.md
+++ b/docs/en/mod/json/reference/json_flags.md
@@ -740,6 +740,7 @@ List of known flags, used in both `terrain.json` and `furniture.json`.
 - `LEAK_DAM` ... Leaks when damaged (may be combined with "RADIOACTIVE").
 - `NEEDS_UNFOLD` ... Has an additional time penalty upon wielding. For melee weapons and guns this
   is offset by the relevant skill. Stacks with "SLOW_WIELD".
+- `MISSION_ITEM` ... will always spawn as loot regardless item spawn rate settings.
 - `NO_PACKED` ... This item is not protected against contamination and won't stay sterile. Only
   applies to CBMs.
 - `NO_REPAIR` ... Prevents repairing of this item even if otherwise suitable tools exist.

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2960,8 +2960,8 @@ void monster::drop_items_on_death()
     if( spawn_rate < 1 ) {
         // Temporary vector, to remember which items will be dropped
         std::vector<detached_ptr<item>> remaining;
-        for( detached_ptr<item> &it : items ) {
-            if( rng_float( 0, 1 ) < spawn_rate ) {
+        for( auto &it : items ) {
+            if( it->has_flag( flag_MISSION_ITEM ) || rng_float( 0, 1 ) < spawn_rate ) {
                 remaining.push_back( std::move( it ) );
             }
         }


### PR DESCRIPTION
## Purpose of change (The Why)

- fixes #5187

## Describe the solution (The How)

for some reason unlike DDA `MISSION_ITEM` flag weren't being used?!

## Describe alternatives you've considered

## Testing

<img width="1410" height="850" alt="image" src="https://github.com/user-attachments/assets/160427c7-d133-4290-abd2-bd95fbd241c2" />

1. set item spawn rate to 0.01
2. spawn prototype robot.
3. confirm that prototype I/O recorder is always spawned.

## Additional context

I can't believe no one has opened a PR for this before

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
