### PR TITLE
docs: fix minor typos and JSON syntax in item_creation.md

### DIFF
--- a/docs/en/mod/json/reference/items/item_creation.md
+++ b/docs/en/mod/json/reference/items/item_creation.md
@@ -633,7 +633,7 @@ can be planted:
     "grow" : 91 // A time duration: how long it takes for a plant to fully mature. Based around a 91 day season length (roughly a real world season) to give better accuracy for longer season lengths
                 // Note that growing time is later converted based upon the season_length option, basing it around 91 is just for accuracy purposes
                 // A value 91 means 3 full seasons, a value of 30 would mean 1 season.
-    "required_terrain_flag" : "PLANTABLE" // A tag that terrain and furniture would need to have in order for the seed to be plantable there.
+    "required_terrain_flag": "PLANTABLE" // A tag that terrain and furniture would need to have in order for the seed to be plantable there.
 					 // Default is "PLANTABLE", and using this will cause any terain the plant is wrown on to turn into dirt once the plant is planted, unless furniture is used.
 					 // Using any other tag will not turn the terrain into dirt.
 }


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
"Identity unknown, but duty calls. 🐾"

I’ve notified the Neko-Neko Network (NNN) that the "Cat Distribution System" needs to dispatch some grooming assistance here in the Bright Nights wastes.

While working on the Japanese translation, I found several "fleas" (tiny typos and missing quotes in JSON examples) hiding deep in the fur of item_creation.md. While the Deno+Lume site renders them gracefully, they can cause "itching" (errors) for modders who copy-paste the code.
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
I have performed a thorough "de-fleaing" (grooming) of the document:

- Fixed missing quotes in fuel and rand_charges sections.
- Corrected minor typos in property names and comments.
- Added/fixed json code tags to ensure proper syntax highlighting in all environments.
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
Leaving the "fleas" as they are, but it's Neko-protocol to keep our fur—and our code—shiny and parasite-free.
## Testing
Checked the file structure. Since these are minor documentation fixes, they won't affect game logic but will prevent copy-paste errors for other users.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context
Dealing with these "fleas" made me realize we definitely need a "Neko Grooming Brush" in-game to keep our gear (and ourselves) in top condition! 

にゃん！ (Nyan!)
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.


