### PR TITLE
feat: makes fruit bushes transplantable

### DIFF
--- a/data/json/construction/construct_farm_wood.json
+++ b/data/json/construction/construct_farm_wood.json
@@ -50,7 +50,7 @@
     "post_terrain": "t_shrub_peanut",
     "dark_craftable": true
   },
-   {
+  {
     "type": "construction",
     "id": "constr_dig_peanut_bush",
     "//": "Digs up a bush.",
@@ -58,13 +58,13 @@
     "required_skills": [ [ "survival", 3 ] ],
     "time": "30 m",
     "qualities": [ [ { "id": "DIG", "level": 2 } ] ],
-    "byproducts": [ { "item": "peanut_bush"}, { "item": "material_soil", "charges": 4 } ],
+    "byproducts": [ { "item": "peanut_bush" }, { "item": "material_soil", "charges": 4 } ],
     "pre_terrain": "t_shrub_peanut",
     "post_terrain": "t_pit_shallow",
     "group": "dig_peanut_bush",
-	"dark_craftable": true
+    "dark_craftable": true
   },
-    {
+  {
     "type": "construction",
     "id": "constr_plant_peanut_bush_h",
     "group": "replant_peanut_bush_h",
@@ -77,7 +77,7 @@
     "post_terrain": "t_shrub_peanut_harvested",
     "dark_craftable": true
   },
-   {
+  {
     "type": "construction",
     "id": "constr_dig_peanut_bush_h",
     "//": "Digs up a bush.",
@@ -85,13 +85,13 @@
     "required_skills": [ [ "survival", 3 ] ],
     "time": "30 m",
     "qualities": [ [ { "id": "DIG", "level": 2 } ] ],
-    "byproducts": [ { "item": "peanut_bush_h"} ],
+    "byproducts": [ { "item": "peanut_bush_h" } ],
     "pre_terrain": "t_shrub_peanut_harvested",
     "post_terrain": "t_pit_shallow",
     "group": "dig_peanut_bush_h",
-	"dark_craftable": true
+    "dark_craftable": true
   },
-   {
+  {
     "type": "construction",
     "id": "constr_plant_blueberry_bush",
     "group": "replant_blueberry_bush",
@@ -104,7 +104,7 @@
     "post_terrain": "t_shrub_blueberry",
     "dark_craftable": true
   },
-    {
+  {
     "type": "construction",
     "id": "constr_dig_blueberry_bush",
     "//": "Digs up a bush.",
@@ -112,13 +112,13 @@
     "required_skills": [ [ "survival", 3 ] ],
     "time": "30 m",
     "qualities": [ [ { "id": "DIG", "level": 2 } ] ],
-    "byproducts": [ { "item": "blueberry_bush"} ],
+    "byproducts": [ { "item": "blueberry_bush" } ],
     "pre_terrain": "t_shrub_blueberry",
     "post_terrain": "t_pit_shallow",
     "group": "dig_blueberry_bush",
-	"dark_craftable": true
+    "dark_craftable": true
   },
-   {
+  {
     "type": "construction",
     "id": "constr_plant_blueberry_bush_h",
     "group": "replant_blueberry_bush_h",
@@ -131,7 +131,7 @@
     "post_terrain": "t_shrub_blueberry_harvested",
     "dark_craftable": true
   },
-    {
+  {
     "type": "construction",
     "id": "constr_dig_blueberry_bush_h",
     "//": "Digs up a bush.",
@@ -139,13 +139,13 @@
     "required_skills": [ [ "survival", 3 ] ],
     "time": "30 m",
     "qualities": [ [ { "id": "DIG", "level": 2 } ] ],
-    "byproducts": [ { "item": "blueberry_bush_h"} ],
+    "byproducts": [ { "item": "blueberry_bush_h" } ],
     "pre_terrain": "t_shrub_blueberry_harvested",
     "post_terrain": "t_pit_shallow",
     "group": "dig_blueberry_bush_h",
-	"dark_craftable": true
+    "dark_craftable": true
   },
-     {
+  {
     "type": "construction",
     "id": "constr_plant_strawberry_bush",
     "group": "replant_strawberry_bush",
@@ -158,7 +158,7 @@
     "post_terrain": "t_shrub_strawberry",
     "dark_craftable": true
   },
-    {
+  {
     "type": "construction",
     "id": "constr_dig_strawberry_bush",
     "//": "Digs up a bush.",
@@ -166,13 +166,13 @@
     "required_skills": [ [ "survival", 3 ] ],
     "time": "30 m",
     "qualities": [ [ { "id": "DIG", "level": 2 } ] ],
-    "byproducts": [ { "item": "strawberry_bush"} ],
+    "byproducts": [ { "item": "strawberry_bush" } ],
     "pre_terrain": "t_shrub_strawberry",
     "post_terrain": "t_pit_shallow",
     "group": "dig_strawberry_bush",
-	"dark_craftable": true
+    "dark_craftable": true
   },
-   {
+  {
     "type": "construction",
     "id": "constr_plant_strawberry_bush_h",
     "group": "replant_strawberry_bush_h",
@@ -185,7 +185,7 @@
     "post_terrain": "t_shrub_strawberry_harvested",
     "dark_craftable": true
   },
-    {
+  {
     "type": "construction",
     "id": "constr_dig_strawberry_bush_h",
     "//": "Digs up a bush.",
@@ -193,13 +193,13 @@
     "required_skills": [ [ "survival", 3 ] ],
     "time": "30 m",
     "qualities": [ [ { "id": "DIG", "level": 2 } ] ],
-    "byproducts": [ { "item": "strawberry_bush_h"} ],
+    "byproducts": [ { "item": "strawberry_bush_h" } ],
     "pre_terrain": "t_shrub_strawberry_harvested",
     "post_terrain": "t_pit_shallow",
     "group": "dig_strawberry_bush_h",
-	"dark_craftable": true
+    "dark_craftable": true
   },
-   {
+  {
     "type": "construction",
     "id": "constr_plant_blackberry_bush",
     "group": "replant_blackberry_bush",
@@ -212,7 +212,7 @@
     "post_terrain": "t_shrub_blackberry",
     "dark_craftable": true
   },
-    {
+  {
     "type": "construction",
     "id": "constr_dig_blackberry_bush",
     "//": "Digs up a bush.",
@@ -220,13 +220,13 @@
     "required_skills": [ [ "survival", 3 ] ],
     "time": "30 m",
     "qualities": [ [ { "id": "DIG", "level": 2 } ] ],
-    "byproducts": [ { "item": "blackberry_bush"} ],
+    "byproducts": [ { "item": "blackberry_bush" } ],
     "pre_terrain": "t_shrub_blackberry",
     "post_terrain": "t_pit_shallow",
     "group": "dig_blackberry_bush",
-	"dark_craftable": true
+    "dark_craftable": true
   },
-    {
+  {
     "type": "construction",
     "id": "constr_plant_blackberry_bush_h",
     "group": "replant_blackberry_bush_h",
@@ -239,7 +239,7 @@
     "post_terrain": "t_shrub_blackberry_harvested",
     "dark_craftable": true
   },
-    {
+  {
     "type": "construction",
     "id": "constr_dig_blackberry_bush_h",
     "//": "Digs up a bush.",
@@ -247,13 +247,13 @@
     "required_skills": [ [ "survival", 3 ] ],
     "time": "30 m",
     "qualities": [ [ { "id": "DIG", "level": 2 } ] ],
-    "byproducts": [ { "item": "blackberry_bush_h"} ],
+    "byproducts": [ { "item": "blackberry_bush_h" } ],
     "pre_terrain": "t_shrub_blackberry_harvested",
     "post_terrain": "t_pit_shallow",
     "group": "dig_blackberry_bush_h",
-	"dark_craftable": true
+    "dark_craftable": true
   },
-    {
+  {
     "type": "construction",
     "id": "constr_plant_huckleberry_bush",
     "group": "replant_huckleberry_bush",
@@ -266,7 +266,7 @@
     "post_terrain": "t_shrub_huckleberry",
     "dark_craftable": true
   },
-    {
+  {
     "type": "construction",
     "id": "constr_dig_huckleberry_bush",
     "//": "Digs up a bush.",
@@ -274,13 +274,13 @@
     "required_skills": [ [ "survival", 3 ] ],
     "time": "30 m",
     "qualities": [ [ { "id": "DIG", "level": 2 } ] ],
-    "byproducts": [ { "item": "huckleberry_bush"} ],
+    "byproducts": [ { "item": "huckleberry_bush" } ],
     "pre_terrain": "t_shrub_huckleberry",
     "post_terrain": "t_pit_shallow",
     "group": "dig_huckleberry_bush",
-	"dark_craftable": true
+    "dark_craftable": true
   },
-    {
+  {
     "type": "construction",
     "id": "constr_plant_huckleberry_bush_h",
     "group": "replant_huckleberry_bush_h",
@@ -293,7 +293,7 @@
     "post_terrain": "t_shrub_huckleberry_harvested",
     "dark_craftable": true
   },
-    {
+  {
     "type": "construction",
     "id": "constr_dig_huckleberry_bush_h",
     "//": "Digs up a bush.",
@@ -301,13 +301,13 @@
     "required_skills": [ [ "survival", 3 ] ],
     "time": "30 m",
     "qualities": [ [ { "id": "DIG", "level": 2 } ] ],
-    "byproducts": [ { "item": "huckleberry_bush_h"} ],
+    "byproducts": [ { "item": "huckleberry_bush_h" } ],
     "pre_terrain": "t_shrub_huckleberry_harvested",
     "post_terrain": "t_pit_shallow",
     "group": "dig_huckleberry_bush_h",
-	"dark_craftable": true
+    "dark_craftable": true
   },
-   {
+  {
     "type": "construction",
     "id": "constr_plant_raspberry_bush",
     "group": "replant_raspberry_bush",
@@ -320,7 +320,7 @@
     "post_terrain": "t_shrub_raspberry",
     "dark_craftable": true
   },
-    {
+  {
     "type": "construction",
     "id": "constr_dig_raspberry_bush",
     "//": "Digs up a bush.",
@@ -328,13 +328,13 @@
     "required_skills": [ [ "survival", 3 ] ],
     "time": "30 m",
     "qualities": [ [ { "id": "DIG", "level": 2 } ] ],
-    "byproducts": [ { "item": "raspberry_bush"} ],
+    "byproducts": [ { "item": "raspberry_bush" } ],
     "pre_terrain": "t_shrub_raspberry",
     "post_terrain": "t_pit_shallow",
     "group": "dig_raspberry_bush",
-	"dark_craftable": true
+    "dark_craftable": true
   },
-    {
+  {
     "type": "construction",
     "id": "constr_plant_raspberry_bush_h",
     "group": "replant_raspberry_bush_h",
@@ -347,7 +347,7 @@
     "post_terrain": "t_shrub_raspberry_harvested",
     "dark_craftable": true
   },
-    {
+  {
     "type": "construction",
     "id": "constr_dig_raspberry_bush_h",
     "//": "Digs up a bush.",
@@ -355,13 +355,13 @@
     "required_skills": [ [ "survival", 3 ] ],
     "time": "30 m",
     "qualities": [ [ { "id": "DIG", "level": 2 } ] ],
-    "byproducts": [ { "item": "raspberry_bush_h"} ],
+    "byproducts": [ { "item": "raspberry_bush_h" } ],
     "pre_terrain": "t_shrub_raspberry_harvested",
     "post_terrain": "t_pit_shallow",
     "group": "dig_raspberry_bush_h",
-	"dark_craftable": true
+    "dark_craftable": true
   },
-   {
+  {
     "type": "construction",
     "id": "constr_plant_grape_bush",
     "group": "replant_grape_bush",
@@ -374,7 +374,7 @@
     "post_terrain": "t_shrub_grape",
     "dark_craftable": true
   },
-    {
+  {
     "type": "construction",
     "id": "constr_dig_grape_bush",
     "//": "Digs up a bush.",
@@ -382,13 +382,13 @@
     "required_skills": [ [ "survival", 3 ] ],
     "time": "30 m",
     "qualities": [ [ { "id": "DIG", "level": 2 } ] ],
-    "byproducts": [ { "item": "grape_bush"} ],
+    "byproducts": [ { "item": "grape_bush" } ],
     "pre_terrain": "t_shrub_grape",
     "post_terrain": "t_pit_shallow",
     "group": "dig_grape_bush",
-	"dark_craftable": true
+    "dark_craftable": true
   },
-   {
+  {
     "type": "construction",
     "id": "constr_plant_grape_bush_h",
     "group": "replant_grape_bush_h",
@@ -401,7 +401,7 @@
     "post_terrain": "t_shrub_grape_harvested",
     "dark_craftable": true
   },
-    {
+  {
     "type": "construction",
     "id": "constr_dig_grape_bush_h",
     "//": "Digs up a bush.",
@@ -409,10 +409,10 @@
     "required_skills": [ [ "survival", 3 ] ],
     "time": "30 m",
     "qualities": [ [ { "id": "DIG", "level": 2 } ] ],
-    "byproducts": [ { "item": "grape_bush_h"} ],
+    "byproducts": [ { "item": "grape_bush_h" } ],
     "pre_terrain": "t_shrub_grape_harvested",
     "post_terrain": "t_pit_shallow",
     "group": "dig_grape_bush_h",
-	"dark_craftable": true
+    "dark_craftable": true
   }
 ]

--- a/data/json/construction_group.json
+++ b/data/json/construction_group.json
@@ -1674,7 +1674,7 @@
     "id": "dig_peanut_bush",
     "name": "Dig Up Peanut Bush"
   },
-   {
+  {
     "type": "construction_group",
     "id": "replant_peanut_bush_h",
     "name": "Replant Harvested Peanut Bush"
@@ -1684,7 +1684,7 @@
     "id": "dig_peanut_bush_h",
     "name": "Dig Up Harvested Peanut Bush"
   },
-    {
+  {
     "type": "construction_group",
     "id": "replant_blueberry_bush",
     "name": "Replant Blueberry Bush"
@@ -1694,7 +1694,7 @@
     "id": "dig_blueberry_bush",
     "name": "Dig Up Blueberry Bush"
   },
-   {
+  {
     "type": "construction_group",
     "id": "replant_blueberry_bush_h",
     "name": "Replant Harvested Blueberry Bush"
@@ -1704,7 +1704,7 @@
     "id": "dig_blueberry_bush_h",
     "name": "Dig Up Harvested Blueberry Bush"
   },
-   {
+  {
     "type": "construction_group",
     "id": "replant_strawberry_bush",
     "name": "Replant Strawberry Bush"
@@ -1714,7 +1714,7 @@
     "id": "dig_strawberry_bush",
     "name": "Dig Up Strawberry Bush"
   },
-   {
+  {
     "type": "construction_group",
     "id": "replant_strawberry_bush_h",
     "name": "Replant Harvested Strawberry Bush"
@@ -1724,7 +1724,7 @@
     "id": "dig_strawberry_bush_h",
     "name": "Dig Up Harvested Strawberry Bush"
   },
-   {
+  {
     "type": "construction_group",
     "id": "replant_blackberry_bush",
     "name": "Replant Blackberry Bush"
@@ -1734,7 +1734,7 @@
     "id": "dig_blackberry_bush",
     "name": "Dig Up Blackberry Bush"
   },
-   {
+  {
     "type": "construction_group",
     "id": "replant_blackberry_bush_h",
     "name": "Replant Harvested Blackberry Bush"
@@ -1744,7 +1744,7 @@
     "id": "dig_blackberry_bush_h",
     "name": "Dig Up Harvested Blackberry Bush"
   },
-   {
+  {
     "type": "construction_group",
     "id": "replant_huckleberry_bush",
     "name": "Replant Huckleberry Bush"
@@ -1754,7 +1754,7 @@
     "id": "dig_huckleberry_bush",
     "name": "Dig Up Huckleberry Bush"
   },
-   {
+  {
     "type": "construction_group",
     "id": "replant_huckleberry_bush_h",
     "name": "Replant Harvested Huckleberry Bush"
@@ -1764,7 +1764,7 @@
     "id": "dig_huckleberry_bush_h",
     "name": "Dig Up Harvested Huckleberry Bush"
   },
-   {
+  {
     "type": "construction_group",
     "id": "replant_raspberry_bush",
     "name": "Replant Raspberry Bush"
@@ -1774,7 +1774,7 @@
     "id": "dig_raspberry_bush",
     "name": "Dig Up Raspberry Bush"
   },
-    {
+  {
     "type": "construction_group",
     "id": "replant_raspberry_bush_h",
     "name": "Replant Harvested Raspberry Bush"
@@ -1784,7 +1784,7 @@
     "id": "dig_raspberry_bush_h",
     "name": "Dig Up Harvested Raspberry Bush"
   },
-   {
+  {
     "type": "construction_group",
     "id": "replant_grape_bush",
     "name": "Replant Grape Bush"
@@ -1794,7 +1794,7 @@
     "id": "dig_grape_bush",
     "name": "Dig Up Grape Bush"
   },
-    {
+  {
     "type": "construction_group",
     "id": "replant_grape_bush_h",
     "name": "Replant Harvested Grape Bush"

--- a/data/json/items/terrain.json
+++ b/data/json/items/terrain.json
@@ -1,6 +1,5 @@
 [
-
-{
+  {
     "abstract": "food_bush",
     "type": "GENERIC",
     "name": "food bush",
@@ -13,82 +12,82 @@
     "symbol": "{",
     "color": "green"
   },
-   {
+  {
     "id": "peanut_bush",
     "type": "GENERIC",
-	"copy-from": "food_bush",
+    "copy-from": "food_bush",
     "looks_like": "t_shrub_peanut",
     "name": "uprooted peanut bush",
     "description": "A peanut bush that's ready for transplanting."
   },
-   {
+  {
     "id": "peanut_bush_h",
     "type": "GENERIC",
-	"copy-from": "food_bush",
+    "copy-from": "food_bush",
     "looks_like": "t_shrub_peanut_harvested",
     "name": "uprooted peanut bush",
     "description": "A harvested peanut bush that's ready for transplanting."
   },
-   {
+  {
     "id": "blueberry_bush",
     "type": "GENERIC",
-	"copy-from": "food_bush",
+    "copy-from": "food_bush",
     "looks_like": "t_shrub_blueberry",
     "name": "uprooted blueberry bush",
     "description": "A blueberry bush that's ready for transplanting."
   },
-    {
+  {
     "id": "blueberry_bush_h",
     "type": "GENERIC",
-	"copy-from": "food_bush",
+    "copy-from": "food_bush",
     "looks_like": "t_shrub_blueberry_harvested",
     "name": "uprooted blueberry bush",
     "description": "A blueberry bush that's ready for transplanting."
   },
-   {
+  {
     "id": "strawberry_bush",
     "type": "GENERIC",
-	"copy-from": "food_bush",
+    "copy-from": "food_bush",
     "looks_like": "t_shrub_strawberry",
     "name": "uprooted strawberry bush",
     "description": "A strawberry bush that's ready for transplanting."
   },
-   {
+  {
     "id": "strawberry_bush_h",
     "type": "GENERIC",
-	"copy-from": "food_bush",
+    "copy-from": "food_bush",
     "looks_like": "t_shrub_strawberry_harvested",
     "name": "uprooted strawberry bush",
     "description": "A harvested strawberry bush that's ready for transplanting."
   },
-   {
+  {
     "id": "blackberry_bush",
     "type": "GENERIC",
-	"copy-from": "food_bush",
+    "copy-from": "food_bush",
     "looks_like": "t_shrub_blackberry",
     "name": "uprooted blackberry bush",
     "description": "A blackberry bush that's ready for transplanting."
   },
-   {
+  {
     "id": "blackberry_bush_h",
     "type": "GENERIC",
-	"copy-from": "food_bush",
+    "copy-from": "food_bush",
     "looks_like": "t_shrub_blackberry_harvested",
     "name": "uprooted blackberry bush",
     "description": "A harvested blackberry bush that's ready for transplanting."
   },
-   {
+  {
     "id": "huckleberry_bush",
     "type": "GENERIC",
-	"copy-from": "food_bush",
+    "copy-from": "food_bush",
     "looks_like": "t_shrub_huckleberry",
     "name": "uprooted huckleberry bush",
     "description": "A huckleberry bush that's ready for transplanting."
   },
-   {
+  {
     "id": "huckleberry_bush_h",
     "type": "GENERIC",
-	"copy-from": "food_bush",
+    "copy-from": "food_bush",
     "looks_like": "t_shrub_huckleberry_harvested",
     "name": "uprooted huckleberry bush",
     "description": "A harvested huckleberry bush that's ready for transplanting."
@@ -96,15 +95,15 @@
   {
     "id": "raspberry_bush",
     "type": "GENERIC",
-	"copy-from": "food_bush",
+    "copy-from": "food_bush",
     "looks_like": "t_shrub_raspberry",
     "name": "uprooted raspberry bush",
     "description": "A raspberry bush that's ready for transplanting."
   },
-    {
+  {
     "id": "raspberry_bush_h",
     "type": "GENERIC",
-	"copy-from": "food_bush",
+    "copy-from": "food_bush",
     "looks_like": "t_shrub_raspberry_harvested",
     "name": "uprooted raspberry bush",
     "description": "A harvested raspberry bush that's ready for transplanting."
@@ -112,18 +111,17 @@
   {
     "id": "grape_bush",
     "type": "GENERIC",
-	"copy-from": "food_bush",
+    "copy-from": "food_bush",
     "looks_like": "t_shrub_grape",
     "name": "uprooted grape bush",
     "description": "A grape bush that's ready for transplanting."
   },
-   {
+  {
     "id": "grape_bush_h",
     "type": "GENERIC",
-	"copy-from": "food_bush",
+    "copy-from": "food_bush",
     "looks_like": "t_shrub_grape_harvested",
     "name": "uprooted grape bush",
     "description": "A harvested grape bush that's ready for transplanting."
   }
-
 ]


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

There are many times where you find a bounty of berries and peanuts someplace but they're way out in a distant field. That means a lot of trekking out of your way just to stock up.

This can be tedious.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

For the time being, I've made it possible to dig up bushes into an item form so you can load them up into your vehicle or, if you like, stuff them in your enormous backpack, carry them, or simply haul them around.

All you need to replant is to dig a shallow pit for the bush to go into, and then 6 units of water and 1 unit of soil.

To represent the knowledge needed to dig out a bush and replant it without killing it in the process, and for balance purposes so it's not terribly cheesy, I assigned 3 survival as the requirement to do the digging and replanting. 

This, like everything else here, can be tweaked as desired.

## Describe alternatives you've considered

Instead of making individual entries in the farming and woodcutting construction tab, I could've simply made one huge group containing all bushes for both digging and replanting.

However, in prior testing, this has resulted in issue when multiple bushes are nearby with it selecting one at random to itemize or place. Taking away precise control from the player isn't something I aim to do.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

I fixed a lot of early oopsies with forgetting small details that the json checker didn't catch because it was all technically correct - such as duplicate blueberry bushes when I wanted one harvested and one normal - or forgetting to assign the correct group to a bush so only one showed up.

It is now cleaned up and polished, and works as intended.

<img width="1600" height="900" alt="wilson" src="https://github.com/user-attachments/assets/9b729346-e47a-4853-adbc-7471e486ef0b" />


I made sure to scan through each entry in-game to make sure it reflects both harvested and harvestable variants of each of the bushes, so that no matter what if you're near a valid bush you can pick it up and replant it somewhere.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

