### PR TITLE
chore: Fix 0.10.0 date in release log

### DIFF
--- a/data/XDG/org.cataclysmbn.CataclysmBN.metainfo.xml
+++ b/data/XDG/org.cataclysmbn.CataclysmBN.metainfo.xml
@@ -68,7 +68,7 @@
         <content_attribute id="language-discrimination">intense</content_attribute>
     </content_rating>
     <releases>
-        <release version="0.10.0" date="2026-02-7">
+        <release version="0.10.0" date="2026-02-07">
             <url type="details">https://github.com/cataclysmbn/Cataclysm-BN/releases/tag/v0.10.0</url>
             <description>
                 <p>Notable Changes</p>


### PR DESCRIPTION
## Purpose of change (The Why)

I got the date wrong by the year AND the month, somehow

## Describe the solution (The How)

Uses the correct date

## Describe alternatives you've considered

- Change the definition of time

## Testing

Read

## Additional context

Now I get to update the metainfo in the flatpak again later (probably give it until the rebuild for fixing the game is done for the sake of not delaying a working version getting shipped even more)

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
