### PR TITLE
fix: Fix lockpicking crash

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -1489,7 +1489,7 @@ void lockpick_activity_actor::start( player_activity &/*act*/, Character & )
 
     if( furn_type != f_null && !furn_type->lockpick_result.is_null() ) {
         progress.emplace( furn_type->name(), moves_total );
-    } else if( veh && door_lock) {
+    } else if( veh && door_lock ) {
         progress.emplace( veh->vehicle().name, moves_total );
     } else {
         if( ter_type->lockpick_result.is_null() ) {


### PR DESCRIPTION

## Purpose of change (The Why)

Fixes #7752 

## Describe the solution (The How)

Better fall through of options. Previously it would get stuck on the first one and error over that instead of trying the others. 

## Testing

Save file posted in #7752 works now. 
