### PR TITLE
feat: pull up grappling hook from above

### DIFF
--- a/data/json/furniture_and_terrain/furniture-tools.json
+++ b/data/json/furniture_and_terrain/furniture-tools.json
@@ -1454,7 +1454,7 @@
     "color": "white",
     "move_cost_mod": 1,
     "required_str": -1,
-    "flags": [ "LADDER", "TRANSPARENT", "SEEN_FROM_ABOVE" ],
+    "flags": [ "LADDER", "TRANSPARENT", "SEEN_FROM_ABOVE", "REMOVE_FROM_ABOVE" ],
     "examine_action": "deployed_furniture",
     "deployed_item": "grapnel",
     "bash": {


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

It was not possible to pull up a grappling hook behind you after using it to climb up. There's no obvious reason why this should be, as it seems you should be able to just grab the hook, on the roof next to your feet, and pull.

## Describe the solution (The How)

There is a new furniture flag `REMOVE_FROM_ABOVE`. If you examine an open space tile directly above deployed furniture with this flag, you can remove it. the furniture item is dropped at your feet, not where the furniture was.

## Describe alternatives you've considered

Currently only the grappling hook has the flag. As I understand it, the stepladder is supposed to be a bit shorter, tall enough to climb to a roof but not reaching the roof lip, so you wouldn't be able to easily grab it. I can't think of any other candidates in the game right now, but if someone adds a regular ladder item, that would make sense.

Logically it should also be significantly more difficult to remove a grappling hook from below, since you can't reach the hook part. Maybe it should take time, and require a throwing skill check or something? Not gonna touch it here, and not sure if it's really worth it.

## Testing

Deployed a grappling hook, removed it from both above and below.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

