### PR TITLE
fix: Invalid Effect in Overlay

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -3860,7 +3860,7 @@ std::vector<Character::overlay_entry> Character::get_overlay_ids() const
 
     // first get effects
     for( const auto &[eff_type, eff_by_part] : *effects ) {
-        const auto eff = eff_by_part.begin()->second;
+        const auto &eff = eff_by_part.begin()->second;
         if( eff.get_id().is_valid() && !eff.is_removed() ) {
             const std::string &looks_like = eff_type.obj().get_looks_like();
 

--- a/src/character_preview.cpp
+++ b/src/character_preview.cpp
@@ -177,14 +177,15 @@ class char_preview_adapter : public cata_tiles
             overlay_result result;
             std::multimap<int, overlay_entry> mutation_sorting;
 
-            for( const auto &[eff_type, eff_by_part] : av.get_all_effects() ) {
+            for( const auto &[eff_type, eff_by_part] : av.get_effects() ) {
                 const effect &eff = eff_by_part.begin()->second;
-                if( !eff.is_removed() ) {
-                    result.overlays.emplace_back( overlay_entry{
-                        "effect_" + eff_type.str(),
-                        &eff
-                    } );
+                if( eff.is_removed() ) {
+                    continue;
                 }
+                result.overlays.emplace_back( overlay_entry{
+                    "effect_" + eff_type.str(),
+                    &eff
+                } );
             }
 
             for( const mutation &mut : av.my_mutations ) {

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -2467,6 +2467,11 @@ void Creature::describe_specials( std::vector<std::string> &buf ) const
     buf.emplace_back( _( "You sense a creature here." ) );
 }
 
+const effects_map &Creature::get_effects() const
+{
+    return *effects;
+}
+
 effects_map Creature::get_all_effects() const
 {
     effects_map effects_without_removed;

--- a/src/creature.h
+++ b/src/creature.h
@@ -942,6 +942,7 @@ class Creature
 
         // TODO: There may be a cleaner way of doing it than exposing the map
         effects_map get_all_effects() const;
+        const effects_map &get_effects() const;
 
     protected:
         weak_ptr_fast<Creature> killer; // whoever killed us. this should be NULL unless we are dead


### PR DESCRIPTION
## Purpose of change (The Why)

Invalid effects are being added somewhere
Or the function for grabbing them is generating garbage
No idea why

## Describe the solution (The How)

Fixes immediate exception on moving, or sometimes even on game start itself
Does this by fixing dangling pointer issues for effect storage.

## Describe alternatives you've considered

ヾ(ﾟдﾟ)ﾉ

## Testing

Works now

## Additional context

`For mental health reasons, I will be passing away.`