### PR TITLE
ci: add PR title validation job

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -99,5 +99,4 @@ jobs:
 
     steps:
       - uses: docker://ghcr.io/scarf005/conventional-prs:main
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        env: { GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} }


### PR DESCRIPTION
## Purpose of change (The Why)

<img width="1971" height="1677" alt="image" src="https://github.com/user-attachments/assets/60a37768-4356-4ae0-84df-00ae69135168" />

add a conventional commit title tutor so it's easier to figure out why semantic PRs is angry

## Describe the solution (The How)

Add `validate-pr-title` job to autofix workflow using https://github.com/scarf005/conventional-prs action.

## Describe alternatives you've considered

screm

## Testing

Workflow will trigger on PR events. Validation uses existing `.github/semantic.yml` config.

## Checklist

### Mandatory

- [x] I wrote the PR title in conventional commit format.
- [x] I ran the code formatter.
- [x] I linked any relevant issues using github keyword syntax like `closes #1234` in Summary of the PR so it can be closed automatically.
- [x] I've committed my changes to new branch that isn't `main` so it won't cause conflict when updating `main` branch later.