### PR TITLE
feat: add pelletizing recipe for ammonium nitrate

### DIFF
--- a/data/json/recipes/chem/chemicals.json
+++ b/data/json/recipes/chem/chemicals.json
@@ -519,6 +519,23 @@
   },
   {
     "type": "recipe",
+    "result": "chem_ammonium_nitrate_pellets",
+    "id_suffix": "from_powder",
+    "category": "CC_CHEM",
+    "subcategory": "CSC_CHEM_CHEMICALS",
+    "skill_used": "cooking",
+    "difficulty": 2,
+    "charges": 100,
+    "time": "20 m",
+    "autolearn": true,
+    "batch_time_factors": [ 80, 4 ],
+    "//": "Wet granulation: dampening ammonium nitrate powder with water to form cohesive pellets, then drying them. Requires gentle heating to evaporate moisture without decomposing the compound.",
+    "qualities": [ { "id": "CONTAIN", "level": 1 } ],
+    "tools": [ [ [ "surface_heat", 5, "LIST" ] ] ],
+    "components": [ [ [ "chem_ammonium_nitrate", 100 ] ], [ [ "water", 1 ], [ "water_clean", 1 ] ] ]
+  },
+  {
+    "type": "recipe",
     "result": "chem_potassium_hydroxide",
     "byproducts": [ [ "water" ] ],
     "category": "CC_CHEM",


### PR DESCRIPTION
## Purpose of change (The Why)

Previously, there was no recipe to convert ammonium nitrate powder to pellets, despite the reverse (pellets to powder) existing. This creates an asymmetry where players can grind pellets but cannot reform them.

## Describe the solution (The How)

Added a recipe that converts ammonium nitrate powder to pellets using wet granulation process:
- Takes 100 charges of ammonium nitrate powder
- Requires small amount of water as binder
- Uses gentle heat to dry the pellets
- Takes 20 minutes (realistic for forming and drying)
- Difficulty 2 (simple but requires some knowledge)

## Describe alternatives you've considered

- Could have made it instant like the fertilizer unpacking, but wet granulation realistically requires drying time
- Could have required specialized tools, but wet granulation can be done with basic containers

## Testing

<img width="2690" height="1570" alt="image" src="https://github.com/user-attachments/assets/85661d80-30d6-4148-8944-07ee682126cc" />
