### PR TITLE
fix: remove_bionic now reduces bionic power

### DIFF
--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -2873,12 +2873,16 @@ void Character::remove_bionic( const bionic_id &b )
     std::set<bionic_id> removed_bionics;
     for( bionic &i : *my_bionics ) {
         if( b == i.id && !removed_bionics.contains( i.id ) ) {
+            const units::energy pow_up = i.id->capacity;
+            mod_max_power_level( -1 * pow_up );
             removed_bionics.emplace( i.id );
             continue;
         }
 
         // Linked bionics: if either is removed, the other is removed as well.
         if( ( b->is_included( i.id ) || i.id->is_included( b ) ) && !removed_bionics.contains( i.id ) ) {
+            const units::energy pow_up = i.id->capacity;
+            mod_max_power_level( -1 * pow_up );
             removed_bionics.emplace( i.id );
             continue;
         }


### PR DESCRIPTION
# Purpose of change (The Why)
> YEP
> I wiffle-waffled on whether I wanted to start with bionics during chargen.
> Unselecting it during chargen doesn't bring it back down.

Probably has existed since #7369 

## Describe the solution (The How)
Modify power apon removing bionics

## Describe alternatives you've considered
None

## Testing
Choose and unchoose bionics dozens of times during chargen
It does not infinitely increase power

## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.