### PR TITLE
fix: ensure Mycus characters can't be softlocked by fungal infection

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -2847,6 +2847,7 @@
     "description": "We have streamlined our nutritional requirements.  We rely on the Mycus for sustenance, as it relies on us.  We may locate sources of sustenance in close proximity to Mycus core towers, and in forested areas that the Mycus has grown into.",
     "valid": false,
     "purifiable": false,
+    "prereqs": [ "M_IMMUNE" ],
     "threshreq": [ "THRESH_MYCUS" ],
     "cancels": [ "GOURMAND", "BEAK", "BEAK_PECK", "BEAK_HUM" ],
     "category": [ "MYCUS" ]

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -196,6 +196,7 @@ static const efftype_id effect_riding( "riding" );
 static const efftype_id effect_saddled( "monster_saddled" );
 static const efftype_id effect_sleep( "sleep" );
 static const efftype_id effect_slept_through_alarm( "slept_through_alarm" );
+static const efftype_id effect_spores( "spores" );
 static const efftype_id effect_stunned( "stunned" );
 static const efftype_id effect_tied( "tied" );
 static const efftype_id effect_took_prozac( "took_prozac" );
@@ -6919,6 +6920,8 @@ bool Character::is_immune_effect( const efftype_id &eff ) const
         return is_immune_damage( DT_ACID ) || has_trait( trait_SLIMY ) || has_trait( trait_VISCOUS );
     } else if( eff == effect_nausea ) {
         return has_trait( trait_STRONGSTOMACH );
+    } else if( eff == effect_spores || eff == effect_fungus ) {
+        return has_trait( trait_M_IMMUNE );
     } else if( eff == effect_bleed ) {
         // Ugly, it was badly implemented and should be a flag
         return mutation_value( "bleed_resist" ) > 0.0f;

--- a/src/character_turn.cpp
+++ b/src/character_turn.cpp
@@ -56,7 +56,6 @@ static const trait_id trait_INSECT_ARMS_OK( "INSECT_ARMS_OK" );
 static const trait_id trait_INSECT_ARMS( "INSECT_ARMS" );
 static const trait_id trait_LIGHTFUR( "LIGHTFUR" );
 static const trait_id trait_LUPINE_FUR( "LUPINE_FUR" );
-static const trait_id trait_M_IMMUNE( "M_IMMUNE" );
 static const trait_id trait_NOMAD( "NOMAD" );
 static const trait_id trait_NOMAD2( "NOMAD2" );
 static const trait_id trait_NOMAD3( "NOMAD3" );
@@ -65,6 +64,7 @@ static const trait_id trait_SLIMY( "SLIMY" );
 static const trait_id trait_STIMBOOST( "STIMBOOST" );
 static const trait_id trait_SUNLIGHT_DEPENDENT( "SUNLIGHT_DEPENDENT" );
 static const trait_id trait_THICK_SCALES( "THICK_SCALES" );
+static const trait_id trait_THRESH_MYCUS( "THRESH_MYCUS" );
 static const trait_id trait_URSINE_FUR( "URSINE_FUR" );
 static const trait_id trait_WEBBED( "WEBBED" );
 static const trait_id trait_WHISKERS_RAT( "WHISKERS_RAT" );
@@ -575,7 +575,8 @@ void Character::process_effects_internal()
     if( has_effect( effect_darkness ) && g->is_in_sunlight( pos() ) ) {
         remove_effect( effect_darkness );
     }
-    if( has_trait( trait_M_IMMUNE ) && has_effect( effect_fungus ) ) {
+    // Mycus can still accidentally get infected until they pick up immunity, but won't suffer from it.
+    if( has_trait( trait_THRESH_MYCUS ) && has_effect( effect_fungus ) ) {
         vomit();
         remove_effect( effect_fungus );
         add_msg_if_player( m_bad, _( "We have mistakenly colonized a local guide!  Purging now." ) );

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -1361,6 +1361,9 @@ int iuse::mycus( player *p, item *it, bool t, const tripoint &pos )
         p->fall_asleep( 5_hours - p->int_cur * 1_minutes );
         p->unset_mutation( trait_THRESH_MARLOSS );
         p->set_mutation( trait_THRESH_MYCUS );
+        // Cleanse fungal infections
+        p->remove_effect( effect_fungus );
+        p->remove_effect( effect_spores );
         g->invalidate_main_ui_adaptor();
         //~ The Mycus does not use the term (or encourage the concept of) "you".  The PC is a local/native organism, but is now the Mycus.
         //~ It still understands the concept, but uninitelligent fungaloids and mind-bent symbiotes should not need it.


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

@ChrisLR mentioned on the discord how an early Mycus character could get fucked over by fungal infection if they don't have Mycus Identity yet, so I went through and did some things to make it a bit more reliable about letting you survive to get that trait, and for good measure added a bit to make its protections more robust.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

C++ changes:
1. In character.cpp, updated `Character::is_immune_effect` to further help insure having Mycus Identity prevents getting fungus or spores.
2. In character_turn.cpp, downgraded the removal of spores in `Character::process_effects_internal` from requiring Mycus Identity to just having the Mycus threshold in general. This should ensure that, if you get infected before picking up immunity, it will quickly purge itself with no harm done besides puking your guts out.
3. In iuse.cpp, set `iuse::mycus` to cure spore and fungus effects on first being granted the Mycus threshold, since cavorting with fungals in the process of completing the marloss triangle has a high risk of you getting an extradimensional STD from the fungal tower or its mobs in the process of getting Marloss Vector via intravenous tentacle hentai. 

JSON changes:
1. Set Mycus Feeder to, like several of the other more advanced Mycus mutations, require Mycus Identity as a prerequisite. This should help ensure the player gets it sooner, and moreover so they can't be locked in a situation where they can get infected by fungus but can't consume fungicide.

## Describe alternatives you've considered

Completely moving the effects of Mycus Indentity to just having Mycus threshold entirely, and either phasing out that mutation or giving it some other new effects.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

1. Compiled and load-tested.
2. Gave myself Mycus mutation.
3. Debugged myself the fungus effect, it clears itself a turn later.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

<img width="360" height="323" alt="image" src="https://github.com/user-attachments/assets/a7ed2d35-f967-43cc-a8c4-f89032f0296d" />

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

