### PR TITLE
feat(UI): add default hair for custom character generation

### DIFF
--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -426,6 +426,22 @@ void Character::clear_cosmetic_traits( std::string mutation_type, trait_id new_t
     }
 }
 
+namespace
+{
+
+void set_cosmetic_trait( Character &c, std::string mutation_type, const trait_id &trait )
+{
+    if( trait.is_valid() ) {
+        c.clear_cosmetic_traits( mutation_type, trait );
+
+        if( !c.has_trait( trait ) ) {
+            c.toggle_trait( trait );
+        }
+    }
+}
+
+} // namespace
+
 void avatar::randomize_cosmetics()
 {
     randomize_cosmetic_trait( type_hair_style );
@@ -454,8 +470,13 @@ bool avatar::create( character_type type, const std::string &tempname )
     int tab = 0;
     points_left points = points_left();
 
+    static auto male_default_hair = trait_id( "hair_black_medium" );
+    static auto female_default_hair = trait_id( "hair_blond_long" );
+
     switch( type ) {
         case character_type::CUSTOM:
+            // don't make them bald!
+            set_cosmetic_trait( *this, type_hair_style, male ? male_default_hair : female_default_hair );
             break;
         case character_type::RANDOM:
             //random scenario, default name if exist


### PR DESCRIPTION
## Purpose of change (The Why)

new characters are bald, and it probably ain't what players want

## Describe alternatives you've considered

<img width="30%" alt="image" src="https://preview.redd.it/hoshino-prank-gone-bald-v0-n9hrshlorq8e1.jpeg?auto=webp&s=7a9d805ebeee41ceb5509bc3abd72643fca255f4" />

humanity according to custom chargen, aka <i>uhe</i>ihachi

## Testing

on custom chargen:

<img width="2690" height="1570" alt="image" src="https://github.com/user-attachments/assets/c9afcd79-b1a2-41cb-b576-02e44e168ba1" />
<img width="2690" height="1570" alt="image" src="https://github.com/user-attachments/assets/f94570f0-8212-4aaf-9de9-5fe2c969389b" />

## Checklist


### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
