### PR TITLE
fix: include reactor power in battery charge time calculation

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -5343,7 +5343,8 @@ int vehicle::total_water_wheel_epower_w() const
 int vehicle::net_battery_charge_rate_w() const
 {
     return total_engine_epower_w() + total_alternator_epower_w() + total_accessory_epower_w() +
-           total_solar_epower_w() + total_wind_epower_w() + total_water_wheel_epower_w();
+           total_solar_epower_w() + total_wind_epower_w() + total_water_wheel_epower_w() +
+           max_reactor_epower_w();
 }
 
 int vehicle::max_reactor_epower_w() const


### PR DESCRIPTION
## Purpose of change (The Why)

Closes #7714

Reactor power generation was not included in the calculation for remaining time to charge/discharge vehicle batteries, causing incorrect time estimates when reactors were active.

## Describe the solution (The How)

Added `max_reactor_epower_w()` to the return value of `vehicle::net_battery_charge_rate_w()` in `src/vehicle.cpp`.

## Testing

<img width="2690" height="1570" alt="image" src="https://github.com/user-attachments/assets/5f005f34-e526-4e5c-8303-3c2c1d5eb14c" />

## Additional context

The bug was in `src/vehicle.cpp` line 5343-5347, where `net_battery_charge_rate_w()` was missing reactor power from its calculation. This function is called by `vehicle_display.cpp` to estimate time remaining for battery charge/discharge.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.