### PR TITLE
fix(UI): remove visual glitch on holes after explosion

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -6,6 +6,7 @@
 #include <climits>
 #include <cstdlib>
 #include <cstring>
+#include <ranges>
 #include <limits>
 #include <optional>
 #include <ostream>
@@ -1518,7 +1519,11 @@ void map::furn_set( const tripoint &p, const furn_id &new_furniture,
     if( ( old_t.has_flag( TFLAG_NO_FLOOR ) != new_t.has_flag( TFLAG_NO_FLOOR ) ) ||
         ( old_t.has_flag( TFLAG_Z_TRANSPARENT ) != new_t.has_flag( TFLAG_Z_TRANSPARENT ) ) ) {
         set_floor_cache_dirty( p.z );
-        set_seen_cache_dirty( p );
+        // Changes to floor / z-transparency can reveal (or hide) tiles on the z-level below.
+        // Invalidate seen caches unconditionally for both affected levels so tiles drawing
+        // does not render stale BLANK visibility after events like explosions.
+        set_seen_cache_dirty( p.z );
+        set_seen_cache_dirty( p.z - 1 );
     }
 
     if( old_t.has_flag( TFLAG_SUN_ROOF_ABOVE ) != new_t.has_flag( TFLAG_SUN_ROOF_ABOVE ) ) {
@@ -1850,12 +1855,16 @@ bool map::ter_set( const tripoint &p, const ter_id &new_terrain )
         set_floor_cache_dirty( p.z );
         // It's a set, not a flag
         support_cache_dirty.insert( p );
-        set_seen_cache_dirty( p );
+        // Opening/closing a floor affects visibility on this and the level below.
+        set_seen_cache_dirty( p.z );
+        set_seen_cache_dirty( p.z - 1 );
     }
 
     if( new_t.has_flag( TFLAG_Z_TRANSPARENT ) != old_t.has_flag( TFLAG_Z_TRANSPARENT ) ) {
         set_floor_cache_dirty( p.z );
-        set_seen_cache_dirty( p );
+        // Changing z-transparency affects visibility between this z-level and the one below.
+        set_seen_cache_dirty( p.z );
+        set_seen_cache_dirty( p.z - 1 );
     }
 
     if( new_t.has_flag( TFLAG_SUSPENDED ) != old_t.has_flag( TFLAG_SUSPENDED ) ) {
@@ -6048,7 +6057,7 @@ void map::update_visibility_cache( const int zlev )
     int sm_squares_seen[MAPSIZE][MAPSIZE];
     std::memset( sm_squares_seen, 0, sizeof( sm_squares_seen ) );
 
-    int min_z = fov_3d ? -OVERMAP_DEPTH : zlev;
+    int min_z = fov_3d ? -OVERMAP_DEPTH : ( zlevels ? std::max( zlev - 1, -OVERMAP_DEPTH ) : zlev );
     int max_z = fov_3d ? OVERMAP_HEIGHT : zlev;
 
     for( int z = min_z; z <= max_z; z++ ) {
@@ -8765,6 +8774,7 @@ void map::build_map_cache( const int zlev, bool skip_lightmap )
     const int minz = zlevels ? -OVERMAP_DEPTH : zlev;
     const int maxz = zlevels ? OVERMAP_HEIGHT : zlev;
     bool seen_cache_dirty = false;
+    std::vector<int> dirty_seen_cache_levels;
     for( int z = minz; z <= maxz; z++ ) {
         // trigger FOV recalculation only when there is a change on the player's level or if fov_3d is enabled
         const bool affects_seen_cache =  z == zlev || fov_3d;
@@ -8772,7 +8782,11 @@ void map::build_map_cache( const int zlev, bool skip_lightmap )
         build_transparency_cache( z );
         update_suspension_cache( z );
         seen_cache_dirty |= ( build_floor_cache( z ) && affects_seen_cache );
-        seen_cache_dirty |= get_cache( z ).seen_cache_dirty && affects_seen_cache;
+        const bool level_seen_dirty = get_cache( z ).seen_cache_dirty;
+        seen_cache_dirty |= level_seen_dirty;
+        if( level_seen_dirty ) {
+            dirty_seen_cache_levels.push_back( z );
+        }
         diagonal_blocks fill = {false, false};
         std::uninitialized_fill_n( &( get_cache( z ).vehicle_obscured_cache[0][0] ), MAPSIZE_X * MAPSIZE_Y,
                                    fill );
@@ -8798,7 +8812,13 @@ void map::build_map_cache( const int zlev, bool skip_lightmap )
         player_prev_pos = p;
     }
     if( !skip_lightmap ) {
-        generate_lightmap( zlev );
+        dirty_seen_cache_levels.push_back( zlev );
+        std::ranges::sort( dirty_seen_cache_levels );
+        dirty_seen_cache_levels.erase( std::ranges::unique( dirty_seen_cache_levels ).begin(),
+                                       dirty_seen_cache_levels.end() );
+        for( const int level : dirty_seen_cache_levels ) {
+            generate_lightmap( level );
+        }
     }
 }
 

--- a/tests/zlevel_visibility_cache_test.cpp
+++ b/tests/zlevel_visibility_cache_test.cpp
@@ -1,0 +1,72 @@
+#include "catch/catch.hpp"
+#include "map_helpers.h"
+
+#include "avatar.h"
+#include "calendar.h"
+#include "game.h"
+#include "map.h"
+#include "options_helpers.h"
+#include "point.h"
+#include "state_helpers.h"
+#include "type_id.h"
+
+TEST_CASE( "opening_floor_invalidates_below_seen_cache", "[vision][zlevel]" )
+{
+    clear_all_state();
+
+    map &here = get_map();
+
+    const ter_id t_floor( "t_floor" );
+    const ter_id t_open_air( "t_open_air" );
+
+    // Place the player on z=1 so we have a meaningful "below".
+    g->place_player( tripoint( 60, 60, 1 ) );
+
+    const tripoint hole_pos = g->u.pos() + point_east;
+
+    // Ensure deterministic starting terrain.
+    here.ter_set( hole_pos, t_floor );
+    here.ter_set( hole_pos + tripoint_below, t_floor );
+
+    // Simulate the pre-breach state where the below-z tile wasn't previously seen.
+    level_cache &below_cache = here.access_cache( hole_pos.z - 1 );
+    below_cache.seen_cache_dirty = false;
+    below_cache.seen_cache[hole_pos.x][hole_pos.y] = 0.0f;
+    below_cache.camera_cache[hole_pos.x][hole_pos.y] = 0.0f;
+
+    REQUIRE_FALSE( here.access_cache( hole_pos.z - 1 ).seen_cache_dirty );
+
+    // Breach the floor (what explosions often do). This must invalidate the below-z seen cache.
+    here.ter_set( hole_pos, t_open_air );
+
+    CHECK( here.access_cache( hole_pos.z - 1 ).seen_cache_dirty );
+}
+
+TEST_CASE( "opening_floor_rebuilds_below_light", "[vision][zlevel]" )
+{
+    clear_all_state();
+
+    override_option fov3d( "FOV_3D", "false" );
+
+    map &here = get_map();
+
+    const ter_id t_floor( "t_floor" );
+    const ter_id t_open_air( "t_open_air" );
+
+    g->place_player( tripoint( 60, 60, 1 ) );
+
+    calendar::turn = calendar::turn_zero + 12_hours;
+
+    const tripoint hole_pos = g->u.pos() + point_east;
+
+    here.ter_set( hole_pos, t_open_air );
+    here.ter_set( hole_pos + tripoint_below, t_floor );
+
+    here.build_map_cache( g->u.posz() );
+    here.update_visibility_cache( g->u.posz() );
+
+    const level_cache &below_cache = here.access_cache( hole_pos.z - 1 );
+
+    CHECK( below_cache.seen_cache[hole_pos.x][hole_pos.y] > 0.0f );
+    CHECK( below_cache.visibility_cache[hole_pos.x][hole_pos.y] != lit_level::BLANK );
+}


### PR DESCRIPTION
## Purpose of change (The Why)

remove those pesky cyan dots after explosion

## Describe the solution (The How)

- remove cyan dot for open air tiles
- invalidate visibility for 1 floor below when opening a floor tile
- calculate all dirty lightmap z-levels instead of current floor only

## Describe alternatives you've considered

## Testing

<table>
  <thead>
    <tr>
      <th width="50%">before</th>
      <th width="50%">after</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>
        <img src="https://github.com/user-attachments/assets/e6ad7d37-9e62-4884-bb74-2aac64c91a8d" width="100%">
      </td>
      <td>
        <img src="https://github.com/user-attachments/assets/5eca7331-60d2-4861-8dad-195197b4c024" width="100%">
      </td>
    </tr>
  </tbody>
</table>

https://github.com/user-attachments/assets/443235e0-ea32-4483-af25-a5449334710b

## Additional context

- this bug prolly existed since #1743
- 10 premium usage of GPT 5.2 was totally worth it

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
