### PR TITLE
feat(balance): Reduce bokken crafting difficulty

### DIFF
--- a/data/json/recipes/weapon/bashing.json
+++ b/data/json/recipes/weapon/bashing.json
@@ -293,9 +293,10 @@
     "category": "CC_WEAPON",
     "subcategory": "CSC_WEAPON_BASHING",
     "skill_used": "fabrication",
-    "difficulty": 7,
+    "difficulty": 4,
     "time": "5 h 40 m",
-    "book_learn": [ [ "textbook_weapeast", 6 ] ],
+    "book_learn": [ [ "textbook_weapeast", 3 ] ],
+    "autolearn": true,
     "qualities": [ { "id": "SAW_W", "level": 1 }, { "id": "CUT", "level": 1 }, { "id": "SANDING", "level": 1 } ],
     "//": "Bokken is a single piece of wood, and the heavy stick just isn't large enough.",
     "components": [


### PR DESCRIPTION
## Purpose of change (The Why)

This is literally not useful by the time you would be able to craft it *whatsoever* unless we continue to heavily gatekeep Niten Ichi Ryu weapons (which I think we shouldn't, and even then you'll probably get a real katana before this or a carbon fiber equivalent). Even with this change, it's still arguable that the ironshod quarterstaff is simply superior for anyone that doesn't need a Japanese Sword / One Handed Sword weapon specifically.

Also, it being booklearn only from one book is kinda stupid.

## Describe the solution (The How)

- Reduce the crafting difficulty from 7 to 4
- Reduce booklearn from 6 to 3
- Add autolearn

## Describe alternatives you've considered

- Drop it down a level more

Valid

## Testing

Known good values, it lints

## Additional context

I am also considering letting the 2-by-sword and its derivatives be special exceptions to a lot of the swordfighting martial arts' requirements for the sake of providing an early-game option (even if bad) to players that pick one without a strong plan for how to get a weapon for it. It's conceivable they'd work for a lot of styles if you just headcanon them as not always being the longsword attempt that their sprite dictates.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
