### PR TITLE
feat(balance): Give Niten Ichi-Ryu more swords

### DIFF
--- a/data/json/martialarts.json
+++ b/data/json/martialarts.json
@@ -920,7 +920,7 @@
       }
     ],
     "techniques": [ "niten_water_cut", "niten_red_leaf", "niten_stone_cut", "niten_timing_attack", "niten_feint" ],
-    "weapon_category": [ "JAPANESE_SWORDS", "BIONIC_SWORDS" ]
+    "weapon_category": [ "JAPANESE_SWORDS", "BIONIC_SWORDS", "SHORT_SWORDS", "1H_SWORDS" ]
   },
   {
     "type": "martial_art",


### PR DESCRIPTION
## Purpose of change (The Why)

Even with the bokken change, Niten Ichi kind has a big progression gap both at the start and in the midgame.

Miyamoto Musashi said to be adaptable, and so we can infer that they should be able to use other swords decently too. Short swords already fit in with the Wakizashi, and one-handed swords are reasonable enough.

## Describe the solution (The How)

Give Niten Ichi Ryu the Short Swords and One-handed Swords categories.

## Describe alternatives you've considered

- Give them staves

While actually ENTIRELY ACCURATE because they do practice bojutsu, that is a far bigger rework that I do not feel like doing right now

- Only give them short swords, with maybe making an exception for the 2-by-sword

I contemplated it, because tbh some of the one-handed swords do seem a little goofy to have on Niten. But hey, if Ninjutsu can have just about every different category imaginable, Niten Ichi can have these as a treat.

## Testing

It loads
<img width="628" height="377" alt="image" src="https://github.com/user-attachments/assets/f2a2f647-f492-4039-af59-b3de1d651093" />


## Additional context

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
