### PR TITLE
ci: use `ubuntu-slim` for short workflows

### DIFF
--- a/.github/workflows/i18n-extraction.yml
+++ b/.github/workflows/i18n-extraction.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   check-extraction:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Install dependencies
         run: |

--- a/.github/workflows/i18n-printf-format.yml
+++ b/.github/workflows/i18n-printf-format.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   check-po-printf:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: "Install dependencies"
         run: |

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -4,7 +4,7 @@ on: pull_request_target
 
 jobs:
   triage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
 
     permissions:
       contents: read

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   release:
     name: Create Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   skip-duplicates:
     continue-on-error: true
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     outputs:
       should_skip_code: ${{ steps.skip_code_check.outputs.should_skip }}
       should_skip_data: ${{ steps.skip_data_check.outputs.should_skip }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   metadata:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     outputs:
       count: ${{ steps.env_vars.outputs.count }}
       tag_name: ${{ steps.env_vars.outputs.tag_name }}
@@ -38,7 +38,7 @@ jobs:
   release:
     needs: metadata
     name: Create Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
 
     if: github.event_name == 'workflow_dispatch' || fromJson(needs.metadata.outputs.count) > 0
     outputs:

--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   validate:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: docker://ghcr.io/scarf005/conventional-prs:main
         env:


### PR DESCRIPTION
## Purpose of change (The Why)

https://github.blog/changelog/2025-10-28-1-vcpu-linux-runner-now-available-in-github-actions-in-public-preview/

> When using these runners, your actions workflows execute inside of a container rather than a dedicated VM instance, enabling cost-effective, performant execution of automation tasks across GitHub.

from 2025-10, github actions offers `ubuntu-slim` runners (1 vCPU, 5GB RAM, 15 minutes max) optimized for lightweight automation tasks. it's quicker to run than regular runners, they say

## Describe the solution (The How)

Switch the following lightweight workflows from `ubuntu-latest` to `ubuntu-slim`:
- validate-pr-title.yml - PR title validation
- label.yml - Auto-labeling PRs
- i18n-extraction.yml - Translation template validation
- i18n-printf-format.yml - Printf format checking
- release.yml (metadata/release jobs) - Release metadata generation
- manual-release.yml (release job) - Manual release creation
- matrix.yml (skip-duplicates job) - Duplicate check

## Testing

<img width="1760" height="96" alt="image" src="https://github.com/user-attachments/assets/216c2509-4c3e-463e-afba-7762134fd5e7" />

8s -> 6s (25% improvement), not bad for single word change

## Checklist

### Mandatory

- [x] I wrote the PR title in conventional commit format.
- [x] I ran the code formatter.
- [x] I linked any relevant issues using github keyword syntax like `closes #1234` in Summary of the PR so it can be closed automatically.
- [x] I've committed my changes to new branch that isn't `main` so it won't cause conflict when updating `main` branch later.