### PR TITLE
fix: character preview works with included bionics

### DIFF
--- a/src/character_preview.cpp
+++ b/src/character_preview.cpp
@@ -101,7 +101,9 @@ class char_preview_adapter : public cata_tiles
                 t_av.add_bionic( bio );
             }
             for( const bionic &bio : *av.my_bionics ) {
-                t_av.add_bionic( bio.id );
+                if( !bio.id->included ) {
+                    t_av.add_bionic( bio.id );
+                }
             }
             for( const bionic &bio : *t_av.my_bionics ) {
                 std::string overlay_id = ( bio.powered ? "active_" : "" ) + bio.id.str();


### PR DESCRIPTION
## Purpose of change (The Why)
>got a thing happening on selecting the anti-glare bionic in chargen, it doesn't like included bionics it seems:

## Describe the solution (The How)
Check for included: true
If so dont add the bionic just add the bionic that includes it

## Describe alternatives you've considered
None

## Testing
Adding anti glare bionics no longer complains

## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.