### PR TITLE
feat: make explosions and smashing randomly flip tables

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -3750,6 +3750,16 @@ bash_results map::bash_ter_furn( const tripoint &p, const bash_params &params )
             sounds::sound( p, sound_volume, sounds::sound_t::combat, bash->sound_fail, false,
                            "smash_fail", soundfxvariant );
         }
+
+        if( !smash_ter && smax > 0 ) {
+            const auto flipped_version = get_furn_transforms_into( p );
+            if( flipped_version != furn_str_id::NULL_ID() ) {
+                const int damage_percent = ( params.strength * 100 ) / smax;
+                if( rng( 1, 100 ) <= damage_percent ) {
+                    furn_set( p, flipped_version );
+                }
+            }
+        }
     } else {
         if( smash_ter ) {
             result |= bash_ter_success( p, params );


### PR DESCRIPTION
## Purpose of change

Closes #7674

## Describe the solution

When furniture survives bash, flip chance = (damage / max_hp) * 100%

## Testing

<img width="1747" height="1227" alt="image" src="https://github.com/user-attachments/assets/3c50425a-fe35-4ef6-9edf-e4c1ae4ae677" />

## Checklist

### Mandatory

- [x] I wrote the PR title in conventional commit format.
- [x] I ran the code formatter.
- [x] I linked any relevant issues using github keyword syntax.
- [x] I've committed my changes to new branch that isn't `main`.