### PR TITLE
build: Add cmake presets for aarch64 cross compilation

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -114,9 +114,7 @@
       "name": "linux-cross-aarch64",
       "binaryDir": "${sourceDir}/out/build/${presetName}",
       "generator": "Ninja",
-      "environment": {
-        "PKG_CONFIG_LIBDIR": "/usr/lib/aarch64-linux-gnu/pkgconfig"
-      },
+      "environment": { "PKG_CONFIG_LIBDIR": "/usr/lib/aarch64-linux-gnu/pkgconfig" },
       "cacheVariables": {
         "CMAKE_SYSTEM_NAME": "Linux",
         "CMAKE_SYSTEM_PROCESSOR": "aarch64",
@@ -132,20 +130,8 @@
         "CMAKE_INCLUDE_PATH": "/usr/include/aarch64-linux-gnu"
       }
     },
-    {
-      "name": "linux-slim-cross-aarch64",
-      "inherits": [
-        "linux-slim",
-        "linux-cross-aarch64"
-      ]
-    },
-    {
-      "name": "linux-full-cross-aarch64",
-      "inherits": [
-        "linux-full",
-        "linux-cross-aarch64"
-      ]
-    },
+    { "name": "linux-slim-cross-aarch64", "inherits": ["linux-slim", "linux-cross-aarch64"] },
+    { "name": "linux-full-cross-aarch64", "inherits": ["linux-full", "linux-cross-aarch64"] },
     {
       "name": "dist-tiles",
       "binaryDir": "${sourceDir}/build",
@@ -264,12 +250,7 @@
     {
       "name": "windows-msvc-build",
       "configurePreset": "windows-tiles-sounds-x64-msvc",
-      "targets": [
-        "cataclysm-bn-tiles",
-        "cata_test-tiles",
-        "json_formatter",
-        "translations"
-      ],
+      "targets": ["cataclysm-bn-tiles", "cata_test-tiles", "json_formatter", "translations"],
       "description": "Build for Windows with tiles and sounds using MSVC."
     },
     {
@@ -300,47 +281,31 @@
     {
       "name": "dist-tiles",
       "configurePreset": "dist-tiles",
-      "targets": [
-        "cataclysm-bn-tiles",
-        "json_formatter",
-        "translations"
-      ],
+      "targets": ["cataclysm-bn-tiles", "json_formatter", "translations"],
       "description": "Build for tiles distribution."
     },
     {
       "name": "dist-curses",
       "configurePreset": "dist-curses",
-      "targets": [
-        "cataclysm-bn",
-        "json_formatter",
-        "translations"
-      ],
+      "targets": ["cataclysm-bn", "json_formatter", "translations"],
       "description": "Build for curses distribution."
     },
     {
       "name": "lint",
       "configurePreset": "lint",
-      "targets": [
-        "json_formatter"
-      ],
+      "targets": ["json_formatter"],
       "description": "Build formatting tools only."
     },
     {
       "name": "ci-curses",
       "configurePreset": "ci-curses",
-      "targets": [
-        "cataclysm-bn",
-        "cata_test"
-      ],
+      "targets": ["cataclysm-bn", "cata_test"],
       "description": "CI build for curses."
     },
     {
       "name": "ci-tiles",
       "configurePreset": "ci-tiles",
-      "targets": [
-        "cataclysm-bn-tiles",
-        "cata_test-tiles"
-      ],
+      "targets": ["cataclysm-bn-tiles", "cata_test-tiles"],
       "description": "CI build for tiles and sound."
     }
   ]


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

Add CMake preset for aarch64 platform cross compilation.
It might be needed to port the game using Portmaster for portable game consoles.

## Describe the solution (The How)

Add preset to build for aarch64 platform using CMake, Ninja and Clang-20.

## Describe alternatives you've considered

## Testing

Tried using WSL and aarch64 toolchain.

```
cmake --preset linux-slim-cross-aarch64
cmake --build build --config MinSizeRel --preset linux-slim-cross-aarch64 --target cataclysm-bn-tiles
```

## Additional context

TODO:
Add description with tool chain and libs installation for aarch64:
**docs/en/dev/guides/building/cmake.md** 

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [ ] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [ ] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

<!-- please remove checkboxes unrelated to this PR. -->

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have added [`port` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#port%3A-ports-from-dda-or-other-forks) to the PR title.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR adds/removes a mod.
  - [ ] I have added [`mods` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#mods-or-mods%2F<mod_id>%3A-mods) to the PR title.
  - [ ] The `mod_name` in `data/mods/<mod_name>` matches `id` in `modinfo.json`.
  - [ ] I have committed the output of `deno task semantic`.
- [ ] This PR modifies lua scripts or the lua API.
  - [ ] I have added [`lua` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#lua%3A-changes-to-lua-api) to the PR title.
  - [ ] I have added [type annotations](https://emmylua.github.io/annotation.html) to functions so that it's safe and easy to maintain.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
