### PR TITLE
fix: Vehicle Tile Fallback

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -2698,7 +2698,7 @@ auto cata_tiles::find_tile_looks_like( const std::string &id, TILE_CATEGORY cate
             // vehicle parts start with vp_ for their tiles, but not their IDs
             const vpart_id base_vpid( id.substr( 3 ) );
             if( !base_vpid.is_valid() ) {
-                return find_tile_looks_like(id.substr(3), category, looks_like_jumps_limit - 1);
+                return find_tile_looks_like( id.substr( 3 ), category, looks_like_jumps_limit - 1 );
             }
             return find_tile_looks_like( "vp_" + base_vpid.obj().looks_like, category,
                                          looks_like_jumps_limit - 1 );


### PR DESCRIPTION
## Purpose of change (The Why)

Vehicle parts cannot look like other tile types, since they prepend vp_ to their tile id and validate the id.
This allows a fallback to be pulled if it doesn't match.

## Describe the solution (The How)

Just call find_tile_looks_like again, but with the vp_ removed, and subtract a looks_like_jumps_limit.

## Describe alternatives you've considered

Making the duck sad.

## Testing

```json

  {
    "copy-from": "trunk_abstract",
    "id": "cargo_space_2_electric_boogaloo",
    "type": "vehicle_part",
    "name": { "str": "cargo space 2: electric boogaloo" },
	"looks_like": "f_sign_warning",
    "size": "500 L",
    "item": "cargo_rack",
    "symbol": "o",
    "flags": [ "BOARDABLE", "CARGO", "COVERED" ],
    "durability": 350,
    "location": "center",
    "damage_reduction": { "all": 28 },
    "breaks_into": [
      { "item": "steel_lump", "count": [ 6, 8 ] },
      { "item": "steel_chunk", "count": [ 6, 8 ] },
      { "item": "scrap", "count": [ 6, 8 ] }
    ]
  },
  ```
  Uninstalled a cargo space, reinstalled it as the second option.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

Rope hope

#7986