### PR TITLE
fix: temp item obtain cost causing divide by zero error

### DIFF
--- a/src/locations.cpp
+++ b/src/locations.cpp
@@ -105,7 +105,7 @@ item_location_type temp_item_location::where() const
 
 int temp_item_location::obtain_cost( const Character &, int, const item * ) const
 {
-    return -100;
+    return 100;
 }
 
 detached_ptr<item> character_item_location::detach( item *it )


### PR DESCRIPTION
## Purpose of change (The Why)
I caused it here #7371 

> Okay so divide by zero
> Great...
> Okay so your total moves was 0

> Huh, cata crashed while dissecting
> They're referring to autonomous scalpel CBM.
> Yes, I have it
> Dissected two corpses without problems

Two people reported crash by dissection; Move count issue this was the most likely suspect

## Describe the solution (The How)
Seems that I accedentially flipped the bionics obtain cost to negative values incorrectly

## Describe alternatives you've considered
None

## Testing
Dissected corpses with the CBM and did not crash

## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.