### PR TITLE
feat(balance): double the range of chemical spray ammo to 8

### DIFF
--- a/data/json/items/ammo/chemical_spray.json
+++ b/data/json/items/ammo/chemical_spray.json
@@ -14,7 +14,7 @@
     "container": "pressurized_tank_chem",
     "phase": "liquid",
     "ammo_type": "chemical_spray",
-    "range": 4,
+    "range": 8,
     "count": 800,
     "effects": [ "TOXICGAS", "NEVER_MISFIRES", "JET" ]
   },
@@ -33,7 +33,7 @@
     "container": "pressurized_tank_chem",
     "phase": "liquid",
     "ammo_type": "chemical_spray",
-    "range": 4,
+    "range": 8,
     "count": 800,
     "effects": [ "GAS_FUNGICIDAL", "STREAM_GAS_FUNGICIDAL", "NEVER_MISFIRES", "JET" ]
   },
@@ -52,7 +52,7 @@
     "container": "pressurized_tank_chem",
     "phase": "liquid",
     "ammo_type": "chemical_spray",
-    "range": 4,
+    "range": 8,
     "count": 800,
     "effects": [ "GAS_INSECTICIDAL", "STREAM_GAS_INSECTICIDAL", "NEVER_MISFIRES", "JET" ]
   }


### PR DESCRIPTION
The ranges of chemical spray ammos were too short, so I thought it would be better if the range is longer

<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

The range of chemical sprays were too short, so I buffed it a bit.

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)

<!-- e.g nerfs monster A -->
doubles the range of ammos, from 4 to 8

## Describe alternatives you've considered

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->
Tested it, works.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
