### PR TITLE
fix: actually check player energy for USE_PLAYER_ENERGY

### DIFF
--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -2696,10 +2696,9 @@ int cast_spell_actor::use( player &p, item &it, bool, const tripoint & ) const
     if( it.has_flag( flag_USE_PLAYER_ENERGY ) ) {
         // [2] this value overrides the mana cost if set to 0
         // Have to check whether the player actually has enough energy or not
-        if ( p.magic->has_enough_energy( p, casting ) ) {
+        if( p.magic->has_enough_energy( p, casting ) ) {
             cast_spell->values.emplace_back( 1 );
-        }
-        else {
+        } else {
             p.add_msg_if_player( m_info, _( "You lack the energy to cast %s." ), casting.name() );
             return 0;
         }


### PR DESCRIPTION
## Purpose of change (The Why)

You could cast item spells regardless of whether you actually had the mana/other energy for them or not.
Fixes #7663 

## Describe the solution (The How)

Adds a check to the iuse actor's use function where it checks whether you actually have enough energy to case the spell.

## Describe alternatives you've considered

- Roll out a can_use function instead

Valid, but a little more annoying given it currently isn't present.

## Testing

Works
<img width="319" height="38" alt="image" src="https://github.com/user-attachments/assets/409eb1b2-8e1b-49a0-a9e8-9ef9ef489b96" />

## Additional context

Charges are generally handled elsewhere through the normal functions relating to that field.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
