### PR TITLE
feat(UI): add compare item option in crafting UI

### DIFF
--- a/data/raw/keybindings/keybindings.json
+++ b/data/raw/keybindings/keybindings.json
@@ -560,6 +560,13 @@
   },
   {
     "type": "keybinding",
+    "id": "COMPARE",
+    "category": "CRAFTING",
+    "name": "Compare",
+    "bindings": [ { "input_method": "keyboard", "key": "I" } ]
+  },
+  {
+    "type": "keybinding",
     "id": "HIDE_SHOW_RECIPE",
     "category": "CRAFTING",
     "name": "Hide/show recipe",

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -19,6 +19,7 @@
 #include "crafting.h"
 #include "cursesdef.h"
 #include "game.h"
+#include "game_inventory.h"
 #include "input.h"
 #include "inventory.h"
 #include "item.h"
@@ -317,6 +318,7 @@ static input_context make_crafting_context( bool highlight_unread_recipes )
     ctxt.register_action( "CYCLE_BATCH" );
     ctxt.register_action( "RELATED_RECIPES" );
     ctxt.register_action( "HIDE_SHOW_RECIPE" );
+    ctxt.register_action( "COMPARE" );
     ctxt.register_action( "TOGGLE_UNAVAILABLE" );
     if( highlight_unread_recipes ) {
         ctxt.register_action( "TOGGLE_RECIPE_UNREAD" );
@@ -448,6 +450,7 @@ const recipe *select_crafting_recipe( int &batch_size_out )
         add_action_desc( "RELATED_RECIPES", pgettext( "crafting gui", "Related" ) );
         add_action_desc( "TOGGLE_FAVORITE", pgettext( "crafting gui", "Favorite" ) );
         add_action_desc( "CYCLE_BATCH", pgettext( "crafting gui", "Batch" ) );
+        add_action_desc( "COMPARE", pgettext( "crafting gui", "Compare" ) );
         add_action_desc( "TOGGLE_UNAVAILABLE", pgettext( "crafting gui", "Show unavailable" ) );
         add_action_desc( "HELP_KEYBINDINGS", pgettext( "crafting gui", "Keybindings" ) );
         keybinding_x = isWide ? 5 : 2;
@@ -961,6 +964,21 @@ const recipe *select_crafting_recipe( int &batch_size_out )
                 return catacurses::newwin( height, width, point( ( TERMX - width ) / 2, ( TERMY - height ) / 2 ) );
             }, data );
 
+            recalc = true;
+            keepline = true;
+        } else if( action == "COMPARE" ) {
+            if( current.empty() ) {
+                popup( _( "Nothing selected!  Press [<color_yellow>ESC</color>]!" ) );
+                recalc = true;
+                continue;
+            }
+            auto crafted_item = current[line]->create_result();
+            crafted_item->set_var( "recipe_exemplar", current[line]->ident().str() );
+            item *selected = game_menus::inv::titled_menu(
+                                 u, _( "Compare to which item?" ), _( "Your inventory is empty." ) );
+            if( selected != nullptr ) {
+                game_menus::inv::compare( *selected, *crafted_item );
+            }
             recalc = true;
             keepline = true;
         } else if( action == "FILTER" ) {


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

Crafting UI doesn't allow for comparing item to another item in player's inventory.
Requested in discord by ExcavatorMan:
<img width="494" height="113" alt="craftyuirequest" src="https://github.com/user-attachments/assets/86596eb6-4de5-4257-af4e-8f80c3539187" />


## Describe the solution (The How)

Adds new keybind (I) to compare items. Shows inventory popup, then compare items.

## Describe alternatives you've considered

## Testing

Tested comparing a couple items, verified I didn't get the item somehow afterwards.

## Additional context

See new keybind listed at bottom of screen (I for Compare):
<img width="1919" height="1079" alt="cc_1" src="https://github.com/user-attachments/assets/d65d4463-d3cb-438a-8b3f-3d927ad0792b" />
See inventory prompt after using Compare keybind:
<img width="1919" height="1079" alt="cc_2" src="https://github.com/user-attachments/assets/9067a3de-e567-4941-823b-6975b758b92b" />
See compare screen appear:
<img width="1919" height="1079" alt="cc_3" src="https://github.com/user-attachments/assets/bcfe9b47-a5e0-47ab-a32a-643651d499cf" />

Upon hitting escape, the crafting menu returns with the item still highlighted.

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.


