### PR TITLE
fix(UI): fix bionics that require other bionics in chargen

### DIFF
--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -1844,14 +1844,6 @@ tab_direction set_bionics( avatar &u, points_left &points )
                     }
                 }
             }
-            std::vector<bionic_id> up_bionics;
-            if( !bio.required_bionics.empty() ) {
-                for( const bionic_id &req_bid : bio.required_bionics ) {
-                    if( !u.has_bionic( req_bid ) ) {
-                        missing_bionics.push_back( req_bid );
-                    }
-                }
-            }
             bionic_id has_downgrade = bionic_id::NULL_ID();
             if( cur_bionic->upgraded_bionic != bionic_id::NULL_ID() ) {
                 bionic_id downgrade = cur_bionic->upgraded_bionic;


### PR DESCRIPTION
## Purpose of change (The Why)
> Hydraulic muscles for example, if allowed in chargen, is greyed out as if it's not selectable, but you can select it anyway. 

continuation of #7651 

## Describe the solution (The How)
Fixes that

## Describe alternatives you've considered
Screming at the derg to be uneepy and fix it himself :P

## Testing
Let hydraulic muscles be selected it was selected

## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.