### PR TITLE
fix: Hair_Any

### DIFF
--- a/data/json/npcs/appearance_trait_groups.json
+++ b/data/json/npcs/appearance_trait_groups.json
@@ -17,6 +17,12 @@
   },
   {
     "type": "trait_group",
+    "id": "Hair_Any",
+    "subtype": "collection",
+    "traits": [ { "group": "Hair_Color_Any", "prob": 100 }, { "group": "Hair_Style_Any", "prob": 100 } ]
+  },
+  {
+    "type": "trait_group",
     "id": "Appearance_Irish",
     "subtype": "collection",
     "traits": [


### PR DESCRIPTION
## Purpose of change (The Why)

Mods that used the old Hair_Any for their NPC defs break now.
It's better to upgrade, but such a minor issue bricking mods sucks.

## Describe the solution (The How)

Makes new Hair_Any trait category