### PR TITLE
feat(UI): Change road marking symbol to make them visible in the dark

### DIFF
--- a/data/json/furniture_and_terrain/terrain-floors-outdoors.json
+++ b/data/json/furniture_and_terrain/terrain-floors-outdoors.json
@@ -291,7 +291,7 @@
     "name": "yellow pavement",
     "connects_to": "PAVEMENT",
     "description": "Streaks of carefully aligned yellow paint mark the road to inform drivers not to cross.  No one is enforcing these rules anymore.",
-    "symbol": ".",
+    "symbol": ":",
     "color": "yellow",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "FLAT", "ROAD", "MINEABLE" ],


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

The yellow pavement used for road lane markings shares a symbol with regular pavement, making them look the same in the dark, and in map memory. This seems like an oversight. Real world road markings are specifically designed to be visible in low light, graphical tilesets tend to have separate tiles for these, and even with ASCII you can actually see the lane markings in the minimap.

## Describe the solution (The How)

Changed symbol of `t_pavement_y` from `.` to `:`

## Describe alternatives you've considered

_**Obviously**_ the symbol should actually be `U+2022 • BULLET`, but due to some legacy code, that symbol can't be used for terrain. Item glyphs get to be more varied, but terrain and furniture are still stuck with 7-bit ASCII.

## Testing

Looked at the road.

## Additional context

Before:
<img width="322" height="304" alt="cata-2026-01-07-17-51-40" src="https://github.com/user-attachments/assets/46884b02-4312-48bb-8a1b-adbe86096eae" />

After:
<img width="291" height="276" alt="cata-2026-01-07-17-53-19" src="https://github.com/user-attachments/assets/0be803ef-d7d7-4f57-8171-a78eb158547e" />


## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional


