### PR TITLE
fix: remove test message from `game::slip_down`

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -13231,7 +13231,6 @@ bool game::slip_down()
     // Parkour and Bad Knees affect it too, avoid division by zero
     if( u.mutation_value( "movecost_obstacle_modifier" ) != 0.0f ) {
         climb = climb / u.mutation_value( "movecost_obstacle_modifier" );
-        add_msg( m_info, _( "We modified climb, it's %s now" ), climb );
     }
     if( one_in( climb ) ) {
         add_msg( m_bad, _( "You slip while climbing and fall down again." ) );


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

I left a testing message in a function when I did [the tree climbing PR](https://github.com/cataclysmbn/Cataclysm-BN/pull/7993) FUCK

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

Removed `add_msg` call in `game::slip_down`.

## Describe alternatives you've considered

Making it a debug-mode-only message and rewording message to be more clear about what it does.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

Used my fucking eyes.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
