### PR TITLE
feat(balance): Mustard and Mayo are not junk food

### DIFF
--- a/data/json/items/comestibles/drink_other.json
+++ b/data/json/items/comestibles/drink_other.json
@@ -57,7 +57,7 @@
     "description": "A gloppy mix of egg, oil, and salt that is traditionally used to moisten sandwiches.",
     "price": "187 cent",
     "price_postapoc": "5 USD",
-    "material": [ "junk", "egg" ],
+    "material": [ "egg" ],
     "weight": "15 g",
     "volume": "250 ml",
     "comestible_type": "DRINK",
@@ -68,7 +68,7 @@
     "charges": 16,
     "fun": -7,
     "phase": "liquid",
-    "vitamins": [ [ "egg_allergen", 1 ], [ "junk_allergen", 1 ] ]
+    "vitamins": [ [ "egg_allergen", 1 ] ]
   },
   {
     "id": "ketchup",
@@ -101,7 +101,7 @@
     "description": "A condiment made from the seeds of a mustard plant (/Brassica/ or /Sinapis/), vinegar, salt, and spices.",
     "price": "50 cent",
     "price_postapoc": "1 USD",
-    "material": [ "junk" ],
+    "material": [ "water" ],
     "weight": "5 g",
     "volume": "250 ml",
     "comestible_type": "DRINK",
@@ -112,7 +112,7 @@
     "spoils_in": "15 days",
     "charges": 48,
     "phase": "liquid",
-    "vitamins": [ [ "iron", 2 ], [ "junk_allergen", 1 ] ]
+    "vitamins": [ [ "iron", 2 ] ]
   },
   {
     "id": "honey_bottled",
@@ -150,7 +150,7 @@
     "volume": "250 ml",
     "comestible_type": "DRINK",
     "container": "jar_glass_sealed",
-    "material": [ "junk", "nut" ],
+    "material": [ "nut" ],
     "quench": -2,
     "calories": 190,
     "charges": 8,


### PR DESCRIPTION
## Purpose of change (The Why)

These are condiments and are not known for being sugary or otherwise junk food. They can in fact be perfectly healthy.

## Describe the solution (The How)

- Mayo and Mustard are no-longer junk food
- Removes the junk material from peanut butter given it doesn't have the allergen in the first place

## Describe alternatives you've considered

- Leave mayo as junk food
- Make peanut butter junk food

## Testing

Lints

## Additional context

Ketchup is still junk food because that is legitimately sugary a lot of the time.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
