### PR TITLE
fix: Vehicle Tile Fallback Fix 2

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -2699,7 +2699,7 @@ auto cata_tiles::find_tile_looks_like( const std::string &id, TILE_CATEGORY cate
             auto base_id = id.substr( 3 );
             const vpart_id base_vpid( base_id );
             if( !base_vpid.is_valid() ) {  // Fixed Fallback
-                find_tile_looks_like( base_id, C_FURNITURE, looks_like_jumps_limit - 1 )
+                return find_tile_looks_like( base_id, C_FURNITURE, looks_like_jumps_limit - 1 )
                 .or_else( [ &, this] { return find_tile_looks_like( base_id, C_TERRAIN, looks_like_jumps_limit - 1 ); } );
             }
             return find_tile_looks_like( "vp_" + base_vpid.obj().looks_like, category,


### PR DESCRIPTION
## Purpose of change (The Why)

Monad broke #7988 due to lacking return.

## Describe the solution (The How)

RETURN THE MONAD

## Describe alternatives you've considered

MOSAD
MOPROBLEMS

## Testing

My patience