### PR TITLE
fix: prevent trade menu when missions give free items to player in debt

### DIFF
--- a/src/npctalk_funcs.cpp
+++ b/src/npctalk_funcs.cpp
@@ -838,6 +838,11 @@ void talk_function::lead_to_safety( npc &p )
 
 bool npc_trading::pay_npc( npc &np, int cost )
 {
+    // Free items should never trigger trading
+    if( cost <= 0 ) {
+        return true;
+    }
+
     if( np.op_of_u.owed >= cost ) {
         np.op_of_u.owed -= cost;
         return true;


### PR DESCRIPTION
Fixes #7979

When a player is in debt with an NPC and the NPC tries to give the player a free item (cost = 0) through mission rewards or mission start items, the trade menu would incorrectly open instead of directly giving the item.

## Root Cause

The issue was in `npc_trading::pay_npc()` which would fall through to `npc_trading::trade()` when:
- The player's debt was negative (player owes NPC)
- Cost was 0 (free item)
- The condition `(negative_debt >= 0)` would be false, opening the trade menu

## Solution

Added an early return for free items (`cost <= 0`) before checking debt, preventing the trade menu from opening for mission item rewards.