### PR TITLE
fix: Prevent choosing locked bionics through scenario switching

### DIFF
--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -4124,6 +4124,7 @@ void reset_scenario( avatar &u, const scenario *scen )
     u.clear_mutations();
     u.recalc_hp();
     u.clear_skills();
+    u.clear_bionics();
     newcharacter::add_traits( u );
 }
 


### PR DESCRIPTION
## Purpose of change (The Why)
fixes #7808 

## Describe the solution (The How)
Call u.clear_bionics() when skill and trait clearing is called

## Describe alternatives you've considered
SCREM

## Testing
I tried to give myself underwater propellers in the mine by switching between experiement and mine
It didnt work

## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.