### PR TITLE
fix: make turret autoloader reload internal mags

### DIFF
--- a/src/vehicle_functions.cpp
+++ b/src/vehicle_functions.cpp
@@ -151,7 +151,11 @@ auto try_autoload_turret( vehicle &veh, vehicle_part &pt ) -> bool
     }
 
     item &gun = pt.get_base();
-    if( gun.ammo_sufficient() ) {
+    const auto ammo_capacity = gun.ammo_capacity();
+    const auto needs_reload = gun.magazine_integral()
+                              ? ( ammo_capacity > 0 && gun.ammo_remaining() < ammo_capacity )
+                              : !gun.ammo_sufficient();
+    if( !needs_reload ) {
         gun.set_var( "autoloader_cycle_start", 0LL );
         return false;
     }

--- a/tests/vehicle_turrets_test.cpp
+++ b/tests/vehicle_turrets_test.cpp
@@ -3,11 +3,13 @@
 #include <algorithm>
 #include <map>
 #include <memory>
+#include <ranges>
 #include <utility>
 #include <vector>
 
 #include "ammo.h"
 #include "avatar.h"
+#include "calendar.h"
 #include "game.h"
 #include "item.h"
 #include "itype.h"
@@ -20,6 +22,7 @@
 #include "value_ptr.h"
 #include "veh_type.h"
 #include "vehicle.h"
+#include "vehicle_functions.h"
 #include "vehicle_part.h"
 
 static std::vector<const vpart_info *> turret_types()
@@ -35,7 +38,7 @@ static std::vector<const vpart_info *> turret_types()
     return res;
 }
 
-static const vpart_info *biggest_tank( const ammotype &ammo )
+static auto biggest_tank( const ammotype &ammo ) -> const vpart_info *
 {
     std::vector<const vpart_info *> res;
 
@@ -51,17 +54,12 @@ static const vpart_info *biggest_tank( const ammotype &ammo )
         }
     }
 
-    if( res.empty() ) {
-        return nullptr;
-    }
+    if( res.empty() ) { return nullptr; }
 
-    return * std::max_element( res.begin(), res.end(),
-    []( const vpart_info * lhs, const vpart_info * rhs ) {
-        return lhs->size < rhs->size;
-    } );
+    return *std::ranges::max_element( res, {}, &vpart_info::size );
 }
 
-TEST_CASE( "vehicle_turret", "[vehicle] [gun] [magazine] [.]" )
+TEST_CASE( "vehicle_turret", "[vehicle][gun][magazine][.]" )
 {
     clear_all_state();
     map &here = get_map();
@@ -105,4 +103,54 @@ TEST_CASE( "vehicle_turret", "[vehicle] [gun] [magazine] [.]" )
             here.destroy_vehicle( veh );
         }
     }
+}
+
+TEST_CASE( "vehicle_turret_autoloader_integral_magazine", "[vehicle][gun][turret][autoload]" )
+{
+    clear_all_state();
+    map &here = get_map();
+    vehicle *veh = here.add_vehicle( vproto_id( "none" ), point( 65, 65 ), 270_degrees, 0, 0 );
+    REQUIRE( veh );
+
+    const auto turret_part_id = vpart_id( "mounted_rebar_rifle" );
+    const auto autoloader_part_id = vpart_id( "turret_autoloader" );
+    const auto cargo_part_id = vpart_id( "box" );
+    const auto battery_part_id = vpart_id( "storage_battery" );
+
+    const auto turret_index = veh->install_part( point_zero, turret_part_id, true );
+    REQUIRE( turret_index >= 0 );
+    REQUIRE( veh->install_part( point_zero, autoloader_part_id, true ) >= 0 );
+    const auto cargo_index = veh->install_part( point_zero, cargo_part_id, true );
+    REQUIRE( cargo_index >= 0 );
+    REQUIRE( veh->install_part( point_zero, battery_part_id, true ) >= 0 );
+    veh->charge_battery( 10000 );
+
+    vehicle_part &turret_part = veh->part( turret_index );
+    item &gun = turret_part.get_base();
+    REQUIRE( gun.magazine_integral() );
+    const auto ammo_capacity = gun.ammo_capacity();
+    REQUIRE( ammo_capacity > 1 );
+
+    const auto ammo_id = itype_id( "rebar_rail" );
+    gun.ammo_set( ammo_id, 0 );
+    const auto ammo_stack = ammo_capacity * 2;
+    auto remaining = veh->add_item( cargo_index, item::spawn( ammo_id, calendar::turn, ammo_stack ) );
+    REQUIRE( !remaining );
+
+    auto current_ammo = gun.ammo_remaining();
+    auto last_ammo = current_ammo;
+    auto tries = 0;
+    const auto max_tries = ammo_capacity * 2;
+    while( current_ammo < ammo_capacity && tries < max_tries ) {
+        calendar::turn += 1_minutes;
+        vehicle_funcs::try_autoload_turret( *veh, turret_part );
+        current_ammo = gun.ammo_remaining();
+        if( current_ammo > last_ammo ) {
+            last_ammo = current_ammo;
+            tries = 0;
+        } else {
+            ++tries;
+        }
+    }
+    REQUIRE( gun.ammo_remaining() == ammo_capacity );
 }


### PR DESCRIPTION
## Why

continuation of #7631

>  Hi, i played with turret autoloader, it is very convinient. I played with mounted ferromagnetic rail rifle and it only reloads one ammo, but it has 12 slots. Could you please make it reload fully?
>
> It works like:
> 0/12 -> autoloads => 1/12
> 1/12 -> stops autoloading

[on discord](https://discord.com/channels/830879262763909202/830916451517857894/1463472215822700656)
 
## What

- made turret autoloader check whether turret has internal magazine
- added tests

## Testing

![Cataclysm: Bright Nights - d2094f53b5 (2026-01-21)_01](https://github.com/user-attachments/assets/80fac0fb-3013-41d4-b967-d69a3f29c48a)

1. spawn humvee
2. have debug hammer{space,time}
3. replace m240 turret with ferromagnatic rail rifle turret
4. spawn 100 rebar rail and put it into cargo space
5. confirm autoloader reloads multiple rails