### PR TITLE
ci: show semver on manual release

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -1,4 +1,5 @@
 name: "Manual release"
+run-name: "Manual Release ${{ inputs.major }}.${{ inputs.minor }}.${{ inputs.patch }}"
 concurrency: release
 
 on:


### PR DESCRIPTION
## Purpose of change (The Why)

<img width="1609" height="265" alt="image" src="https://github.com/user-attachments/assets/433e0334-ee80-453c-be33-69754fe55bb5" />

so it's ez to see which version is getting released
prequel of #7941