### PR TITLE
feat: basement dweller scenario

### DIFF
--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -813,6 +813,25 @@
   },
   {
     "type": "scenario",
+    "id": "basement_dweller",
+    "name": "Basement Dweller",
+    "points": 1,
+    "description": "You were happiest tucked away below street level, tinkering and hiding in your basement.",
+    "start_name": "Basement Hideout",
+    "allowed_locs": [
+      "sloc_basement_bionic",
+      "sloc_basement_game",
+      "sloc_basement_chem",
+      "sloc_basement_hidden_lab",
+      "sloc_basement_meth",
+      "sloc_basement_messed",
+      "sloc_basement_survival",
+      "sloc_basement_weed"
+    ],
+    "flags": [ "CITY_START", "LONE_START" ]
+  },
+  {
+    "type": "scenario",
     "id": "cyberpunk",
     "name": "High Tech, Low Life",
     "description": "Before the world ended, bionics were reserved for the rich and the famous.  You might not have been either, but you wanted in.  Hidden offices sequestered away in basements, anesthetic smuggled out of hospitals, and desperate people with little to lose could get you what you wanted.  If you went too deep, however, your augmentation may have come at a price...",

--- a/data/json/start_locations.json
+++ b/data/json/start_locations.json
@@ -396,6 +396,48 @@
   },
   {
     "type": "start_location",
+    "id": "sloc_basement_game",
+    "name": "Game Room Basement",
+    "terrain": [ "basement" ]
+  },
+  {
+    "type": "start_location",
+    "id": "sloc_basement_chem",
+    "name": "Chemistry Basement",
+    "terrain": [ "basement_chem", "basement_chem2" ]
+  },
+  {
+    "type": "start_location",
+    "id": "sloc_basement_hidden_lab",
+    "name": "Hidden Lab Stairs",
+    "terrain": [ "basement_hidden_lab_stairs" ]
+  },
+  {
+    "type": "start_location",
+    "id": "sloc_basement_meth",
+    "name": "Meth Lab Basement",
+    "terrain": [ "basement_meth" ]
+  },
+  {
+    "type": "start_location",
+    "id": "sloc_basement_messed",
+    "name": "Ruined Basement",
+    "terrain": [ "basement_messed" ]
+  },
+  {
+    "type": "start_location",
+    "id": "sloc_basement_survival",
+    "name": "Prepper Basement",
+    "terrain": [ "basement_survival" ]
+  },
+  {
+    "type": "start_location",
+    "id": "sloc_basement_weed",
+    "name": "Grow Operation Basement",
+    "terrain": [ "basement_weed" ]
+  },
+  {
+    "type": "start_location",
     "id": "sloc_zoo_giftshop",
     "name": "Zoo (Giftshop)",
     "terrain": [ "zoo_0_1" ]


### PR DESCRIPTION
## Purpose of change (The Why)
It can be hard to engage with our cool basements & basement content as a result of how hard they are to find, and how useless the rest of the basements are.

## Describe the solution (The How)
Add a starting scenario called "Basement Dweller" which allows you to choose from any of the "cool" or unique basements. This currently includes the "shady" basement (CBMs), game room basement, chemistry basement, hidden lab basement, meth lab basement, ruined basement, prepper basement, and the grow operation basement.

## Describe alternatives you've considered
Reworking our basements completely so they aren't linked to the above house? Sounds like hell. Would allow for us to create more interesting basements, though as well as individually controlling the rarity of them.

## Testing
Make a new character, spawn in using the scenario.

## Additional context

## Checklist

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.