### PR TITLE
fix(UI): add selected bionics to character preview

### DIFF
--- a/src/character_preview.cpp
+++ b/src/character_preview.cpp
@@ -100,6 +100,9 @@ class char_preview_adapter : public cata_tiles
             for( const bionic_id &bio : av.prof->CBMs() ) {
                 t_av.add_bionic( bio );
             }
+            for( const bionic &bio : *av.my_bionics ) {
+                t_av.add_bionic( bio.id );
+            }
             for( const bionic &bio : *t_av.my_bionics ) {
                 std::string overlay_id = ( bio.powered ? "active_" : "" ) + bio.id.str();
                 int order = get_overlay_order_of_mutation( overlay_id );


### PR DESCRIPTION
## Purpose of change (The Why)
> btw does the character preview reflect bionics?
> seems like it doesnt show them, or we have none that are visible changes yet
This is true

continuation of #7651

## Describe the solution (The How)
Iterate over given bionics and add them to the temporary preview

## Describe alternatives you've considered
Screm; Ignore visuals

## Testing
Let alloy plating be selectable, it changes appearance

## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.