### PR TITLE
fix: prevent current power level from exceding max power level

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2265,6 +2265,9 @@ void Character::mod_power_level( const units::energy &npower )
 void Character::mod_max_power_level( const units::energy &npower_max )
 {
     max_power_level += npower_max;
+    if( power_level > max_power_level ) {
+        set_power_level( max_power_level );
+    }
 }
 
 bool Character::is_max_power() const


### PR DESCRIPTION
## Purpose of change (The Why)
followup to: #7739
Also fixes an issue mentioned by chaos
> I recall ages ago that spells that grant bionic power on use can exceed the max too,

## Describe the solution (The How)
If power level greater then max power on modifying max power
Set to max power

## Describe alternatives you've considered
None

## Testing
Added and powered then removed the power supply Mk2
Never exceeding the maximum permitted

## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.