### PR TITLE
feat(balance): Make RPG mod affect magic stat scaling like STK

### DIFF
--- a/data/mods/rpg_system/modinfo.json
+++ b/data/mods/rpg_system/modinfo.json
@@ -9,5 +9,11 @@
     "category": "content",
     "lua_api_version": 2,
     "dependencies": [ "bn" ]
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "MAGIC_STAT_SCALING_PERCENT",
+    "stype": "int",
+    "value": 5
   }
 ]


### PR DESCRIPTION
## Purpose of change (The Why)

RPG system gives stats like STS and STK, and as such it should carry the same reduction in magic stats scaling.

## Describe the solution (The How)

```json
{
    "type": "EXTERNAL_OPTION",
    "name": "MAGIC_STAT_SCALING_PERCENT",
    "stype": "int",
    "value": 5
  }
```

## Describe alternatives you've considered

- Extra reduction
- Leave it be for powerfantasy

## Testing

Copy-pasted from STS, should be fine

## Additional context

Finally got around to it lol

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
