### PR TITLE
feat(UI,mods/pride_flags): Make pride flags modname rainbow colored

### DIFF
--- a/data/mods/pride_flags/modinfo.json
+++ b/data/mods/pride_flags/modinfo.json
@@ -2,7 +2,7 @@
   {
     "type": "MOD_INFO",
     "id": "pride_flags",
-    "name": "Pride Flags for BN",
+    "name": "<color_red>P</color><color_pink>r</color><color_yellow>i</color><color_green>d</color><color_blue>e</color> <color_magenta>F</color><color_red>l</color><color_pink>a</color><color_yellow>g</color><color_green>s</color> <color_blue>f</color><color_magenta>o</color><color_red>r</color> <color_pink>B</color><color_yellow>N</color>",
     "authors": [ "Robbietheneko" ],
     "maintainers": [ "Robbietheneko" ],
     "description": "Pride flags for Bright Nights, for all your roleplaying needs.",


### PR DESCRIPTION
## Purpose of change (The Why)
> Is CRIT supposed to be red on my mod list and loading screen?

> pride flags mod should have the rainbow colors

In order to alleviate confusion I agree that more mods should have colors

## Describe the solution (The How)
Add a lot of color tags

## Describe alternatives you've considered
Smuggle Arcana into the game like chaos once proposed

## Testing
See that fine image below

## Additional context
<img width="1920" height="1080" alt="2026-01-07-142252_1920x1080_scrot" src="https://github.com/user-attachments/assets/12ff430f-0bf5-4eb4-b366-e5008bd584af" />

## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.