### PR TITLE
feat(UI): add option for vehicle spawn rate scaling

### DIFF
--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -2162,7 +2162,15 @@ class jmapgen_vehicle : public jmapgen_piece
         }
         void apply( const mapgendata &dat, const jmapgen_int &x, const jmapgen_int &y
                   ) const override {
-            if( !x_in_y( chance.get(), 100 ) ) {
+            const auto raw_chance = chance.get();
+            if( raw_chance != 100 ) {
+                const auto vehicle_spawn_rate = get_option<float>( "VEHICLE_SPAWNRATE" );
+                const auto scaled_chance =
+                    std::clamp( static_cast<int>( std::lround( raw_chance * vehicle_spawn_rate ) ), 0, 100 );
+                if( !x_in_y( scaled_chance, 100 ) ) {
+                    return;
+                }
+            } else if( !x_in_y( raw_chance, 100 ) ) {
                 return;
             }
             vgroup_id chosen_id = type.get( dat );

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2466,6 +2466,11 @@ void options_manager::add_options_world_default()
          translate_marker( "Determines if new vehicles can spawn with locked doors." ), true
        );
 
+    add( "VEHICLE_SPAWNRATE", world_default, translate_marker( "Vehicle spawn rate scaling factor" ),
+         translate_marker( "A scaling factor that determines density of vehicle spawns." ),
+         0.0, 5.0, 1.0, 0.01
+       );
+
     add( "SPAWN_DENSITY", world_default, translate_marker( "Spawn rate scaling factor" ),
          translate_marker( "A scaling factor that determines density of monster spawns." ),
          0.0, 50.0, 1.0, 0.1

--- a/src/vehicle_group.cpp
+++ b/src/vehicle_group.cpp
@@ -9,6 +9,7 @@
 #include "json.h"
 #include "map.h"
 #include "memory_fast.h"
+#include "options.h"
 #include "point.h"
 #include "rng.h"
 #include "translations.h"
@@ -200,10 +201,15 @@ void VehicleSpawn::reset()
 
 void VehicleSpawn::apply( map &m, const std::string &terrain_name ) const
 {
-    const shared_ptr_fast<VehicleFunction> *func = types.pick();
-    if( func == nullptr ) {
-        debugmsg( "unable to find valid function for vehicle spawn" );
-    } else {
+    const auto vehicle_spawn_rate = get_option<float>( "VEHICLE_SPAWNRATE" );
+    const auto num_applications = roll_remainder( vehicle_spawn_rate );
+
+    for( int i = 0; i < num_applications; i++ ) {
+        const shared_ptr_fast<VehicleFunction> *func = types.pick();
+        if( func == nullptr ) {
+            debugmsg( "unable to find valid function for vehicle spawn" );
+            return;
+        }
         ( *func )->apply( m, terrain_name );
     }
 }


### PR DESCRIPTION
## Purpose of change (The Why)

there has been reports that there's just too many cars in sidewalk in general, making driving highly annoying. might as well as make it configurable

## Describe the solution (The How)

- added world option `VEHICLE_SPAWNRATE` to control vehicle spawn rate

## Describe alternatives you've considered

maybe set default to 0.5?

## Testing

### spawn rate 0

<img width="2690" height="1570" alt="image" src="https://github.com/user-attachments/assets/b659cdeb-3c22-48cc-a7d9-11fd757f3945" />

### spawn rate 5.00

<img width="2690" height="1570" alt="image" src="https://github.com/user-attachments/assets/293af7b0-e784-4045-9fe3-b0977356e541" />


## Additional context

<img src="https://styles.redditmedia.com/t5_3cs2l/styles/bannerBackgroundImage_ko5s8sh8b4t81.jpg?format=pjpg&s=e8fc4374273754c486f53b0af186bbd7c6c9b3bb" />

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
