### PR TITLE
chore: fix misplaced nested mapgen on the mapgen `music_venue_1_roof`

### DIFF
--- a/data/json/mapgen/music_venue.json
+++ b/data/json/mapgen/music_venue.json
@@ -302,7 +302,7 @@
       "place_items": [ { "item": "roof_trash", "x": [ 4, 18 ], "y": [ 2, 17 ], "chance": 50, "repeat": [ 1, 3 ] } ],
       "place_nested": [
         { "chunks": [ [ "roof_2x2_utilities", 50 ] ], "x": 17, "y": 3 },
-        { "chunks": [ [ "null", 70 ], [ "roof_6x6_survivor", 5 ] ], "x": [ 6, 17 ], "y": 8 }
+        { "chunks": [ [ "null", 70 ], [ "roof_6x6_survivor", 5 ] ], "x": [ 6, 13 ], "y": 8 }
       ]
     },
     "om_terrain": "music_venue_1_roof",


### PR DESCRIPTION
## Purpose of change (The Why)
<details>
<summary>Because "roof_6x6_survivor" can appear partially on the open air on this roof and trigger this error:</summary>
<br><a href="https://github.com"><img src="https://github.com/user-attachments/assets/596ffdd7-06af-41f7-865f-4240d226ed45"></a>
</details>

## Describe the solution (The How)

## Describe alternatives you've considered
none
## Testing

## Additional context

## Checklist

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.