### PR TITLE
fix: clear vehicle rope cache everywhere

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -393,6 +393,7 @@ void map::clear_vehicle_point_from_cache( vehicle *veh, const tripoint &pt )
             ch.veh_exists_at[pt.x][pt.y] = false;
         }
         ch.veh_cached_parts.erase( it );
+        cached_veh_rope.erase( pt.xy() );
     }
 
 }


### PR DESCRIPTION
## Purpose of change (The Why)
#7986 had a minor caching error reported by chaos

## Describe the solution (The How)
Clear cache in clear_vehicle_point_from_cache

## Describe alternatives you've considered
None

## Testing
Can't replicate rope duplication

## Additional context
I screm

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.