### PR TITLE
feat(UI): small NPC dialogue UI adjustments

### DIFF
--- a/src/dialogue_win.cpp
+++ b/src/dialogue_win.cpp
@@ -155,7 +155,7 @@ static void print_responses( const catacurses::window &w, const page &responses,
         const auto selected = entry.response_index == selected_response;
         const auto base_col = entry.col == c_white ? c_light_gray : entry.col;
         const auto col = selected ? hilite( entry.col ) : base_col;
-        const auto letter_col = selected ? hilite(entry.col) : c_light_green;
+        const auto letter_col = selected ? hilite( entry.col ) : c_light_green;
         bool first_line = true;
         for( const std::string &line : entry.lines ) {
             // add letter and space to only first line


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

Follow up to #7912 and #7883. Just a few small changes to refine the dialogue UI and unify the design language.

## Describe the solution (The How)

- Make hotkey hints light grey and use brackets to denote key
- Use page indicator at bottom right of window to communicate current/max pages
- Response list entries are light gray instead of white

## Describe alternatives you've considered

## Testing

Verified changes were made correctly.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
