### PR TITLE
fix: fluid grid mapgen placed tanks not registering correctly

### DIFF
--- a/src/fluid_grid.cpp
+++ b/src/fluid_grid.cpp
@@ -1535,8 +1535,15 @@ auto on_contents_changed( const tripoint_abs_ms &p ) -> void
 
 auto on_structure_changed( const tripoint_abs_ms &p ) -> void
 {
+    const auto sm_pos = project_to<coords::sm>( p );
+    // Mapgen mutates temporary submaps before they are committed to MAPBUFFER.
+    // Ignore those transient updates so we don't cache zero-capacity grids.
+    if( MAPBUFFER.lookup_submap( sm_pos ) == nullptr ) {
+        return;
+    }
+
     const auto omt_pos = project_to<coords::omt>( p );
-    invalidate_transformer_cache_at( project_to<coords::sm>( p ) );
+    invalidate_transformer_cache_at( sm_pos );
     invalidate_grid_members_cache_at( omt_pos );
     get_fluid_grid_tracker().rebuild_at( p );
     get_fluid_grid_tracker().update_transformers_at( p );


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

bugfix follow-up for #8102 

A small bug in fluid grids where tanks placed by mapgen did not contribute their capacity to the grid until the next cache invalidation. This was due to invalidating cache before a submap was in the overmap buffer, causing the capacity to be 0.

## Describe the solution (The How)

Added a check to avoid invalidating the cache when the submap isn't in the buffer yet. (this is only a problem for mapgen)

## Describe alternatives you've considered

## Testing

- Create new game using default scenario
- immediately spawn a utility maintenance kit
- check fluid grid stats
- verify grid capacity is 300L as expected
- teleport to another evac shelter
- repeat and confirm capacity is 300L

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.