### PR TITLE
fix: disable effect coloring

### DIFF
--- a/src/cata_tiles_color.cpp
+++ b/src/cata_tiles_color.cpp
@@ -93,10 +93,6 @@ auto cata_tiles::get_effect_color(
 auto cata_tiles::get_effect_color(
     const effect &eff, const Character &c ) -> color_tint_pair
 {
-    const color_tint_pair *tint = tileset_ptr->get_tint( eff.get_id().str() );
-    if( tint != nullptr ) {
-        return *tint;
-    }
     return { std::nullopt, std::nullopt };
 }
 


### PR DESCRIPTION
## Purpose of change (The Why)
Invalid effects are being added somewhere
Or the function for grabbing them is generating garbage
No idea why
Check for them so grabbing the id of an invalid effect doesn't happen

## Describe the solution (The How)
Temporarily disable the broken part

## Describe alternatives you've considered
Fix #8076

## Testing
I no longer crash

## Additional context
For if #8076 doesn't work by nightly

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.