### PR TITLE
fix: `PHYSICAL` spells should not deny two-handed weapons

### DIFF
--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1463,7 +1463,8 @@ static void cast_spell()
         }
     }
 
-    if( u.is_armed() && !( sp.has_flag( spell_flag::NO_HANDS ) || sp.has_flag( spell_flag::PHYSICAL ) ) &&
+    if( u.is_armed() && !( sp.has_flag( spell_flag::NO_HANDS ) ||
+                           sp.has_flag( spell_flag::PHYSICAL ) ) &&
         !u.primary_weapon().has_flag( flag_MAGIC_FOCUS ) && u.primary_weapon().is_two_handed( u ) ) {
         add_msg( game_message_params{ m_bad, gmf_bypass_cooldown },
                  _( "You need at least one hand free to cast this spell!" ) );


### PR DESCRIPTION
## Purpose of change (The Why)

`PHYSICAL` spells were not able to be used with two-handed normal weapons, which was not intended.

## Describe the solution (The How)

Add a check to the denial for whether or not the spell is flagged as `PHYSICAL`

## Describe alternatives you've considered

- Further cement magic as attempting to even the playing field between one-handers and two-handers by giving one-handers an explicit bonus

## Testing

Compiled, loaded into a world with MN
1. Gave myself spells through debug
2. Leveled Smite and Swift Strike such that they won't fail naturally
3. Wielded a Zweihander
4. Attempted to cast Smite, failed (as it should, given Smite is not `PHYSICAL`)
5. Attempted to cast Swift Strike, succeeded (as it should, given Swift Strike is `PHYSICAL`)

## Additional context

Thanks Chorus for pointing it out to me

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
