### PR TITLE
chore: Add notice to `/data/mods` to not put 3rd party mods there

### DIFF
--- a/data/mods/!ONLY MODS INCLUDED WITH THE GAME GO HERE!/Where-to-put-3rd-party-mods.txt
+++ b/data/mods/!ONLY MODS INCLUDED WITH THE GAME GO HERE!/Where-to-put-3rd-party-mods.txt
@@ -1,0 +1,9 @@
+Where you put the third party mods depends on whether you installed manually or with Catapult. No matter which you do, 3rd party mods do not go in data/mods. That folder should be reserved for in-repo mods only, especially given correctly updating will wipe the contents of that folder!
+
+For a manual installation, you should use the player mods folder in the root folder for Cataclysm (i.e. the folder containing the data folder and the executable). If it is not present, you may need to create it (or check for XDG or /home related paths if on Linux and using a custom build)
+
+For Catapult, you would put them in bn/userdata/mods (creating the folder if it's not already there) inside your catapult installation. For example, it might look like Catapult/bn/userdata/mods.
+
+For Linux users using the XDG directories (but NOT the flatpak): The user mods directory should be in ~/.local/share/cataclysm-bn/mods (~/.local/share/cataclysm-bn is the user directory in general)
+
+For flatpak users, the user mods folder is ~/.var/app/org.cataclysmbn.CataclysmBN/data/cataclysm-bn/mods (the user directory in general is ~/.var/app/org.cataclysmbn.CataclysmBN/data/cataclysm-bn/)


### PR DESCRIPTION
## Purpose of change (The Why)

The root `/mods` folder doesn't actually copy over for some weird reason, but this surely must and at least gives us the ability to say "did you read the notice to not put them there?"

## Describe the solution (The How)

Add a dummy folder and text file to `/data/mods` saying that it's only for mods included with the game, and explaining where to put the 3rd party mods 

## Describe alternatives you've considered

- Figure out how to get the root `/mods` to actually show up
- Create a cursed solution of knowing how many folders *should* be in there in order to yell at players if there are too many in there

## Testing

None, it's a folder and a text file. Worst thing it does is just not actually get copied over.

## Additional context

Too many people keep getting their mods lost because they put things in `/data/mods`

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.