### PR TITLE
feat(balance): bump coat rack allowed volume to 100L

### DIFF
--- a/data/json/furniture_and_terrain/furniture-storage.json
+++ b/data/json/furniture_and_terrain/furniture-storage.json
@@ -628,7 +628,7 @@
     "required_str": 4,
     "flags": [ "TRANSPARENT", "FLAMMABLE", "PLACE_ITEM", "BLOCKSDOOR", "MOUNTABLE" ],
     "deconstruct": { "items": [ { "item": "nail", "charges": 8 }, { "item": "2x4", "count": 3 } ] },
-    "max_volume": "30 L",
+    "max_volume": "100 L",
     "bash": {
       "str_min": 6,
       "str_max": 30,


### PR DESCRIPTION

## Purpose of change (The Why)

30L is just absolutely pitiful when people are using it as flavor for storing more clothes than just hats

## Describe the solution (The How)

30L -> 100L

## Describe alternatives you've considered

- Add dedicated armor (and weapon) racks

I think I'd want them to have some special functionality, and I don't feel like spriting them atm (definitely would be nice though)

## Testing

Number tweak

## Additional context

This is still limiting you to a tenth of the volume of an empty tile just because you're doing flavor, but tbh we'd need to do a whole rework of the storage furniture in general if we went by that logic.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
