### PR TITLE
fix: correct tow cable pull direction

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -6599,8 +6599,8 @@ void vehicle::do_towing_move()
     const tripoint tower_tow_point = g->m.getabs( global_part_pos3( tow_index ) );
     const tripoint towed_tow_point = g->m.getabs( towed_veh->global_part_pos3( other_tow_index ) );
     // same as above, but where the pulling vehicle is pulling from
-    units::angle towing_veh_angle = towed_veh->get_angle_from_targ( tower_tow_point );
-    const bool reverse = towed_veh->tow_data.tow_direction == TOW_BACK;
+    const auto towing_veh_angle = towed_veh->get_angle_from_targ( tower_tow_point );
+    const auto reverse = towing_veh_angle > 90_degrees || towing_veh_angle < -90_degrees;
     int accel_y = 0;
     tripoint vehpos = global_square_location().raw();
     int turn_x = get_turn_from_angle( towing_veh_angle, vehpos, tower_tow_point, reverse );

--- a/tests/vehicle_towing_test.cpp
+++ b/tests/vehicle_towing_test.cpp
@@ -1,0 +1,52 @@
+#include "catch/catch.hpp"
+
+#include "game.h"
+#include "item.h"
+#include "map.h"
+#include "map_helpers.h"
+#include "state_helpers.h"
+#include "type_id.h"
+#include "vehicle.h"
+#include "vehicle_part.h"
+#include "vpart_position.h"
+
+TEST_CASE( "towed_vehicle_reverses_when_target_behind", "[vehicle][towing]" )
+{
+    clear_all_state();
+    build_test_map( ter_id( "t_pavement" ) );
+
+    map &here = get_map();
+
+    const tripoint towed_origin( 60, 60, 0 );
+    const tripoint tower_origin = towed_origin + tripoint_west * 10;
+
+    vehicle *towed = here.add_vehicle( vproto_id( "bicycle" ), towed_origin, 0_degrees, 0, 0 );
+    vehicle *tower = here.add_vehicle( vproto_id( "bicycle" ), tower_origin, 180_degrees, 0, 0 );
+
+    REQUIRE( towed != nullptr );
+    REQUIRE( tower != nullptr );
+
+    const auto add_tow_part = [&]( vehicle & veh, const tripoint & pos ) {
+        const optional_vpart_position vp = here.veh_at( pos );
+        REQUIRE( vp );
+
+        const auto vcoords = vp->mount();
+        auto tow_part = vehicle_part( vpart_id( "hd_tow_cable" ), vcoords, item::spawn( "hd_tow_cable" ),
+                                      &veh );
+        veh.install_part( vcoords, std::move( tow_part ) );
+    };
+
+    add_tow_part( *towed, towed_origin );
+    add_tow_part( *tower, tower_origin );
+
+    REQUIRE( tower->tow_data.set_towing( tower, towed ) );
+
+    tower->velocity = 1000;
+    towed->velocity = 0;
+
+    REQUIRE( tower->no_towing_slack() );
+
+    tower->do_towing_move();
+
+    CHECK( towed->velocity < 0 );
+}


### PR DESCRIPTION
Fixes cataclysmbn/Cataclysm-BN#6655.

- Make towing logic reverse the towed vehicle when the towing point is behind it (relative to the towed vehicle facing), preventing it from driving away when facing opposite.
- Add regression test.