### PR TITLE
fix: init mods/ on game load

### DIFF
--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -51,6 +51,7 @@
 #include "wcwidth.h"
 #include "worldfactory.h"
 #include "game_info.h"
+
 enum class main_menu_opts : int {
     MOTD = 0,
     NEWCHAR = 1,


### PR DESCRIPTION
## Purpose of change (The Why)
Apparently we have been having issues with the ./mods directory
Well it seems usermods is not set to spawn itself in

## Describe the solution (The How)
Spawn itself in

## Describe alternatives you've considered
Screm

## Testing
I deleted the directory and it is now created

## Additional context
~~Stupid confusion on default userdir~~

## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.