### PR TITLE
fix(UI): preserve camera position when exiting vehicle interaction screen

### DIFF
--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -221,6 +221,9 @@ struct veh_interact::install_info_t {
 veh_interact::veh_interact( vehicle &veh, point p )
     : dd( p ), veh( &veh ), main_context( "VEH_INTERACT" )
 {
+    stored_view_offset = get_avatar().view_offset;
+    get_avatar().view_offset = tripoint_zero;
+
     // Only build the shapes map and the wheel list once
     for( const auto &e : vpart_info::all() ) {
         const vpart_info &vp = e.second;
@@ -266,7 +269,10 @@ veh_interact::veh_interact( vehicle &veh, point p )
     move_cursor( point_zero );
 }
 
-veh_interact::~veh_interact() = default;
+veh_interact::~veh_interact()
+{
+    get_avatar().view_offset = stored_view_offset;
+}
 
 void veh_interact::allocate_windows()
 {

--- a/src/veh_interact.h
+++ b/src/veh_interact.h
@@ -61,6 +61,7 @@ class veh_interact
         item *target = nullptr;
 
         point dd = point_zero;
+        tripoint stored_view_offset;
         /* starting offset for vehicle parts description display and max offset for scrolling */
         int start_at = 0;
         int start_limit = 0;

--- a/src/vehicle_preview.h
+++ b/src/vehicle_preview.h
@@ -68,6 +68,8 @@ struct vehicle_preview_window {
         static constexpr int MAX_ZOOM = 64;
         static constexpr int DEFAULT_ZOOM = 16;
         int zoom = DEFAULT_ZOOM;
+        bool saved_original_zoom = false;
+        float original_zoom = DEFAULT_ZOOM;
 
         /**
          * Draw a single vehicle part at the given pixel position.


### PR DESCRIPTION
## Purpose of change (The Why)

- fixes #7744
- fixes #7759

## Describe the solution (The How)

- Save `view_offset` (camera position) in `veh_interact` constructor
- Restore `view_offset` in `veh_interact` destructor
- Follows existing RAII pattern used in other UI systems (`pointmenu_cb`, targeting, etc.)

## Describe alternatives you've considered

N/A - This is the established pattern throughout the codebase for UI state preservation.

## Testing

- Built successfully: `cmake --build --preset linux-full --target cataclysm-bn-tiles`
- Manual testing: Enter vehicle examine screen, move camera, exit screen → camera position should be restored to original position

## Additional context

Bug was introduced in PR #7709 which added graphical tiles to vehicle interaction but didn't preserve view state.

## Checklist

### Mandatory

- [x] I wrote the PR title in conventional commit format.
- [x] I ran the code formatter.
- [x] I linked any relevant issues using github keyword syntax like `closes #1234` in Summary of the PR so it can be closed automatically.
- [x] I've committed my changes to new branch that isn't `main` so it won't cause conflict when updating `main` branch later.