### PR TITLE
fix: can no longer put EXTENDABLE parts on occupied tiles

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1539,19 +1539,23 @@ bool vehicle::can_mount( point dp, const vpart_id &id ) const
     const std::vector<int> parts_in_square = parts_at_relative( dp, false );
 
     //New Subpath for balloon type structures when on the edge
-    if( parts_in_square.empty() && part.has_flag( "EXTENDABLE" ) ) {
-        // There needs to be parts for these
-        if( !parts.empty() ) {
-            if( !has_structural_or_extendable_part( dp ) &&
-                !has_structural_or_extendable_part( dp + point_east ) &&
-                !has_structural_or_extendable_part( dp + point_south ) &&
-                !has_structural_or_extendable_part( dp + point_west ) &&
-                !has_structural_or_extendable_part( dp + point_north ) ) {
-                return false;
+    if( part.has_flag( "EXTENDABLE" ) ) {
+        if( parts_in_square.empty() ) {
+            // There needs to be parts for these
+            if( !parts.empty() ) {
+                if( !has_structural_or_extendable_part( dp ) &&
+                    !has_structural_or_extendable_part( dp + point_east ) &&
+                    !has_structural_or_extendable_part( dp + point_south ) &&
+                    !has_structural_or_extendable_part( dp + point_west ) &&
+                    !has_structural_or_extendable_part( dp + point_north ) ) {
+                    return false;
+                }
+                return true;
             }
-            return true;
+            // If there are no parts, we go on our merry day
+        } else {
+            return false;
         }
-        // If there are no parts, we go on our merry day
     }
     //First part in an empty square MUST be a structural part
     if( parts_in_square.empty() && part.location != part_location_structure ) {


### PR DESCRIPTION
## Purpose of change (The Why)
I felt productive today
The derg also pinged me
> You're not supposed to be able to slap extra parts onto external protrusion parts, so being able to double up on balloons sounds like an oversight. 

## Describe the solution (The How)
Prevent stacking my making extendable parts only work when there is no other part on the tile

## Describe alternatives you've considered
Buff balloons as people believe stacking is needed

## Testing
I cannot figure out how to put an extendable balloon on non-empty tiles at this point
It still works on empty tiles

## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.