### PR TITLE
fix(mods/crt_expansion): dhp_pellet migration typo

### DIFF
--- a/data/mods/CRT_EXPANSION/migrations/rename_to_crt.json
+++ b/data/mods/CRT_EXPANSION/migrations/rename_to_crt.json
@@ -16,6 +16,11 @@
   },
   {
     "type": "MIGRATION",
+    "id": "hp_pellet",
+    "replace": "crt_hp_pellet"
+  },
+  {
+    "type": "MIGRATION",
     "id": "alloy_pellet",
     "replace": "crt_alloy_pellet"
   }


### PR DESCRIPTION
## Purpose of change (The Why)
> @Wishduck Got an error with dhp_pellet from CRIT mod, invalid template, would post a pic but autopilot'ed

Issue added in: #7358
## Describe the solution (The How)
Guess who forgot about dhp

## Describe alternatives you've considered
Screm

## Testing
Added both right migrations

## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.