### PR TITLE
fix: fix delayed effect from failing to disarm traps, revamp EXP for disarming

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -5712,6 +5712,7 @@ void map::disarm_trap( const tripoint &p )
 
     const int tSkillLevel = g->u.get_skill_level( skill_traps );
     const int diff = tr.get_difficulty();
+    const int tReward = diff + tr.get_avoidance();
     int roll = rng( tSkillLevel, 4 * tSkillLevel );
 
     // Some traps are not actual traps. Skip the rolls, different message and give the option to grab it right away.
@@ -5736,7 +5737,7 @@ void map::disarm_trap( const tripoint &p )
         g->u.add_morale( MORALE_ACCOMPLISHMENT, morale_buff, 40 );
         tr.on_disarmed( *this, p );
         if( diff > 1.25 * tSkillLevel ) { // failure might have set off trap
-            g->u.practice( skill_traps, 1.5 * ( diff - tSkillLevel ) );
+            g->u.practice( skill_traps, tReward );
         }
     } else if( roll >= diff * .8 ) {
         add_msg( _( "You fail to disarm the trap." ) );
@@ -5744,7 +5745,7 @@ void map::disarm_trap( const tripoint &p )
         g->u.rem_morale( MORALE_ACCOMPLISHMENT );
         g->u.add_morale( MORALE_FAILURE, morale_debuff, -40 );
         if( diff > 1.25 * tSkillLevel ) {
-            g->u.practice( skill_traps, 1.5 * ( diff - tSkillLevel ) );
+            g->u.practice( skill_traps, tReward / 2 );
         }
     } else {
         add_msg( m_bad, _( "You fail to disarm the trap, and you set it off!" ) );
@@ -5752,12 +5753,9 @@ void map::disarm_trap( const tripoint &p )
         g->u.rem_morale( MORALE_ACCOMPLISHMENT );
         g->u.add_morale( MORALE_FAILURE, morale_debuff, -40 );
         tr.trigger( p, &g->u );
-        if( diff - roll <= 6 ) {
-            // Give xp for failing, but not if we failed terribly (in which
-            // case the trap may not be disarmable).
-            g->u.practice( skill_traps, 2 * diff );
-        }
+        g->u.practice( skill_traps, tReward / 4 );
     }
+    g->u.mod_moves( -100 );
 }
 
 void map::remove_trap( const tripoint &p )


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

This fixes a couple issues with disarming traps.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. In map.cpp, set `map::disarm_trap` to take a turn. Aside from it looking odd that disarming a trap took zero time whatsoever, it also allowed for a visual oddity where the trap doesn't set itself off instantly, instead going off a turn after the failed attempted.
2. Sanity-checked EXP gain from disarming attempts. Instead of getting twice the trap's difficulty for setting it off, instead it combines the total of avoidance plus difficulty to determine the base EXP, then grants that amount for a successful disarm, half that for a failure that doesn't trigger it, and quartered for failures that set the trap off. This also helps compensate for EXP losses due to https://github.com/cataclysmbn/Cataclysm-BN/pull/7950
3. In addition, it no longer subtracts your trap skill from the EXP gain, since it already checks whether your trap skill is within 1.25x of the trap's difficulty, so there's no point in arbitrarily tanking the EXP gain for something that's already slow as hell and risky to grind.
4. Removed roll restriction on gaining a baseline amount of EXP for setting a trap off while failing to disarm it. The "trap may not be disarmable" justification doesn't really make sense since iexamine code doesn't even allow you to attempt to disarm traps with difficulty of 99.

## Describe alternatives you've considered

screm

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

1. Compiled and load-tested.
2. Tried and failed to disarm a buried landmine, it no longer gives me a free turn to contemplate my mistakes before blowing up in my face like a Wile E. Coyote gag.
3. Checked that at level zero trapping it gave me 6% level progression (buried landmines currently have 10 difficulty and 14 avoidance, so this is 25% that as expected) for setting it off.
4. Repeated after setting dexterity super high, I get 24% level progression for a successful disarm.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
