### PR TITLE
fix: Reallow Ice Labs to spawn

### DIFF
--- a/data/json/overmap/overmap_mutable/lab.json
+++ b/data/json/overmap/overmap_mutable/lab.json
@@ -96,8 +96,8 @@
     "subtype": "mutable",
     "locations": [ "subterranean_empty" ],
     "city_distance": [ 10, -1 ],
-    "occurrences": [ 50, 0 ],
-    "flags": [ "LAB", "UNIQUE" ],
+    "occurrences": [ 1, 10 ],
+    "flags": [ "LAB" ],
     "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road" } ],
     "check_for_locations": [
       [ [ 0, 0, 0 ], [ "wilderness" ] ],


### PR DESCRIPTION
## Purpose of change (The Why)
I dont have quotes but I remember people being confused about the lack of ice labs except for when you spawn in them
I like letting players suffer

## Describe the solution (The How)
Readd ice labs with  [ 1, 10 ] occurances

## Describe alternatives you've considered
Change the probability

## Testing
I debug teleported to an ice lab
Worked now but not before

## Additional context
I didnt know we had sunken labs

## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.