### PR TITLE
feat(balance): reduce autoloader power draw from 50 kJ to 5 kJ

### DIFF
--- a/data/json/vehicleparts/utilities.json
+++ b/data/json/vehicleparts/utilities.json
@@ -362,7 +362,7 @@
     "broken_color": "dark_gray",
     "broken_symbol": "x",
     "size": "10 L",
-    "epower": -50,
+    "epower": -5,
     "flags": [ "COVERED", "ENABLED_DRAINS_EPOWER", "AUTOLOADER" ],
     "requirements": {
       "install": { "skills": [ [ "mechanics", 5 ], [ "electronics", 3 ] ], "time": "60 m", "using": [ [ "vehicle_bolt", 1 ] ] },


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

Testing of https://github.com/cataclysmbn/Cataclysm-BN/pull/7947 revealed to me how incredibly wacky the autoloader's power draw gets when presented with a `RELOAD_ONE` weapon, as it drained a full 1000 power just to fully load a heavy rail rifle (note that the GUN is the "heavy" here, not the ammo).

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

Reduced `epower` of turret autoloader from -50 to -5.

## Describe alternatives you've considered

Coding in some manner of fuckery where power draw scales with weight of item being loaded.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

Load-tested and installed a heavy rail rifle on a car, battery is at 96% instead of 66% after fully loading it.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
