### PR TITLE
fix: remove upgraded bionic from bionic slot count

### DIFF
--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -2770,7 +2770,10 @@ std::map<bodypart_id, int> Character::bionic_installation_issues( const bionic_i
         return issues;
     }
     for( const std::pair<const bodypart_str_id, int> &elem : bioid->occupied_bodyparts ) {
-        const int lacked_slots = elem.second - get_free_bionics_slots( elem.first );
+        int lacked_slots = elem.second - get_free_bionics_slots( elem.first );
+        if( bioid->upgraded_bionic ) {
+            lacked_slots -= bioid->upgraded_bionic->occupied_bodyparts.at( elem.first );
+        }
         if( lacked_slots > 0 ) {
             issues.emplace( elem.first, lacked_slots );
         }


### PR DESCRIPTION
## Purpose of change (The Why)
fixes: #7751

## Describe the solution (The How)
Reduce bionic slots needed by bionic slots in the bionic being upgraded

## Describe alternatives you've considered
Reconsider alternatives to bionic balancing

## Testing
I can now install the bionic reactor thingy while having other bionics installed ( which takes 55 slots for the upgrade ) 

## Additional context
~~Honestly bio reactor slot cost might also need to be rebalanced~~

## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.