### PR TITLE
build: remove duplicate data directory installation in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -538,9 +538,6 @@ endif()
 if (RELEASE)
     if (USE_PREFIX_DATA_DIR)
         install(DIRECTORY doc TYPE DOC)
-        install(DIRECTORY data TYPE DATA
-            PATTERN "json/external_tileset/README.md" EXCLUDE
-            PATTERN "json/mapgen/lab/README.md" EXCLUDE)
         install(FILES
             ${CMAKE_SOURCE_DIR}/README.md
             ${CMAKE_SOURCE_DIR}/LICENSE.txt
@@ -549,9 +546,6 @@ if (RELEASE)
             TYPE DOC)
     else()
         install(DIRECTORY doc DESTINATION .)
-        install(DIRECTORY data DESTINATION .
-            PATTERN "json/external_tileset/README.md" EXCLUDE
-            PATTERN "json/mapgen/lab/README.md" EXCLUDE)
         install(FILES
             ${CMAKE_SOURCE_DIR}/README.md
             ${CMAKE_SOURCE_DIR}/LICENSE.txt

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -1,33 +1,17 @@
-set(CATACLYSM_DATA_DIRS
-        font
-        json
-        lua
-        mods
-        names
-        raw
-        motd
-        credits
-        title
-        help)
-
-if (SOUND)
-    list(APPEND CATACLYSM_DATA_DIRS sound)
-endif ()
-
-set(CATACLYSM_DATA_FILES
-        changelog.txt
-        cataicon.ico)
-
 if (RELEASE)
     if (USE_PREFIX_DATA_DIR)
-        install(DIRECTORY ${CATACLYSM_DATA_DIRS} TYPE DATA
+        install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/
+                TYPE DATA
+                PATTERN "CMakeLists.txt" EXCLUDE
+                PATTERN "XDG" EXCLUDE
                 PATTERN "external_tileset/README.md" EXCLUDE
                 PATTERN "mapgen/lab/README.md" EXCLUDE)
-        install(FILES ${CATACLYSM_DATA_FILES} TYPE DATA)
     else()
-        install(DIRECTORY ${CATACLYSM_DATA_DIRS} DESTINATION data
+        install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/
+                DESTINATION data
+                PATTERN "CMakeLists.txt" EXCLUDE
+                PATTERN "XDG" EXCLUDE
                 PATTERN "external_tileset/README.md" EXCLUDE
                 PATTERN "mapgen/lab/README.md" EXCLUDE)
-        install(FILES ${CATACLYSM_DATA_FILES} DESTINATION data)
     endif()
 endif ()


### PR DESCRIPTION
## Purpose

CMake was installing data/ twice:
1. Main CMakeLists.txt: `install(DIRECTORY data ...)`
2. data/CMakeLists.txt: explicit subdirectory list

Prerequisite for Flathub CMake migration.

## Solution

1. Removed data/ install from main CMakeLists.txt
2. Simplified data/CMakeLists.txt to copy entire directory with exclusions

## Verification

```bash
# System install (USE_PREFIX_DATA_DIR=ON)
ls /tmp/cbn-test-system/share/cataclysm-bn/
# → font/ json/ lua/ mods/ etc. (no XDG/, no CMakeLists.txt)

# Portable install (USE_PREFIX_DATA_DIR=OFF)  
ls /tmp/cbn-test-portable/data/
# → font/ json/ lua/ mods/ etc. (no XDG/, no CMakeLists.txt)
```

Both modes work correctly.