### PR TITLE
chore: remove the roofs above the stairs on top of the water tower

### DIFF
--- a/data/json/mapgen/water_tower/water_tower_5zl.json
+++ b/data/json/mapgen/water_tower/water_tower_5zl.json
@@ -33,7 +33,7 @@
         "........................"
       ],
       "palettes": [ "water_tower" ],
-      "terrain": { " ": "t_od_metal_floor", ".": "t_open_air" },
+      "terrain": { " ": "t_od_metal_floor", ".": "t_open_air", ">": "t_stairs_down_no_roof" },
       "furniture": { "s": "f_small_satelitte_dish", "c": "f_cellphone_booster" }
     }
   }


### PR DESCRIPTION
## Purpose of change (The Why)
Because the roofs above the stairs are floating in the open air without any support.
## Describe the solution (The How)
Replace the stairs at the top of the water tower with this terrain "t_stairs_down_no_roof"
## Describe alternatives you've considered
none
## Testing
no errors
## Additional context

<details>
<summary>Screenshots (Before):</summary>
<br><a href="https://github.com"><img src="https://github.com/user-attachments/assets/ec9d747f-329a-408d-8799-588afced82ac"></a>
</details>

<details>
<summary>Screenshots (After):</summary>
<br><a href="https://github.com"><img src="https://github.com/user-attachments/assets/286ee3ea-a412-43d6-a804-8eab503a8a0c"></a>
</details>

## Checklist

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.