### PR TITLE
fix: advanced butcher rack fixes

### DIFF
--- a/data/json/items/fake.json
+++ b/data/json/items/fake.json
@@ -779,7 +779,8 @@
     "copy-from": "fake_item",
     "type": "TOOL",
     "name": { "str": "installed advanced butchering station" },
-    "qualities": [ [ "BUTCHER", 50 ], [ "CUT", 3 ], [ "CUT_FINE", 5 ] ]
+    "qualities": [ [ "BUTCHER", 50 ], [ "CUT", 3 ], [ "CUT_FINE", 5 ] ],
+    "flags": [ "FLAT_SURFACE" ]
   },
   {
     "id": "translocation_caster_spell",

--- a/data/json/vehicleparts/utilities.json
+++ b/data/json/vehicleparts/utilities.json
@@ -188,7 +188,7 @@
     "damage_reduction": { "all": 30 },
     "description": "Combining a fixed-up dissector, workbench and advanced electronics, this is a marvel capable of butchering, dissecting and cutting like nothing else!",
     "durability": 80,
-    "flags": [ "CARGO", "OBSTACLE", "CRAFTER", "TRANSPARENT", "FLAT_SURF" ],
+    "flags": [ "CARGO", "OBSTACLE", "BUTCHER_EQ", "CRAFTER", "TRANSPARENT", "FLAT_SURF" ],
     "integrated_tools": [ "fake_adv_butchery" ],
     "item": "adv_butchery",
     "location": "center",

--- a/docs/en/mod/json/reference/json_flags.md
+++ b/docs/en/mod/json/reference/json_flags.md
@@ -541,6 +541,7 @@ List of known flags, used in both `terrain.json` and `furniture.json`.
 - `BLOCK_WIND` This terrain will block the effects of wind.
 - `BURROWABLE` Burrowing monsters can travel under this terrain, while most others can't (e.g.
   graboid will traverse under the chain link fence, while ordinary zombie will be stopped by it).
+- `BUTCHER_EQ` Butcher's equipment - required for full butchery of corpses.
 - `CAN_SIT` Furniture the player can sit on. Player sitting near furniture with the "FLAT_SURF" tag
   will get mood bonus for eating.
 - `CHIP` Used in construction menu to determine if wall can have paint chipped off.

--- a/docs/en/mod/json/reference/vehicles/vehicle_parts.md
+++ b/docs/en/mod/json/reference/vehicles/vehicle_parts.md
@@ -79,7 +79,7 @@ Most legacy crafting vehiclepart flags have been removed and should be replaced 
 "integrated_tools": [ "dehydrator", "vac_sealer", "food_processor", "press" ],  // Replaces the `CRAFTRIG` flag
 "integrated_tools": [ "chemistry_set", "electrolysis_kit" ],  // Replaces the `CHEMLAB` flag
 "integrated_tools": [ "forge" ],  // Replaces the `FORGE` flag
-"integrated_tools": [ "fake_adv_butchery" ],  // Replaces the `BUTCHER_EQ` flag
+"integrated_tools": [ "fake_adv_butchery" ],  // Needed with the `BUTCHER_EQ` flag
 "integrated_tools": [ "kiln" ],  // Replaces the `KILN` flag
 "integrated_tools": [ "soldering_iron", "welder" ],  // Replaces the tools
 "integrated_tools": [ "water_purifier" ],  // Replaces the tools, but not the ability to purify water in vehicle tanks, of the `WATER_PURIFIER` flag


### PR DESCRIPTION
## Purpose of change (The Why)
I apparently missed some things around #7186 & butchery racks
Specifically
- It hardcoded adding the FLAT_SURFACE flag to the item?
- And BUTCHER_EQ was actually still needed

## Describe the solution (The How)
Readd BUTCHER_EQ & BUTCHER_EQ docs
Add FLAT_SURFACE to the advanced butchery fake item

## Describe alternatives you've considered
Add a flag to the item for butchery instead?

## Testing
I can butcher a moose

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.