### PR TITLE
fix(UI): fluid grid fixtures (sinks) now prompt user on (e)xamine

### DIFF
--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -4556,9 +4556,26 @@ void iexamine::liquid_source( player &, const tripoint &examp )
                                    calendar::turn, item::INFINITE_CHARGES ) );
 }
 
-auto iexamine::fluid_grid_fixture( player &, const tripoint &examp ) -> void
+auto iexamine::fluid_grid_fixture( player &p, const tripoint &examp ) -> void
 {
     map &here = get_map();
+    const auto has_lootable_items = !here.i_at( examp ).empty();
+    if( has_lootable_items ) {
+        uilist selection_menu;
+        selection_menu.text = _( "Select an action" );
+        selection_menu.addentry( 0, true, 'g', _( "Get items" ) );
+        selection_menu.addentry( 1, true, 'w', _( "Use fixture" ) );
+        selection_menu.query();
+        if( selection_menu.ret == 0 ) {
+            none( p, examp );
+            pickup::pick_up( examp, 0 );
+            return;
+        }
+        if( selection_menu.ret != 1 ) {
+            return;
+        }
+    }
+
     const auto &furn = here.furn( examp ).obj();
     if( !furn.fluid_grid || furn.fluid_grid->role != fluid_grid_role::fixture ) {
         add_msg( m_info, _( "It is not connected to a fluid grid fixture." ) );


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

Follow up to #7981 and #8102 

Restores option to pickup items using (e)xamine for sink tiles. 

## Describe the solution (The How)

Prompts user to either pick up items or use fixture. If no items are available for pickup, it jumps straight to the fixture interaction.

## Describe alternatives you've considered

## Testing

Loaded game and tested sink interaction flow.

## Additional context

<img width="541" height="231" alt="image" src="https://github.com/user-attachments/assets/ff21de14-c558-4722-9e05-081afb2c871f" />

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
