### PR TITLE
feat: add easier recipe for nitric acid (Birkeland-Eyde)

### DIFF
--- a/data/json/recipes/chem/chemicals.json
+++ b/data/json/recipes/chem/chemicals.json
@@ -433,6 +433,23 @@
     "components": [ [ [ "water", 3 ], [ "water_clean", 3 ] ], [ [ "ammonia", 1 ] ] ]
   },
   {
+    "//": "abstracted Birkeland-Eyde process, using electric arc to fix nitrogen from air into nitric oxide, which is then oxidized to nitrogen dioxide and absorbed into water to form nitric acid",
+    "type": "recipe",
+    "result": "chem_nitric_acid",
+    "id_suffix": "birkeland_eyde",
+    "category": "CC_CHEM",
+    "subcategory": "CSC_CHEM_CHEMICALS",
+    "skill_used": "cooking",
+    "difficulty": 4,
+    "time": "60 m",
+    "autolearn": true,
+    "batch_time_factors": [ 80, 5 ],
+    "book_learn": [ [ "textbook_chemistry", 3 ], [ "adv_chemistry", 3 ], [ "reference_cooking", 3 ] ],
+    "qualities": [ { "id": "CONTAIN", "level": 1 }, { "id": "CHEM", "level": 1 }, { "id": "WELD", "level": 1 } ],
+    "using": [ [ "welding_standard", 50 ] ],
+    "components": [ [ [ "water", 3 ], [ "water_clean", 3 ] ] ]
+  },
+  {
     "type": "recipe",
     "result": "chem_nitric_acid",
     "id_suffix": "from muriatic",


### PR DESCRIPTION
## Purpose of change (The Why)

read https://gall.dcinside.com/board/view/?id=rlike&no=509056, OP mentioned there's way easier method than Ostwald process to generate nitric acitd, so naturally, we should have an easier method.

## Describe the solution (The How)

Add [Birkeland-Eyde process (1903)](https://en.wikipedia.org/wiki/Birkeland–Eyde_process), which is way easier but less efficient (10x!) method for producing nitric acid. it uses electric arc to oxidize atmospheric nitrogen.

## Testing

<img width="1410" height="850" alt="image" src="https://github.com/user-attachments/assets/43057e1d-f69e-4c5a-b6b3-d51e435787d8" />

## Additional context

> The Birkeland–Eyde process is relatively inefficient in terms of energy consumption. Therefore, in the 1910s and 1920s, it was gradually replaced in Norway by a combination of the [Haber process](https://en.wikipedia.org/wiki/Haber_process) and the [Ostwald process](https://en.wikipedia.org/wiki/Ostwald_process).

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
