### PR TITLE
perf: add underwater_age_speedup to long-lasting gas fields to prevent exponential spread

### DIFF
--- a/data/json/field_type.json
+++ b/data/json/field_type.json
@@ -447,6 +447,7 @@
     "decay_amount_factor": 5,
     "percent_spread": 15,
     "outdoor_age_speedup": "1 minutes",
+    "underwater_age_speedup": "30 minutes",
     "dirty_transparency_cache": true,
     "has_fume": true,
     "priority": 8,
@@ -577,6 +578,7 @@
     "gas_absorption_factor": 15,
     "percent_spread": 30,
     "outdoor_age_speedup": "3 minutes",
+    "underwater_age_speedup": "10 minutes",
     "dirty_transparency_cache": true,
     "has_fume": true,
     "immunity_data": { "body_part_env_resistance": [ [ "mouth", 15 ] ] },
@@ -1123,8 +1125,9 @@
     "decay_amount_factor": 5,
     "percent_spread": 100,
     "outdoor_age_speedup": "100 minutes",
+    "underwater_age_speedup": "1 minute",
     "priority": -1,
-    "half_life": "50 minutes",
+    "half_life": "5 minutes",
     "phase": "gas"
   },
   {
@@ -1139,8 +1142,9 @@
     "decay_amount_factor": 5,
     "percent_spread": 100,
     "outdoor_age_speedup": "100 minutes",
+    "underwater_age_speedup": "1 minute",
     "priority": -1,
-    "half_life": "50 minutes",
+    "half_life": "5 minutes",
     "phase": "gas"
   },
   {
@@ -1155,8 +1159,9 @@
     "decay_amount_factor": 5,
     "percent_spread": 100,
     "outdoor_age_speedup": "100 minutes",
+    "underwater_age_speedup": "1 minute",
     "priority": -1,
-    "half_life": "50 minutes",
+    "half_life": "5 minutes",
     "phase": "gas"
   },
   {
@@ -1171,8 +1176,9 @@
     "decay_amount_factor": 5,
     "percent_spread": 100,
     "outdoor_age_speedup": "100 minutes",
+    "underwater_age_speedup": "1 minute",
     "priority": -1,
-    "half_life": "50 minutes",
+    "half_life": "5 minutes",
     "phase": "gas"
   },
   {
@@ -1187,8 +1193,9 @@
     "decay_amount_factor": 5,
     "percent_spread": 100,
     "outdoor_age_speedup": "100 minutes",
+    "underwater_age_speedup": "1 minute",
     "priority": -1,
-    "half_life": "50 minutes",
+    "half_life": "5 minutes",
     "phase": "gas"
   },
   {
@@ -1203,8 +1210,9 @@
     "decay_amount_factor": 5,
     "percent_spread": 100,
     "outdoor_age_speedup": "100 minutes",
+    "underwater_age_speedup": "1 minute",
     "priority": -1,
-    "half_life": "50 minutes",
+    "half_life": "5 minutes",
     "phase": "gas"
   },
   {
@@ -1219,8 +1227,9 @@
     "decay_amount_factor": 5,
     "percent_spread": 100,
     "outdoor_age_speedup": "100 minutes",
+    "underwater_age_speedup": "1 minute",
     "priority": -1,
-    "half_life": "50 minutes",
+    "half_life": "5 minutes",
     "phase": "gas"
   },
   {
@@ -1235,8 +1244,9 @@
     "decay_amount_factor": 5,
     "percent_spread": 100,
     "outdoor_age_speedup": "100 minutes",
+    "underwater_age_speedup": "1 minute",
     "priority": -1,
-    "half_life": "50 minutes",
+    "half_life": "5 minutes",
     "phase": "gas"
   },
   {
@@ -1323,6 +1333,7 @@
     "gas_absorption_factor": 15,
     "percent_spread": 100,
     "outdoor_age_speedup": "1 minutes",
+    "underwater_age_speedup": "50 minutes",
     "dirty_transparency_cache": true,
     "has_fume": true,
     "immunity_data": { "body_part_env_resistance": [ [ "mouth", 15 ] ] },
@@ -1345,6 +1356,7 @@
     "gas_absorption_factor": 15,
     "percent_spread": 100,
     "outdoor_age_speedup": "1 minutes",
+    "underwater_age_speedup": "50 minutes",
     "dirty_transparency_cache": true,
     "has_fume": true,
     "immunity_data": { "body_part_env_resistance": [ [ "mouth", 15 ] ] },


### PR DESCRIPTION
## Purpose of change (The Why)
  - Gas fields were causing severe performance issues underwater because they aged 3000x slower than on the surface,
  leading to exponential accumulation
  - Closes #8054

  ## Describe the solution (The How)
  - Added `underwater_age_speedup` property to gas fields that were in danger of exponential spread

  ## Describe alternatives you've considered
  - Could have disabled gas spreading underwater, why are we simulating natural gas vents anyway.
  - Could have prevented gas vents from spawning underwater, are they really needed?

  ## Testing
  - User tested and confirmed hot air fields now dissipate underwater
  - Performance returned to slightly worse than normal in a otherwise laggy area

  ## Additional context
  - Gas fields had `outdoor_age_speedup` but no `underwater_age_speedup`, causing 1 turn/turn aging underwater vs 100+
   minutes/turn outdoors
  - With 100% spread rate, fields accumulated faster than they could decay
  - Even with these changes there is still noticable slowdown from simulating vent hot air. This seems unnecessary.

  ## Checklist
  - [x] I wrote the PR title in [conventional commit
  format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
  - [-] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style) -- this is a json change
  - [x] I linked any relevant issues using [github keyword
  syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of
   the PR](#purpose-of-change-the-why) so it can be closed automatically.
  - [x] I've [committed my changes to new branch that isn't
  `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when
  updating `main` branch later.