### PR TITLE
feat: sunken bottles & sunken corpses

### DIFF
--- a/data/json/itemgroups/Locations_MapExtras/locations_waterbody.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations_waterbody.json
@@ -19,11 +19,7 @@
     "id": "lakebed_sunken_corpse",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [
-      { "item": "chain", "count": 1 },
-      { "item": "concrete", "count": 1 },
-      { "group": "everyday_corpse" }
-    ]
+    "entries": [ { "item": "chain", "count": 1 }, { "item": "concrete", "count": 1 }, { "group": "everyday_corpse" } ]
   },
   {
     "id": "underwater_toxic_waste",

--- a/data/json/mapgen/lake.json
+++ b/data/json/mapgen/lake.json
@@ -214,9 +214,7 @@
     "object": {
       "mapgensize": [ 12, 12 ],
       "rotation": [ 0, 3 ],
-      "place_items": [
-        { "item": "lakebed_sunken_corpse", "x": [ 2, 11 ], "y": [ 2, 11 ],  "chance": 75, "repeat": [ 2, 6 ] }
-      ]
+      "place_items": [ { "item": "lakebed_sunken_corpse", "x": [ 2, 11 ], "y": [ 2, 11 ], "chance": 75, "repeat": [ 2, 6 ] } ]
     }
   },
   {


### PR DESCRIPTION
## Purpose of change (The Why)
Adds some more flavor to underwater content.

## Describe the solution (The How)
Adds a spawn for survivor notes inside of glass bottles, which can be found on the lake bed.

Additionally, adds a spawn of sunken corpses which have everyday gear, and a concrete sack with a chain attached to hint at them being killed by drowning.
## Describe alternatives you've considered

## Testing
Spawned the nested mapgen, walked around on the lakebed for a bit.

## Additional context

<img width="1842" height="1007" alt="image" src="https://github.com/user-attachments/assets/8bf723c9-cc07-4ea9-8127-9cb9621fcec5" />

## Checklist

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.