### PR TITLE
fix: Spelunker's map no longer showing minefields

### DIFF
--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -1483,7 +1483,6 @@ void vehicle::operate_planter()
                 }
                 if( !i->count_by_charges() || i->charges == 1 ) {
                     i->set_age( 0_turns );
-                    i->set_flag( flag_id( "HIDDEN_ITEM" ) );
                     detached_ptr<item> det;
                     v.erase( it, &det );
                     g->m.add_item( loc, std::move( det ) );
@@ -1491,7 +1490,6 @@ void vehicle::operate_planter()
                     detached_ptr<item> tmp = item::spawn( *i );
                     tmp->charges = 1;
                     tmp->set_age( 0_turns );
-                    tmp->set_flag( flag_id( "HIDDEN_ITEM" ) );
                     g->m.add_item( loc, std::move( tmp ) );
                     i->charges--;
                 }


### PR DESCRIPTION
## Purpose of change

Prevents spelunker's map from revealing military base minefields.

- Fixes #7792

## Describe the solution

Changed spelunker's map (`cavemap`) terrain matching from implicit `CONTAINS` to explicit `PREFIX` to avoid matching `mil_base_minefield_*` overmap terrains.

## Testing

- Game loads without JSON errors
- Spelunker's map no longer reveals military base minefields
- All mine-related terrains are still properly revealed

## Checklist

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #7792` in [Summary of the PR](#purpose-of-change) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.