### PR TITLE
feat(balance): reduce `ups_charges_modifier` of powered air pump

### DIFF
--- a/data/json/items/gunmod/mechanism.json
+++ b/data/json/items/gunmod/mechanism.json
@@ -276,7 +276,7 @@
     "mod_target_category": [ [ "PNEUMATIC" ] ],
     "install_time": "5 m",
     "reload_modifier": -80,
-    "ups_charges_modifier": 40
+    "ups_charges_modifier": 6
   },
   {
     "id": "mod_makeshift_capacitor",


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

While looking at https://github.com/cataclysmbn/Cataclysm-BN/pull/8067 I checked how the air gun reload mod works and realized it has an absolutely absurd UPS cost of 40 kJ per shot, which is excessive given it will be applied for every single shot and then only benefit you when you're reloading.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

Lowered UPS cost from 40 to 6, bit more than the crossbow mod since this gives an 80% bonus while the crossbow one gives a 65% bonus.

## Describe alternatives you've considered

Making it also 5 UPS cost like the crossbow gunmod?

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

Used my eyes and elementary-level mathematics to confirm that 6 is a smaller number than 40.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
