### PR TITLE
feat(mods/rpg_system): add recipe for lost system interfaces

### DIFF
--- a/data/mods/rpg_system/system_interface.json
+++ b/data/mods/rpg_system/system_interface.json
@@ -44,5 +44,16 @@
       "pain_max_val": [ 100 ],
       "morale": [ -20 ]
     }
+  },
+  {
+    "type": "recipe",
+    "result": "system_interface",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_TOOLS",
+    "skill_used": "fabrication",
+    "time": "1 m",
+    "autolearn": true,
+    "flags": [ "BLIND_EASY" ],
+    "components": [ [ [ "rock", 1 ], [ "sharp_rock", 1 ] ] ]
   }
 ]


### PR DESCRIPTION
## Purpose of change (The Why)

People have no way to get the item back if they lose it.

## Describe the solution (The How)

Add in a recipe to just stare at a rock for a minute to get the interface back

## Describe alternatives you've considered

- Make it consume literally nothing
- Do a spell or a trait instead

## Testing

None, I copied the recipe json over from pebbles and just changed some values to other known-goods.

## Additional context

Brought up to me by Cdru in the Discord

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

