### PR TITLE
build(lua): fix MSVC linker error

### DIFF
--- a/src/lua/CMakeLists.txt
+++ b/src/lua/CMakeLists.txt
@@ -1,12 +1,13 @@
 file(GLOB LUA_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/*.c)
 file(GLOB LUA_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/*.h)
-list(APPEND LUA_SOURCES ${LUA_HEADERS})
 
-# We compile Lua C sources with C++ compiler so we don't have to bother 
+# We compile Lua C sources with C++ compiler so we don't have to bother
 # with defining 2 different compilers.
+# Apply property ONLY to source files, NOT headers.
 set_source_files_properties(${LUA_SOURCES} PROPERTIES LANGUAGE CXX)
 
-add_library(liblua ${LUA_SOURCES})
+# Add both sources and headers to the library (headers for IDE visibility)
+add_library(liblua ${LUA_SOURCES} ${LUA_HEADERS})
 target_include_directories(liblua SYSTEM PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 set_target_properties(liblua PROPERTIES LINKER_LANGUAGE CXX)


### PR DESCRIPTION
fix regression (or hidden bug?) introduced by https://github.com/cataclysmbn/Cataclysm-BN/pull/7655

exclude headers from compilation properties so CMake/MSVC doesn't try to compile them into object files.
fixes LNK1181 errors (missing .obj files) when using ccache on Windows.

[logs_52736998863.zip](https://github.com/user-attachments/files/24279462/logs_52736998863.zip)
