### PR TITLE
fix: prevent crash in training activity

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -2617,9 +2617,20 @@ void activity_handlers::train_skill_do_turn( player_activity *act, player *p )
     item &skill_training_item = *main_tool;
     int training_skill_interval = atoi( p->get_value( "training_iuse_skill_interval" ).c_str() );
 
+    if( training_skill_interval <= 0 ) {
+        debugmsg( "training_iuse_skill_interval is invalid ( %d )", training_skill_interval );
+        act->moves_left = 0;
+        return;
+    }
+
     if( calendar::once_every( 1_minutes * training_skill_interval ) ) {
         // pull metadata. this is probably the easiest way to get this data from the JSON definition
         std::string training_skill = p->get_value( "training_iuse_skill" );
+        if( training_skill.empty() ) {
+            debugmsg( "training_iuse_skill is empty" );
+            act->moves_left = 0;
+            return;
+        }
         int training_skill_xp = atoi( p->get_value( "training_iuse_skill_xp" ).c_str() );
         int training_skill_max_level = atoi( p->get_value( "training_iuse_skill_xp_max_level" ).c_str() );
         int training_skill_xp_chance = atoi( p->get_value( "training_iuse_skill_xp_chance" ).c_str() );

--- a/src/calendar.cpp
+++ b/src/calendar.cpp
@@ -491,6 +491,9 @@ float calendar::season_ratio()
 
 bool calendar::once_every( const time_duration &event_frequency )
 {
+    if( event_frequency <= 0_turns ) {
+        return false;
+    }
     return ( calendar::turn - calendar::turn_zero ) % event_frequency == 0_turns;
 }
 

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -6027,7 +6027,9 @@ int train_skill_actor::use( player &p, item &i, bool, const tripoint & ) const
     p.set_value( "training_iuse_skill_xp_chance", std::to_string( training_skill_xp_chance ) );
     p.assign_activity( ACT_TRAIN_SKILL, hours * 360000, -1, 0, "training" );
     p.activity->str_values.emplace_back( i.typeId() );
-    p.activity->tools.emplace_back( i );
+    if( !i.has_flag( flag_PSEUDO ) ) {
+        p.activity->tools.emplace_back( i );
+    }
 
     return 0;
 }


### PR DESCRIPTION
## Purpose of change (The Why)

fixes #7914
caused by #7371

## Describe the solution (The How)

- don't try to store `PSEUDO` items into `player_activity::tools`
- also added training_iuse_skill_interval > 0 check
- also added divide-by-0 check to `calendar::once_every`

## Testing

1. spawn exercise machine
2. set athletics to 2
3. practice athletics for 2 hours
4. you've gained 16% skills without triggering error

## Additional context

fixed by GPT-5.2

## Checklist


### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
