### PR TITLE
fix: add turn cost to furniture transform action

### DIFF
--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -1831,6 +1831,7 @@ void iexamine::transform( player &p, const tripoint &pos )
                 }
                 g->m.ter_set( pos, g->m.get_ter_transforms_into( pos ) );
             }
+            p.moves -= to_moves<int>( 2_seconds );
             return;
         }
         case 2: {


### PR DESCRIPTION
## Purpose of change

> idk if its worth its own issue or not, but flipping tables costs no turns to do such. i.e. you can examine, select table flip and un-flip infinitely with no turn cost.
> 
> it should be the same amount of time that moving furniture like chairs/tables/shelves/etc have.

https://github.com/cataclysmbn/Cataclysm-BN/issues/7672#issuecomment-3700547505