### PR TITLE
fix: make label-narrow limb panel legible

### DIFF
--- a/src/panels.cpp
+++ b/src/panels.cpp
@@ -1073,7 +1073,7 @@ static void draw_limb_narrow( avatar &u, const catacurses::window &w )
     for( const bodypart_id &bp : u.get_all_body_parts( true ) ) {
         int ny;
         int nx;
-        if (i % 2) {
+        if( i % 2 ) {
             ny = ny2++;
             nx = 26;
         } else {


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<img width="254" height="158" alt="2026-02-10-06:32:59" src="https://github.com/user-attachments/assets/b2855f40-5968-4c49-b011-4cf5dca84d19" />

The labels on the label-narrow limb panel are incorrectly placed, with one even covering the hp for your right leg

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)

The issue here is that the `i` iterator isn't reset to 0, along with the for loop that adds the label not actually incrementing `i` ever. which is an easy fix

However I dont think there is any reason to iterate over body parts once to draw the hp bars and then again to draw the labels, so I have opted to merge these for loops together

Additionally reordered the limb bars to be
head, torso
left arm, right arm
left leg, right leg

As I felt that was a bit more natural compared to the prior layout

<!-- e.g nerfs monster A -->

## Describe alternatives you've considered

doing the simpler fix of setting i to 0 and incrementing it properly in the second for loop

~~could change the ordering of the limbs to be:~~
~~`head   torso`~~
~~`left arm   right arm`~~
~~`left leg    right leg`~~
~~or something? I dunno~~ (ended up deciding to do this)

## Testing

<img width="252" height="47" alt="2026-02-10-07:16:42" src="https://github.com/user-attachments/assets/9511f287-70c5-46c6-9df1-11c4e23f214f" />
<img width="215" height="41" alt="2026-02-10-07:16:39" src="https://github.com/user-attachments/assets/dc6ab002-03f5-4335-a34c-c6b4e39028b6" />


made both a tiles and curses build and verified the panel now looks correct in both

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
