### PR TITLE
fix: unboard vehicle on using phase door

### DIFF
--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -101,6 +101,9 @@ bool teleport::teleport( Creature &critter, int min_distance, int max_distance, 
         }
     }
 
+    if( p && p->in_vehicle ) {
+        get_map().unboard_vehicle( p->pos() );
+    }
     critter.setpos( new_pos );
     //player and npc exclusive teleporting effects
     if( p ) {


### PR DESCRIPTION
## Purpose of change (The Why)
> an oopsie i found: you can cast phase door while driving a vehicle
> after doing so, you error out the next turn
> the vehicle continues to drive in its targeted path

WHY DO WE STILL HAVE UNBOARD_VEHICLE ERRORS LYING AROUND

## Describe the solution (The How)
Unboard the vehicle

## Describe alternatives you've considered
No longer let the players board vehicles as an alternate solution
Note: this will prevent using vehicles

## Testing
I spawned a cube van
Teleported
Didn't error

## Additional context
~~Dont you love my alternatives~~

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.