### PR TITLE
fix(UI): disable zone overlay by default

### DIFF
--- a/src/game.h
+++ b/src/game.h
@@ -981,7 +981,7 @@ class game
 
         bool debug_pathfinding = false; // show NPC pathfinding on overmap ui
         bool debug_submap_grid_overlay = false;
-        bool show_zone_overlay = true;
+        bool show_zone_overlay = false;
 
         /* tile overlays */
         // Toggle all other overlays off and flip the given overlay on/off.


### PR DESCRIPTION
followup of #7768
fixes https://github.com/cataclysmbn/Cataclysm-BN/issues/7812
as said by others, we'd need a toggle key for this on zone manager sidebar for better visibility