### PR TITLE
feat(UI): add spells to overview and fix profession spell display

### DIFF
--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -3350,8 +3350,7 @@ tab_direction set_description( avatar &you, const bool allow_reroll,
         if( !you.prof->spells().empty() ) {
             for( const std::pair<spell_id, int> spell_pair : you.prof->spells() ) {
                 trim_and_print( w_bionics, point( 0, pos ), getmaxx( w_bionics ) - 1,
-                                c_white, "\t" + string_format( _( "%s level %d" ), spell_pair.first->name,
-                                        spell_pair.second ) + "\n" );
+                                c_white, "\t" + string_format( _( "%s level %d" ), spell_pair.first->name, spell_pair.second ) );
                 pos++;
             }
         } else {


### PR DESCRIPTION
## Purpose of change (The Why)
> the spell list in the character preview UI probably should have a \n after each spell name
I then realized that I never added spells to overview

## Describe the solution (The How)
Add spells to the overview section and add a \n after each spell in the profession preview

## Describe alternatives you've considered
Screm

## Testing
I opened magical nights
Choose the storm thingy
It looked right in profession preview
And there are now spells in overview

## Additional context
~~UI is evil~~
<img width="1920" height="1080" alt="2026-01-02-090131_1920x1080_scrot" src="https://github.com/user-attachments/assets/86f4c674-4db9-4b9f-96a8-765f35166298" />
<img width="1920" height="1080" alt="2026-01-02-090121_1920x1080_scrot" src="https://github.com/user-attachments/assets/5ecb8c4b-dccb-4d4d-8527-e6994646770c" />

## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.