### PR TITLE
fix(UI): droppers now properly display themselves again

### DIFF
--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -877,26 +877,18 @@ void vehicle::use_controls( const tripoint &pos )
 
     }
 
-    if( has_part( "DROPPER" ) ) {
-        std::vector<vehicle_part *> droppers;
-        for( auto &p : parts ) {
-            if( p.has_flag( VPFLAG_DROPPER ) && !p.removed ) {
-                droppers.push_back( &p );
-            }
-        }
-        if( !droppers.empty() ) {
-            options.emplace_back( _( "Activate all item droppers (Drop Everything)" ),
-                                  keybind( "DROPPER_ALL" ) );
-            actions.emplace_back( [&] { item_dropper_drop_all(); refresh(); } );
+    if( !droppers.empty() ) {
+        options.emplace_back( _( "Activate all item droppers (Drop Everything)" ),
+                              keybind( "DROPPER_ALL" ) );
+        actions.emplace_back( [&] { item_dropper_drop_all(); refresh(); } );
 
-            options.emplace_back( _( "Activate one item dropper (Drop Everything)" ),
-                                  keybind( "DROPPER_SINGLE_ALL" ) );
-            actions.emplace_back( [&] { item_dropper_drop_single( false ); refresh(); } );
+        options.emplace_back( _( "Activate one item dropper (Drop Everything)" ),
+                              keybind( "DROPPER_SINGLE_ALL" ) );
+        actions.emplace_back( [&] { item_dropper_drop_single( false ); refresh(); } );
 
-            options.emplace_back( _( "Activate one item dropper (Drop One Thing)" ),
-                                  keybind( "DROPPER_SINGLE" ) );
-            actions.emplace_back( [&] { item_dropper_drop_single( true ); refresh(); } );
-        }
+        options.emplace_back( _( "Activate one item dropper (Drop One Thing)" ),
+                              keybind( "DROPPER_SINGLE" ) );
+        actions.emplace_back( [&] { item_dropper_drop_single( true ); refresh(); } );
     }
     uilist menu;
     menu.text = _( "Vehicle controls" );


### PR DESCRIPTION
## Purpose of change (The Why)
Apparently something I did in #7829 to fix what I thought was an issue in the PR actually was in main too

## Describe the solution (The How)
Port the has_part( "DROPPER" ) to !droppers.empty() change

## Describe alternatives you've considered
Just fix that PR

## Testing
Droppers seem to appear again

## Additional context
Why does everything break today

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.