### PR TITLE
feat(balance): buff mininuke damage by 10x (300 -> 3000)

### DIFF
--- a/data/json/ammo_effects.json
+++ b/data/json/ammo_effects.json
@@ -182,16 +182,16 @@
       "field_type": "fd_nuke_gas",
       "intensity_min": 3,
       "intensity_max": 3,
-      "radius": 18,
+      "radius": 24,
       "size": 1,
       "check_passable": true,
       "check_sees": true,
       "check_sees_radius": 3
     },
     "explosion": {
-      "damage": 300,
+      "damage": 3000,
       "radius": 20,
-      "fragment": { "impact": { "damage_type": "heat", "amount": 300, "armor_multiplier": 2 }, "range": 24 }
+      "fragment": { "impact": { "damage_type": "heat", "amount": 3000, "armor_multiplier": 2 }, "range": 24 }
     }
   },
   {

--- a/data/json/items/tool/explosives.json
+++ b/data/json/items/tool/explosives.json
@@ -959,16 +959,16 @@
     "use_action": {
       "type": "explosion",
       "fields_type": "fd_nuke_gas",
-      "fields_radius": 18,
+      "fields_radius": 24,
       "fields_min_intensity": 3,
       "fields_max_intensity": 3,
       "sound_volume": 2,
       "sound_msg": "Tick.",
       "no_deactivate_msg": "You've already set the %s's timer, you might want to get away from it.",
       "explosion": {
-        "damage": 300,
+        "damage": 3000,
         "radius": 20,
-        "fragment": { "impact": { "damage_type": "heat", "amount": 300, "armor_multiplier": 2 }, "range": 24 }
+        "fragment": { "impact": { "damage_type": "heat", "amount": 3000, "armor_multiplier": 2 }, "range": 24 }
       }
     },
     "//": "Allowed to 'use' remotely so that triggering the message telling you to run won't put it back in your inventory and cause a YASD",


### PR DESCRIPTION
## Purpose of change (The Why)

mininukes are comically weak; they deal a puny 300 damage, whereas C4 deals 200.

## Describe the solution (The How)

- buff both physical and heat wave damage by 10x
- also increase nuke gas radius to 24

## Testing

https://github.com/user-attachments/assets/93997e49-2f39-4242-87e4-90855ab4c675

## Additional context

_I nuke you 3000_

still too weak imao

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

