### PR TITLE
chore: fix accidental deletion of one of the palettes of `bungalow30_basement`

### DIFF
--- a/data/json/mapgen/house/bungalow30.json
+++ b/data/json/mapgen/house/bungalow30.json
@@ -56,9 +56,9 @@
     "object": {
       "palettes": [
         "standard_domestic_palette",
+        "standard_domestic_basement_palette",
         "parameterized_linoleum_color_kitchen",
-        "parameterized_linoleum_color_bathroom",
-        "standard_domestic_lino_bathroom"
+        "parameterized_linoleum_color_bathroom"
       ],
       "fill_ter": "t_floor",
       "rows": [


### PR DESCRIPTION
## Purpose of change (The Why)
Because my PR https://github.com/cataclysmbn/Cataclysm-BN/pull/7083 caused this on the basement of this house:

<details>
<summary>Screenshot:</summary>
<br><a href="https://github.com"><img src="https://github.com/user-attachments/assets/5e7a3230-a81d-4723-abb2-b5a4b06a0770"></a>
</details>

## Describe the solution (The How)
Remove `standard_domestic_lino_bathroom` and re-add `standard_domestic_basement_palette` to the second variant of `bungalow30_basement`
## Describe alternatives you've considered
none
## Testing

## Additional context

<details>
<summary>Screenshot (After):</summary>
<br><a href="https://github.com"><img src="https://github.com/user-attachments/assets/80a3d731-1f53-444b-a6aa-a8c0400052ea"></a>
</details>

## Checklist

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.