### PR TITLE
fix: Add missing shield technique to large spiked shield, change descriptions of banded shields to mention iron instead of steel

### DIFF
--- a/data/json/items/armor/shields.json
+++ b/data/json/items/armor/shields.json
@@ -124,7 +124,7 @@
     "id": "shield_banded",
     "type": "ARMOR",
     "name": { "str": "banded shield" },
-    "description": "A simple round shield made of wood with bands of steel reinforcing it.  Stronger than a simple wooden shield, but also more encumbering.",
+    "description": "A simple round shield made of wood with bands of iron reinforcing it.  Stronger than a simple wooden shield, but also more encumbering.",
     "weight": "3400 g",
     "volume": "3 L",
     "price": "100 USD",
@@ -164,7 +164,7 @@
     "looks_like": "shield_wooden_large",
     "type": "ARMOR",
     "name": { "str": "large banded shield" },
-    "description": "A large shield made of wood with steel bands reinforcing it.  Stronger than a simple wooden shield, but also more encumbering.",
+    "description": "A large shield made of wood with iron bands reinforcing it.  Stronger than a simple wooden shield, but also more encumbering.",
     "volume": "5 L",
     "weight": "5400 g",
     "price": "120 USD",
@@ -287,7 +287,8 @@
     "to_hit": -2,
     "bashing": 10,
     "cutting": 10,
-    "encumbrance": 30
+    "encumbrance": 30,
+    "techniques": [ "WBLOCK_3" ]
   },
   {
     "id": "shield_bronze",


### PR DESCRIPTION
## Purpose of change (The Why)

Large spiked shield still had the parry technique of the small version, unlike all other large shields.
Banded shields mentioned bands of steel in the description, despite the shield being made from iron.

## Describe the solution (The How)

Add missing WBLOCK_3 technique to large spiked shield.
Change "steel" to "iron" in banded shields.

## Describe alternatives you've considered

Originally I changed the banded shields to be made from steel, but as chaosvolt pointed out, they should remain low-tier with iron.

## Testing

Loaded into the game, no errors.
Large spiked shield had the same technique as other large shields.
Banded shields mentioned iron in the descriptions.

## Additional context

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional
