### PR TITLE
fix: finished items go inside the mill instead of around it

### DIFF
--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -5996,7 +5996,7 @@ void iexamine::mill_finalize( player &, const tripoint &examp, const time_point 
     }
 
     for( detached_ptr<item> &it : results ) {
-        items.insert( std::move( it ) );
+        here.add_item( examp, std::move( it ) );
     }
     here.furn_set( examp, next_mill_type );
 }


### PR DESCRIPTION
The mill used to put things on the ground near itself, now things go inside the mill.

## Purpose of change (The Why)

Smoker was changed to not drop items on the ground (#8042) but the mill wasn't, let's make it consistent.

## Describe the solution (The How)

Use map::add_item() instead of items.insert() in mill_finalize().  This is the same fix that was applied to smoker_finalize in #8042.
See #8042 for details.

## Describe alternatives you've considered

Letting the mill drop things on the floor - seemed like expected behaviour to me,

## Testing

Not tested

## Checklist

- [x ] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.