### PR TITLE
feat(balance, mods/MagicalNights): Double length of haste spell, nerf cost

### DIFF
--- a/data/mods/MagicalNights/Spells/magus.json
+++ b/data/mods/MagicalNights/Spells/magus.json
@@ -133,10 +133,12 @@
     "energy_source": "MANA",
     "difficulty": 4,
     "base_casting_time": 200,
-    "base_energy_cost": 300,
+    "base_energy_cost": 750,
+    "final_energy_cost": 600,
+    "energy_increment": -10,
     "max_level": 15,
-    "min_duration": 48000,
-    "max_duration": 138000,
+    "min_duration": 96000,
+    "max_duration": 186000,
     "duration_increment": 6000
   },
   {


### PR DESCRIPTION
## Purpose of change (The Why)

It's annoying to recast it every X minutes

Haste is a good spell that deserves to be a bit pricey, and this is an easy way to do that.

## Describe the solution (The How)

- Doubles the duration of Haste spell
- 2.5x the cost at base
- At max level the spell will only be 2x the cost instead of 2.5x (i.e. per minute the mana cost will be the same as the current stats when at max)

## Describe alternatives you've considered

- Figure out how to make channelable spells a thing
- Just straight up 2.5x the mana cost

## Testing

Number tweaks, it lints.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
