### PR TITLE
chore: Add 0.10.0 changelog to XDG metainfo

### DIFF
--- a/data/XDG/org.cataclysmbn.CataclysmBN.metainfo.xml
+++ b/data/XDG/org.cataclysmbn.CataclysmBN.metainfo.xml
@@ -68,6 +68,21 @@
         <content_attribute id="language-discrimination">intense</content_attribute>
     </content_rating>
     <releases>
+        <release version="0.10.0" date="2025-01-7">
+            <url type="details">https://github.com/cataclysmbn/Cataclysm-BN/releases/tag/v0.10.0</url>
+            <description>
+                <p>Notable Changes</p>
+                <ul>
+                    <li>Added the ability to select bionics in character creation</li>
+                    <li>Implemented framework for multi-tier mutation thresholds</li>
+                    <li>Expanded list of swords Niten Ichi Ryu can use</li>
+                    <li>Ice labs spawn naturally again</li>
+                    <li>Added a lesser version of the Brawler trait that only bans guns known as Gunshy</li>
+                    <li>Added nyctophobia (fear of the dark) trait</li>
+                    <li>Rest of the changes can be found in the github repo</li>
+                </ul>
+            </description>
+        </release>
         <release version="0.9.1" date="2025-11-14">
             <url type="details">https://github.com/cataclysmbn/Cataclysm-BN/releases/tag/v0.9.1</url>
             <description>


### PR DESCRIPTION
## Purpose of change (The Why)

We released 0.10.0, Flathub/Flatpak wants a changelog in the metainfo

## Describe the solution (The How)

Adds it, poaching some of the "Featured changes" from the reddit posts and just grabbing stuff from recently merged commits

## Describe alternatives you've considered

Make someone else do it for the heck of it

## Testing

N/A

## Additional context

Those Reddit posts will probably be very nice whenever we release new stables, for having highlighted nice changes

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
