### PR TITLE
docs: add changelog for stable release 0.10.0

### DIFF
--- a/docs/en/game/changelog/stable_10.md
+++ b/docs/en/game/changelog/stable_10.md
@@ -8,6 +8,7 @@ This summary lists the most significant changes from this release. This release 
 - Added a world option for initial trait purification and cancellation
 - Climbing trees can trigger slips and heavy impacts can knock survivors off unstable terrain
 - Vehicle idle lift now reduces drag and supports floating at ground level
+- Added vehicle turret autoloaders
 
 ## New Content
 
@@ -40,11 +41,10 @@ This summary lists the most significant changes from this release. This release 
 - Fixed Mycus fruit-eating crashes and progression blockers that could softlock Mycus characters
 - Fixed items disappearing when loading smoking racks and charcoal kilns
 - Fixed vehicle ladders so they function without install-order dependency
-- Fixed turret autoloaders so internal magazines reload correctly
 
 ## Ported from DDA
 
 - Ported the relentless hulk and NEMESIS content set including its scenario
 - Ported directed trap disarm changes that remove base difficulty checks
 
-See detailed changelog [https://github.com/cataclysmbn/Cataclysm-BN/releases/tag/v0.10.0 here]
+See full changelog here: <https://github.com/cataclysmbn/Cataclysm-BN/releases/tag/v0.10.0>


### PR DESCRIPTION
## Purpose of change (The Why)

We want to communicate gameplay changes and new features more clearly, with stronger emphasis on new content.

For that, changelogs should be user-friendly, condensed, readable, and easy to access.

Goals for this text:
- Help communicate the game's vision and strengths
- Focus on what matters to the average player
- Keep it short (under 50 lines)
- Use as little developer jargon as possible

Please give it a quick read. If it looks good, I suggest using it as the v0.10.0 description.

## Describe the solution (The How)

The changelog was precompiled by AI, then reviewed, sorted, and refined through multiple iterations.

## Describe alternatives you've considered

Keep the current approach and continue with less player-facing communication.

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

<!-- please remove checkboxes unrelated to this PR. -->

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have added [`port` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#port%3A-ports-from-dda-or-other-forks) to the PR title.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR adds/removes a mod.
  - [ ] I have added [`mods` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#mods-or-mods%2F<mod_id>%3A-mods) to the PR title.
  - [ ] The `mod_name` in `data/mods/<mod_name>` matches `id` in `modinfo.json`.
  - [ ] I have committed the output of `deno task semantic`.
- [ ] This PR modifies lua scripts or the lua API.
  - [ ] I have added [`lua` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#lua%3A-changes-to-lua-api) to the PR title.
  - [ ] I have added [type annotations](https://emmylua.github.io/annotation.html) to functions so that it's safe and easy to maintain.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
