### PR TITLE
fix(UI): Make advanced inventory AIM_ALL to respect CLOSE_ADV_INV option

### DIFF
--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -780,7 +780,7 @@ bool advanced_inventory::move_all_items( bool nested_call )
         // restore the pane to its former glory
         panes[src] = shadow;
         // make it auto loop back, if not already doing so
-        if( !g->u.activity && (!done || !get_option<bool>( "CLOSE_ADV_INV" )) ) {
+        if( !g->u.activity && ( !done || !get_option<bool>( "CLOSE_ADV_INV" ) ) ) {
             do_return_entry();
         }
         return true;


### PR DESCRIPTION
## Purpose of change (The Why)

Using the `move_all_items` when only one tile of the source is selected works fine, and the `CLOSE_ADV_INV` option works as expected.
This is not the case when the source is all 9 tiles of the surrounding area, the inventory will close no matter the option state.

## Describe the solution (The How)

Add already existing check `!get_option<bool>( "CLOSE_ADV_INV"` from `move_all_items` to the AIM_ALL source area routine.

## Describe alternatives you've considered

I dream of Ultimate Unified Inventory...

## Additional context

<details>
  <summary>Testing video</summary>

https://github.com/user-attachments/assets/67ee8085-7a2a-4c15-82e4-baf6e91c06e4

</details>

_This small fix was done while we were testing the automated one-click-solution script for setting up a building environment on Windows. This was to see if the game builds and everything seems to be working. Will share it later, when I think it's ready, a little nitpicks to deal with on different Windows versions._

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.