### PR TITLE
fix: fix switching tileset not working due to vehicle fallback

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -2700,7 +2700,7 @@ auto cata_tiles::find_tile_looks_like( const std::string &id, TILE_CATEGORY cate
             const vpart_id base_vpid( base_id );
             if( !base_vpid.is_valid() ) {  // Fixed Fallback
                 find_tile_looks_like( base_id, C_FURNITURE, looks_like_jumps_limit - 1 )
-                    .or_else( [&, this]{ return find_tile_looks_like( base_id, C_TERRAIN, looks_like_jumps_limit - 1 ); } );
+                .or_else( [ &, this] { return find_tile_looks_like( base_id, C_TERRAIN, looks_like_jumps_limit - 1 ); } );
             }
             return find_tile_looks_like( "vp_" + base_vpid.obj().looks_like, category,
                                          looks_like_jumps_limit - 1 );


### PR DESCRIPTION
## Purpose of change (The Why)

May resolve #7999

## Describe the solution (The How)

Use tile categories for the fallback so it doesn't try going through the vehicle tile case.
Honestly not sure why it worked at all.

## Describe alternatives you've considered

Removing the fallback

## Testing

Spawn, make a vehicle, then try to change tileset.
Errors before, doesn't now.