### PR TITLE
chore: Rename airship balloon to C.R.I.T. airship balloon

### DIFF
--- a/data/mods/CRT_EXPANSION/vehicles/flying_parts.json
+++ b/data/mods/CRT_EXPANSION/vehicles/flying_parts.json
@@ -35,7 +35,7 @@
     "id": "crt_airship_balloon_item",
     "symbol": "o",
     "color": "light_gray",
-    "name": { "str": "crt_airship balloon" },
+    "name": { "str": "C.R.I.T. airship balloon" },
     "description": "A big plastic airbag lined with solar panels and filled with hydrogen gas.  Provides lift if installed on a vehicle, but you'll need a propeller to do anything more than float up and down.",
     "price": "5 USD",
     "price_postapoc": "25 cent",


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

Name change cuz crt_airship is more like ID 

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)

C.R.I.T. airship balloon

<!-- e.g nerfs monster A -->

## Describe alternatives you've considered

A different name since this is the item but Meh, not needed. 

## Testing

String change copied directly from my game, should work

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

<!-- please remove checkboxes unrelated to this PR. -->

