### PR TITLE
fix: allow airplanes to autodrive when on ground

### DIFF
--- a/src/vehicle_autodrive.cpp
+++ b/src/vehicle_autodrive.cpp
@@ -1222,7 +1222,7 @@ autodrive_result vehicle::do_autodrive( Character &driver )
     }
     active_autodrive_controller->check_safe_speed();
     std::optional<navigation_step> next_step = active_autodrive_controller->compute_next_step();
-    if( has_part( VPFLAG_WING ) && is_flying_in_air()  ) {
+    if( has_part( VPFLAG_WING ) && is_flying_in_air() ) {
         driver.add_msg_if_player( _( "Autodrive is not good enough for flying planes." ) );
         stop_autodriving( false );
         return autodrive_result::abort;


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

Currently, autodrive is disabled no matter what if a vehicle has a single wing, because autodrive will probably crash your plane into the ground

However this means autodrive is also disabled for grounded planes, which function identically to a standard ground vehicle, so if a player wants to autodrive their plane on the ground, they must first uninstall all their wings and reinstall them upon reaching their destination, which is annoying

## Describe the solution (The How)

Only prevent autodrive on planes if the vehicle is actually in the air

<!-- e.g nerfs monster A -->

## Describe alternatives you've considered

Not doing this I guess?

## Testing

Spawned in a plane, drove it around on some roads and a bridge using autodrive, worked fine
Took the plane into the air and attempted to use autodrive but was correctly prevented from doing so

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.