### PR TITLE
feat(UI): completely overhaul final chargen menu

### DIFF
--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -3104,22 +3104,23 @@ tab_direction set_description( avatar &you, const bool allow_reroll,
         w_gender = catacurses::newwin( 2, 33, point( 46, 5 ) );
         w_height = catacurses::newwin( 1, 20, point( 80, 5 ) );
         w_location = catacurses::newwin( 2, 60, point( 100, 5 ) );
-        w_scenario = catacurses::newwin( 1, TERMX - 161, point( 160, 5 ) );
-        w_profession = catacurses::newwin( 1, TERMX - 161, point( 160, 6 ) );
+        w_scenario = catacurses::newwin( 1, std::max( 1, TERMX - 161 ), point( 160, 5 ) );
+        w_profession = catacurses::newwin( 1, std::max( 1, TERMX - 161 ), point( 160, 6 ) );
 
         // Row 2
         w_age = catacurses::newwin( 1, 12, point( 80, 6 ) );
 
         // Big Row
         w_stats = catacurses::newwin( 6, 20, point( 2, 9 ) );
-        w_skills = catacurses::newwin( TERMY - 17, 25, point( 2, 16 ) );
-        w_traits = catacurses::newwin( TERMY - 10, 30, point( 28, 9 ) );
-        w_bionics = catacurses::newwin( TERMY - 10, 30, point( 59, 9 ) );
-        w_misc = catacurses::newwin( TERMY - 10, 30, point( 90, 9 ) );
-        w_gear = catacurses::newwin( TERMY - 10, TERMX - 122, point( 121, 9 ) );
+        w_skills = catacurses::newwin( std::max( 1, TERMY - 17 ), 25, point( 2, 16 ) );
+        w_traits = catacurses::newwin( std::max( 1, TERMY - 10 ), 30, point( 28, 9 ) );
+        w_bionics = catacurses::newwin( std::max( 1, TERMY - 10 ), 30, point( 59, 9 ) );
+        w_misc = catacurses::newwin( std::max( 1, TERMY - 10 ), 30, point( 90, 9 ) );
+        w_gear = catacurses::newwin( std::max( 1, TERMY - 10 ), std::max( 1, TERMX - 122 ), point( 121,
+                                     9 ) );
 
         // Very bottom Row
-        w_guide = catacurses::newwin( 6, TERMX - 3, point( 2, TERMY - 7 ) );
+        w_guide = catacurses::newwin( 6, std::max( 1, TERMX - 3 ), point( 2, TERMY - 7 ) );
 
 #if defined(TILES)
         const int int_page_width = 38;


### PR DESCRIPTION
## Purpose of change (The Why)
Our UI was lacking things like pets, addictions, cash, NPCs and items in the final menu
It also had terrible use of space

## Describe the solution (The How)
Change this:
<img width="1920" height="1080" alt="prev" src="https://github.com/user-attachments/assets/ae03b76e-8fa6-4f6c-a8a4-bc9f55302d0e" />

To this:
<img width="1920" height="1080" alt="2025-12-23-163258_1920x1080_scrot" src="https://github.com/user-attachments/assets/8214269f-1013-4f3d-b167-98951f273ca1" />

## Describe alternatives you've considered
Screm

## Testing
The UI doesn't blow up for professions with each thing

## Additional context
There is a planned followup for bionics colors and adding game start date & cataclysm start date

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.