### PR TITLE
feat: add `repair_difficulty` field to items

### DIFF
--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -1758,7 +1758,8 @@
     "price_postapoc": "5 cent",
     "material": [ "plastic" ],
     "weight": "4 g",
-    "flags": [ "FANCY" ]
+    "flags": [ "FANCY" ],
+    "repair_difficulty": 2
   },
   {
     "id": "towel",

--- a/docs/en/mod/json/reference/items/item_creation.md
+++ b/docs/en/mod/json/reference/items/item_creation.md
@@ -71,6 +71,7 @@
     }
   }
 },
+"repair_difficulty": 2                       // Overrites recipe difficulty being used for repair difficulty
 ```
 
 #### damage_instance

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -2634,6 +2634,7 @@ void Item_factory::load_basic_info( const JsonObject &jo, itype &def, const std:
     assign( jo, "magazine_well", def.magazine_well );
     assign( jo, "explode_in_fire", def.explode_in_fire );
     assign( jo, "solar_efficiency", def.solar_efficiency );
+    assign( jo, "repair_difficulty", def.repair_difficulty );
     assign( jo, "ascii_picture", def.picture_id );
 
     if( jo.has_member( "thrown_damage" ) ) {

--- a/src/itype.h
+++ b/src/itype.h
@@ -1075,6 +1075,10 @@ struct itype {
          */
         float solar_efficiency = 0;
 
+        // Sets repair difficulty for items
+        // Overrides recipe difficulty
+        int repair_difficulty = -1;
+
         FlagsSetType item_tags;
 
         std::string get_item_type_string() const;

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -3300,7 +3300,10 @@ bool repair_item_actor::handle_components( player &pl, const item &fix,
 static int find_repair_difficulty( const player &pl, const itype_id &id, bool training )
 {
     // If the recipe is not found, this will remain unchanged
-    int min = -1;
+    int min = id->repair_difficulty;
+    if( min != -1 ) {
+        return min;
+    }
     for( const auto &e : recipe_dict ) {
         const auto r = e.second;
         if( id != r.result() ) {


### PR DESCRIPTION
## Purpose of change (The Why)
> It's because the hair pin isn't a craftable item, so it has max difficulty
> I hate that code raaaahhhh

Must prevent angry derg

## Describe the solution (The How)
Add repair difficulty field which takes priority over recipe difficulty

## Describe alternatives you've considered
Break all mods and require this field on all items :P


## Testing
The fancy hairpin, unlike what was seen earlier today
Can still be repaired

## Additional context
I give proof too
<img width="1920" height="1080" alt="2026-01-04-155055_1920x1080_scrot" src="https://github.com/user-attachments/assets/3a771c53-d5a4-4912-83f0-9cae0eb00e01" />

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional
- [x] This is a C++ PR that modifies JSON loading or behavior.
  - [x] I have documented the changes in the appropriate location in the `docs/` folder.