### PR TITLE
fix: prevent fake tool errors in activity

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -730,7 +730,7 @@ static void set_up_butchery_activity( player_activity &act, player &u, const but
     }
 
     print_reasons();
-    act.tools.clear();
+    act.get_tools_mut().clear();
     act.speed.calc_all_moves( u );
     act.moves_left = setup.move_cost;
     act.moves_total = setup.move_cost;
@@ -1886,8 +1886,8 @@ void activity_handlers::pickaxe_finish( player_activity *act, player *p )
     } else {
         here.destroy( pos, true );
     }
-    if( !act->tools.empty() ) {
-        item &it = *act->tools.front();
+    if( !act->get_tools().empty() ) {
+        item &it = *act->get_tools().front();
         p->consume_charges( it, it.ammo_required() );
     } else {
         debugmsg( "pickaxe activity has no tool" );
@@ -2058,7 +2058,7 @@ void activity_handlers::start_fire_finish( player_activity *act, player *p )
 {
     static const std::string iuse_name_string( "firestarter" );
 
-    item &it = *act->tools.front();
+    item &it = *act->get_tools().front();
     item *used_tool = it.get_usable_item( iuse_name_string );
     if( used_tool == nullptr ) {
         debugmsg( "Lost tool used for starting fire" );
@@ -2090,7 +2090,7 @@ void activity_handlers::start_fire_finish( player_activity *act, player *p )
 void activity_handlers::start_fire_do_turn( player_activity *act, player *p )
 {
     map &here = get_map();
-    item &firestarter = *act->tools.front();
+    item &firestarter = *act->get_tools().front();
     // Try fueling the fire if we don't already have fuel, OR if the tool needs to look for tinder to work
     if( !here.is_flammable( act->placement ) || ( firestarter.has_flag( flag_REQUIRES_TINDER ) &&
             !here.tinder_at( act->placement ) ) ) {
@@ -2235,7 +2235,7 @@ void activity_handlers::hand_crank_do_turn( player_activity *act, player *p )
     // to 10 watt (suspicious claims from some manufacturers) sustained output.
     // It takes 2.4 minutes to produce 1kj at just slightly under 7 watts (25 kj per hour)
     // time-based instead of speed based because it's a sustained activity
-    item &hand_crank_item = *act->tools.front();
+    item &hand_crank_item = *act->get_tools().front();
 
     if( calendar::once_every( 144_seconds ) ) {
         p->mod_fatigue( 1 );
@@ -2258,7 +2258,7 @@ void activity_handlers::vibe_do_turn( player_activity *act, player *p )
     //Using a vibrator takes time (10 minutes), not speed
     //Linear increase in morale during action with a small boost at end
     //Deduct 1 battery charge for every minute in use, or vibrator is much less effective
-    item &vibrator_item = *act->tools.front();
+    item &vibrator_item = *act->get_tools().front();
 
     if( p->encumb( body_part_mouth ) >= 30 ) {
         act->moves_left = 0;
@@ -2607,7 +2607,7 @@ void activity_handlers::train_skill_do_turn( player_activity *act, player *p )
             hack_original_charges = main_tool ? main_tool->charges : 0;
         }
     } else {
-        main_tool = &*act->tools.front();
+        main_tool = &*act->get_tools().front();
     }
     if( main_tool == nullptr ) {
         debugmsg( "train skill tools array and hack values are empty. this would have caused invalid safe reference error" );
@@ -2991,11 +2991,11 @@ void activity_handlers::gunmod_add_finish( player_activity *act, player *p )
 void activity_handlers::toolmod_add_finish( player_activity *act, player *p )
 {
     act->set_to_null();
-    if( act->targets.size() != 1 || !act->tools[0] || !act->targets[0] ) {
+    if( act->targets.size() != 1 || !act->get_tools()[0] || !act->targets[0] ) {
         debugmsg( "Incompatible arguments to ACT_TOOLMOD_ADD" );
         return;
     }
-    item &tool = *act->tools[0];
+    item &tool = *act->get_tools()[0];
     item &mod = *act->targets[0];
     p->add_msg_if_player( m_good, _( "You successfully attached the %1$s to your %2$s." ),
                           mod.tname(), tool.tname() );
@@ -3164,7 +3164,7 @@ void activity_handlers::fish_do_turn( player_activity *act, player *p )
         }
         return;
     }
-    item &rod = *act->tools.front();
+    item &rod = *act->get_tools().front();
     int fish_chance = 1;
     int survival_mod = p->get_skill_level( skill_survival );
     if( rod.has_flag( flag_FISH_POOR ) ) {
@@ -3970,13 +3970,13 @@ void activity_handlers::chop_tree_finish( player_activity *act, player *p )
     act->set_to_null();
 
     // Quality of tool used and assistants can together both reduce intensity of work.
-    if( act->tools.empty() ) {
+    if( act->get_tools().empty() ) {
         debugmsg( "woodcutting item location not set" );
         resume_for_multi_activities( *p );
         return;
     }
 
-    safe_reference<item> &loc = act->tools[ 0 ];
+    safe_reference<item> &loc = act->get_tools_mut()[ 0 ];
     if( !loc ) {
         debugmsg( "woodcutting item location lost" );
         resume_for_multi_activities( *p );
@@ -4039,7 +4039,7 @@ void activity_handlers::chop_logs_finish( player_activity *act, player *p )
 
     // Quality of tool used and assistants can together both reduce intensity of work.
 
-    safe_reference<item> &loc = act->tools[ 0 ];
+    safe_reference<item> &loc = act->get_tools_mut()[ 0 ];
     if( !loc ) {
         debugmsg( "woodcutting item location lost" );
         return;
@@ -4121,8 +4121,8 @@ void activity_handlers::jackhammer_finish( player_activity *act, player *p )
                               _( "You finish drilling." ),
                               _( "<npcname> finishes drilling." ) );
     act->set_to_null();
-    if( !act->tools.empty() ) {
-        item &it = *act->tools.front();
+    if( !act->get_tools().empty() ) {
+        item &it = *act->get_tools().front();
         p->consume_charges( it, it.ammo_required() );
     } else {
         debugmsg( "unable to find tool" );

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -2456,7 +2456,7 @@ static bool mine_activity( player &p, const tripoint &src_loc )
         moves /= 2;
     }
     p.assign_activity( powered ? ACT_JACKHAMMER : ACT_PICKAXE, moves );
-    p.activity->tools.emplace_back( chosen_item );
+    p.activity->add_tool( chosen_item );
     p.activity->placement = here.getabs( src_loc );
     return true;
 
@@ -2476,12 +2476,12 @@ static bool chop_tree_activity( player &p, const tripoint &src_loc )
     const ter_id ter = here.ter( src_loc );
     if( here.has_flag( flag_TREE, src_loc ) ) {
         p.assign_activity( ACT_CHOP_TREE, moves, -1, p.get_item_position( best_qual ) );
-        p.activity->tools.emplace_back( best_qual );
+        p.activity->add_tool( best_qual );
         p.activity->placement = here.getabs( src_loc );
         return true;
     } else if( ter == t_trunk || ter == t_stump ) {
         p.assign_activity( ACT_CHOP_LOGS, moves, -1, p.get_item_position( best_qual ) );
-        p.activity->tools.emplace_back( best_qual );
+        p.activity->add_tool( best_qual );
         p.activity->placement = here.getabs( src_loc );
         return true;
     }
@@ -2956,7 +2956,7 @@ static bool generic_multi_activity_do( player &p, const activity_id &act_id,
         item *best_rod = p.best_quality_item( qual_FISHING );
         p.assign_activity( std::make_unique<player_activity>( ACT_FISH, to_moves<int>( 5_hours ), 0,
                            0, best_rod->tname() ) );
-        p.activity->tools.emplace_back( best_rod );
+        p.activity->add_tool( best_rod );
         p.activity->coord_set = g->get_fishable_locations( ACTIVITY_SEARCH_DISTANCE, src_loc );
         return false;
     } else if( reason == do_activity_reason::NEEDS_MINING ) {
@@ -3316,7 +3316,7 @@ void try_fuel_fire( player_activity &act, player &p, const bool starting_fire )
         // If we specifically need tinder to start this fire, grab it the instant it's found and ignore any other fuel
         if( starting_fire ) {
             // Only track firestarter if we have an activity assigned to light a new fire, or it will implode.
-            item &firestarter = *act.tools.front();
+            item &firestarter = *act.get_tools().front();
             if( firestarter.has_flag( flag_REQUIRES_TINDER ) ) {
                 if( it->has_flag( flag_TINDER ) ) {
                     move_item( p, *it, 1, *refuel_spot, *best_fire );

--- a/src/activity_type.cpp
+++ b/src/activity_type.cpp
@@ -8,6 +8,7 @@
 #include "activity_handlers.h"
 #include "assign.h"
 #include "debug.h"
+#include "flag.h"
 #include "enum_conversions.h"
 #include "json.h"
 #include "sounds.h"
@@ -202,8 +203,11 @@ bool activity_type::call_finish( player_activity *act, player *p ) const
         pair->second( act, p );
         // kill activity sounds at finish
         sfx::end_activity_sounds();
-        if( !act->tools.empty() ) {
-            g->remove_fake_item( &*act->tools.front() );
+        if( !act->get_tools().empty() ) {
+            auto &tool = *act->get_tools().front();
+            if( tool.has_flag( flag_TEMPORARY_ITEM ) ) {
+                g->remove_fake_item( &tool );
+            }
         }
         return true;
     }

--- a/src/avatar_functions.cpp
+++ b/src/avatar_functions.cpp
@@ -566,7 +566,7 @@ void toolmod_add( avatar &you, item &tool, item &mod )
     }
 
     you.assign_activity( activity_id( "ACT_TOOLMOD_ADD" ), 1, -1 );
-    you.activity->tools.emplace_back( &tool );
+    you.activity->add_tool( &tool );
     you.activity->targets.emplace_back( &mod );
 }
 

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -1752,7 +1752,7 @@ int iuse::fishing_rod( player *p, item *it, bool, const tripoint & )
     }
     p->add_msg_if_player( _( "You cast your line and wait to hook something…" ) );
     p->assign_activity( ACT_FISH, to_moves<int>( 5_hours ), 0, 0, it->tname() );
-    p->activity->tools.emplace_back( it );
+    p->activity->add_tool( it );
     p->activity->placement = *found;
     p->activity->coord_set = g->get_fishable_locations( 60, *found );
     return 0;
@@ -2881,7 +2881,7 @@ int iuse::jackhammer( player *p, item *it, bool, const tripoint &pos )
     moves = moves * ( 10 - helpers.size() ) / 10;
 
     p->assign_activity( ACT_JACKHAMMER, moves );
-    p->activity->tools.emplace_back( it );
+    p->activity->add_tool( it );
     p->activity->placement = g->m.getabs( pnt );
     p->add_msg_if_player( _( "You start drilling into the %1$s with your %2$s." ),
                           g->m.tername( pnt ), it->tname() );
@@ -2973,7 +2973,7 @@ int iuse::pickaxe( player *p, item *it, bool, const tripoint &pos )
     moves = moves * ( 10 - helpers.size() ) / 10;
 
     p->assign_activity( ACT_PICKAXE, moves, -1 );
-    p->activity->tools.emplace_back( it );
+    p->activity->add_tool( it );
     p->activity->placement = g->m.getabs( pnt );
     p->add_msg_if_player( _( "You strike the %1$s with your %2$s." ),
                           g->m.tername( pnt ), it->tname() );
@@ -4078,7 +4078,7 @@ int iuse::hand_crank( player *p, item *it, bool, const tripoint & )
             p->add_msg_if_player( _( "You start cranking the %s to charge its %s." ), it->tname(),
                                   it->magazine_current()->tname() );
             p->assign_activity( ACT_HAND_CRANK, moves, -1, 0, "hand-cranking" );
-            p->activity->tools.emplace_back( it );
+            p->activity->add_tool( it );
         } else {
             p->add_msg_if_player( _( "You could use the %s to charge its %s, but it's already charged." ),
                                   it->tname(), magazine->tname() );
@@ -4125,7 +4125,7 @@ int iuse::vibe( player *p, item *it, bool, const tripoint & )
                                   it->tname() );
         }
         p->assign_activity( ACT_VIBE, moves, -1, 0, "de-stressing" );
-        p->activity->tools.emplace_back( it );
+        p->activity->add_tool( it );
     }
     return it->type->charges_to_use();
 }
@@ -4450,7 +4450,7 @@ int iuse::chop_tree( player *p, item *it, bool t, const tripoint & )
     moves = moves * ( 10 - helpers.size() ) / 10;
 
     p->assign_activity( ACT_CHOP_TREE, moves, -1, p->get_item_position( it ) );
-    p->activity->tools.emplace_back( it );
+    p->activity->add_tool( it );
     p->activity->placement = g->m.getabs( pnt );
 
     return it->type->charges_to_use();
@@ -4497,7 +4497,7 @@ int iuse::chop_logs( player *p, item *it, bool t, const tripoint & )
 
     p->assign_activity( ACT_CHOP_LOGS, moves, -1, p->get_item_position( it ) );
     p->activity->placement = g->m.getabs( pnt );
-    p->activity->tools.emplace_back( it );
+    p->activity->add_tool( it );
 
     return it->type->charges_to_use();
 }

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -1846,7 +1846,7 @@ int firestarter_actor::use( player &p, item &it, bool t, const tripoint &spos ) 
         moves_modifier + moves_cost_fast / 100.0 + 2;
     p.assign_activity( ACT_START_FIRE, moves, potential_skill_gain,
                        0, it.tname() );
-    p.activity->tools.emplace_back( &it );
+    p.activity->add_tool( &it );
     p.activity->values.push_back( g->natural_light_level( pos.z ) );
     p.activity->placement = pos;
     // charges to use are handled by the activity
@@ -6027,9 +6027,7 @@ int train_skill_actor::use( player &p, item &i, bool, const tripoint & ) const
     p.set_value( "training_iuse_skill_xp_chance", std::to_string( training_skill_xp_chance ) );
     p.assign_activity( ACT_TRAIN_SKILL, hours * 360000, -1, 0, "training" );
     p.activity->str_values.emplace_back( i.typeId() );
-    if( !i.has_flag( flag_PSEUDO ) ) {
-        p.activity->tools.emplace_back( i );
-    }
+    p.activity->add_tool( &i );
 
     return 0;
 }
@@ -6049,7 +6047,7 @@ int sex_toy_actor::use( player &p, item &i, bool, const tripoint & ) const
                              i.tname() );
     }
     p.assign_activity( ACT_VIBE, moves, -1, 0, "de-stressing" );
-    p.activity->tools.emplace_back( i );
+    p.activity->add_tool( &i );
 
     return i.type->charges_to_use();
 }

--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -19,6 +19,7 @@
 #include "construction_partial.h"
 #include "crafting.h"
 #include "distraction_manager.h"
+#include "flag.h"
 #include "game.h"
 #include "item.h"
 #include "itype.h"
@@ -753,4 +754,11 @@ void activity_ptr::serialize( JsonOut &json ) const
 void activity_ptr::deserialize( JsonIn &jsin )
 {
     act->deserialize( jsin );
+}
+
+auto player_activity::add_tool( item *it ) -> void
+{
+    if( it && !it->has_flag( flag_PSEUDO ) ) {
+        tools_.emplace_back( it );
+    }
 }

--- a/src/player_activity.h
+++ b/src/player_activity.h
@@ -54,7 +54,6 @@ class player_activity
         bool interruptable_with_kb = true;
 
         activity_speed speed;
-        std::vector<safe_reference<item>> tools;
 
         // The members in the following block are deprecated, prefer creating a new
         // activity_actor.
@@ -212,6 +211,16 @@ class player_activity
         void ignore_distraction( distraction_type type );
         void allow_distractions();
         void inherit_distractions( const player_activity & );
+
+        /// Add a tool to the activity. PSEUDO items (fake/temporary items) are automatically skipped.
+        void add_tool( item *it );
+        /// Get the tools vector (read-only access)
+        auto get_tools() const -> const std::vector<safe_reference<item>>& { return tools_; } // *NOPAD*
+        /// Get the tools vector (read-write access for internal use)
+        auto get_tools_mut() -> std::vector<safe_reference<item>>& { return tools_; } // *NOPAD*
+
+    private:
+        std::vector<safe_reference<item>> tools_;
 };
 
 

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -209,7 +209,7 @@ void player_activity::serialize( JsonOut &json ) const
         json.member( "str_values", str_values );
         json.member( "auto_resume", auto_resume );
         json.member( "monsters", monsters );
-        json.member( "tools", tools );
+        json.member( "tools", tools_ );
         json.member( "moves_total", moves_total );
         json.member( "moves_left", moves_left );
         json.member( "assistants_ids", assistants_ids_ );
@@ -272,7 +272,7 @@ void player_activity::deserialize( JsonIn &jsin )
     str_values = data.get_string_array( "str_values" );
     data.read( "auto_resume", auto_resume );
     data.read( "monsters", monsters );
-    data.read( "tools", tools );
+    data.read( "tools", tools_ );
     data.read( "assistants_ids", assistants_ids_ );
 
 }


### PR DESCRIPTION

## Purpose of change (The Why)

fix #7878, fix #7924
also fixes #7836
prevent #7371 from causing further issues

## Describe the solution (The How)

- made activity tools private
- made it so adding tools automatically skip PSEUDO items
- when deleting fake item from activity, check whether it's actually fake

## Describe alternatives you've considered

idk maybe check them on using?

## Testing

![Cataclysm: Bright Nights - d743446bd8 (2026-01-20)_02](https://github.com/user-attachments/assets/f7ecfb6b-691b-4259-ac9c-a797a331d2a0)

chopped down a tree without errors

![Cataclysm: Bright Nights - d743446bd8 (2026-01-20)_03](https://github.com/user-attachments/assets/6ad7f03a-be6a-4941-875f-a8db5083168d)

gave myself integrated toolset CBM, cutted down metals without errors

## Additional context

fixed using sonnet 4.5

## Checklist


### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
