### PR TITLE
fix: check favorited items in container contents for autonotes

### DIFF
--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -68,6 +68,7 @@
 #include "stomach.h"
 #include "string_formatter.h"
 #include "string_id.h"
+#include "string_utils.h"
 #include "translations.h"
 #include "trap.h"
 #include "units.h"
@@ -444,9 +445,7 @@ void drop_on_map( Character &c, item_drop_reason reason,
         | std::ranges::to<std::vector>();
 
         if( !all_favorited_names.empty() ) {
-            auto note_text = all_favorited_names
-                             | std::views::join_with( std::string_view( "; " ) )
-                             | std::ranges::to<std::string>();
+            const auto note_text = join( all_favorited_names, "; " );
 
             if( !overmap_buffer.has_note( your_pos ) ) {
                 overmap_buffer.add_note( your_pos, note_text );


### PR DESCRIPTION
## Purpose of change (The Why)

Closes #7770

Favorited items inside non-favorited containers don't generate autonotes when dropped.

## Describe the solution (The How)

Added helper function `collect_favorited_item_names()` that recursively checks container contents for favorited items. Modified `drop_on_map()` to use this helper, checking all dropped items and their contents for favorited items before creating autonotes.

## Testing

<img width="2690" height="1570" alt="image" src="https://github.com/user-attachments/assets/90285b4c-b06f-491a-9217-de172deaaa16" />

## Checklist

### Mandatory

- [x] I wrote the PR title in conventional commit format.
- [x] I ran the code formatter.
- [x] I linked any relevant issues using github keyword syntax like `closes #7770`.
- [x] I've committed my changes to new branch that isn't `main`.