### PR TITLE
fix: actually fix artifact analyzer

### DIFF
--- a/data/json/artifact_analyzer.lua
+++ b/data/json/artifact_analyzer.lua
@@ -67,7 +67,7 @@ end
 
 ---@type fun(who: Character, item: Item, pos: Tripoint): integer
 analyzer.menu = function(params)
-  local who = params.who
+  local who = params.user
   local item = params.item
   local pos = params.pos
   local artifacts = collect_artifacts(who)


### PR DESCRIPTION
## Purpose of change (The Why)
#8106 
I missed that .who was suppose to be .user

## Describe the solution (The How)
Make it .user instead

## Describe alternatives you've considered
Break compat again and make it .who because everyone seems to like that

## Testing
Eyes

## Additional context
I screm

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.