### PR TITLE
fix: Mark seeds as HIDDEN_ITEM when planted by seed drill

### DIFF
--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -1483,6 +1483,7 @@ void vehicle::operate_planter()
                 }
                 if( !i->count_by_charges() || i->charges == 1 ) {
                     i->set_age( 0_turns );
+                    i->set_flag( flag_id( "HIDDEN_ITEM" ) );
                     detached_ptr<item> det;
                     v.erase( it, &det );
                     g->m.add_item( loc, std::move( det ) );
@@ -1490,6 +1491,7 @@ void vehicle::operate_planter()
                     detached_ptr<item> tmp = item::spawn( *i );
                     tmp->charges = 1;
                     tmp->set_age( 0_turns );
+                    tmp->set_flag( flag_id( "HIDDEN_ITEM" ) );
                     g->m.add_item( loc, std::move( tmp ) );
                     i->charges--;
                 }


### PR DESCRIPTION
When the seed drill plants seeds, mark them with the HIDDEN_ITEM flag, matching the behavior of manual planting via plant_seed_finish(). This prevents seeds from being accessible via advanced inventory when a CARGO vehicle part is over the planted seed, which was causing the 'Missing seed for plant' error when seeds were moved.

Fixes issue #5799.

## Purpose of change (The Why)

Resolves 5799

## Describe the solution (The How)

 - Mark seeds with HIDDEN_ITEM flag when planted by seed drill in operate_planter() function
 - This matches the existing behavior of manual planting via plant_seed_finish()
 - HIDDEN_ITEM prevents seeds from being accessible/removable via advanced inventory when a CARGO part of a vehicle is over an otherwise NOITEM furniture
 - Resolves the "Missing seed for plant" debugmsg that occurred when seeds were removed from plant furniture


## Describe alternatives you've considered

Preventing SEALED furniture from being accessed altogether somehow, but it seems like plants are the only SEALED furniture without a collision right now so maybe it's fine. A theoretical non-colliding CARGO part could probably be used to access things in crates, safes and boxes right now.

## Testing

Planted a seed with a seed drill and could not access it via advanced inventory while cargo is over it.

## Checklist

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
