### PR TITLE
docs: corrected links to BN Guide

### DIFF
--- a/doc/astro.config.ts
+++ b/doc/astro.config.ts
@@ -15,7 +15,7 @@ const { CUSTOM_SITE_URL, CUSTOM_REPO_URL } = env
 
 const site = CUSTOM_SITE_URL || "https://docs.cataclysmbn.org"
 const github = CUSTOM_REPO_URL || "https://github.com/cataclysmbnteam/Cataclysm-BN"
-const itemGuide = "https://next.cbn-guide.pages.dev/?t=UNDEAD_PEOPLE"
+const itemGuide = "https://cbn-guide.pages.dev/"
 const discord = "https://discord.gg/XW7XhXuZ89"
 
 const docModes = (dir: string) => [

--- a/docs/_data.yml
+++ b/docs/_data.yml
@@ -3,7 +3,7 @@ menu_links:
     href: https://github.com/cataclysmbnteam/Cataclysm-BN
     icon: github-logo
   - text: BN Item Guide
-    href: https://next.cbn-guide.pages.dev/?t=UNDEAD_PEOPLE
+    href: https://cbn-guide.pages.dev/
     icon: book
   - text: Discord
     href: https://discord.gg/XW7XhXuZ89

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1568,7 +1568,7 @@ void options_manager::add_options_interface()
 
     add( "HHG_URL", interface, translate_marker( "Hitchhiker's Guide URL" ),
          translate_marker( "The URL opened by pressing the open HHG keybind." ),
-         "https://next.cbn-guide.pages.dev", 60
+         "https://cbn-guide.pages.dev", 60
        );
 
     add_empty_line();


### PR DESCRIPTION
continuation of https://github.com/cataclysmbn/Cataclysm-BN/pull/7640

This change ensures the link points to the production version of the item's guide rather than the next development build. 
Also removed unnecessary tileset hardcoding.

I’m currently the maintainer of the guide