### PR TITLE
build: include missing `lua/` dir on mac builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1004,6 +1004,7 @@ install: version $(TARGET)
 	cp -R data/credits $(DATA_PREFIX)
 	cp -R data/title $(DATA_PREFIX)
 	cp -R data/help $(DATA_PREFIX)
+	cp -R data/lua $(DATA_PREFIX)
 ifeq ($(TILES), 1)
 	cp -R gfx $(DATA_PREFIX)
 endif
@@ -1035,6 +1036,7 @@ install: version $(TARGET)
 	cp -R --no-preserve=ownership data/credits $(DATA_PREFIX)
 	cp -R --no-preserve=ownership data/title $(DATA_PREFIX)
 	cp -R --no-preserve=ownership data/help $(DATA_PREFIX)
+	cp -R --no-preserve=ownership data/lua $(DATA_PREFIX)
 ifeq ($(TILES), 1)
 	cp -R --no-preserve=ownership gfx $(DATA_PREFIX)
 endif
@@ -1090,6 +1092,7 @@ endif
 	cp -R data/credits $(APPDATADIR)
 	cp -R data/title $(APPDATADIR)
 	cp -R data/help $(APPDATADIR)
+	cp -R data/lua $(APPDATADIR)
 ifdef LANGUAGES
 	lang/compile_mo.sh $(LANGUAGES)
 	mkdir -p $(APPRESOURCESDIR)/lang/mo/

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(CATACLYSM_DATA_DIRS
         font
         json
+        lua
         mods
         names
         raw


### PR DESCRIPTION
fixes #8095

https://github.com/scarf005/Cataclysm-BN/releases/tag/v0.0.102

<img width="960" height="616" alt="image" src="https://github.com/user-attachments/assets/074e7f13-ecaf-48b6-8e9b-40ffe08d8808" />

confirmed that `lua/` is included in build artifact