### PR TITLE
fix: lifting welding mask visor no longer breaks using it for crafting, remove `BLIND` from welding mask

### DIFF
--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -219,7 +219,7 @@
     "encumbrance": 60,
     "material_thickness": 3,
     "qualities": [ [ "GLARE", 3 ] ],
-    "flags": [ "SUN_GLASSES", "FLASH_PROTECTION", "BLIND" ]
+    "flags": [ "SUN_GLASSES", "FLASH_PROTECTION" ]
   },
   {
     "id": "welding_mask_crude",
@@ -272,6 +272,7 @@
     "encumbrance": 60,
     "material_thickness": 2,
     "coverage": 30,
+    "qualities": [ [ "GLARE", 2 ] ],
     "flags": [ "ALLOWS_NATURAL_ATTACKS", "ALLOWS_HORNS" ]
   },
   {
@@ -297,7 +298,8 @@
     "warmth": 5,
     "encumbrance": 60,
     "material_thickness": 3,
-    "coverage": 30
+    "coverage": 30,
+    "qualities": [ [ "GLARE", 3 ] ]
   },
   {
     "type": "TOOL_ARMOR",


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

We ran into a confusing problem on the discord where a player was unable to weld because they're raised the visor on a welding mask. We already don't bother mandating that the player wear welding goggles and let them use , so we should assume welding masks can be left raised and still provide glare protection quality during crafting on the basis of "bruh you just lower it mid-craft like how you're clearly putting the goggles on mid-craft if using them while they're on the floor"

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. Gave raised welding mask the same level 3 glare protection it has when lowered.
2. Gave raised crude welding mask level 2 glare protection as it has when lowered.
3. Misc: Removed the `BLIND` flag from welding masks because neither welding goggles nor crude welding masks have that, and "makes it hard to see" as per the description does not mean "can't see shit bro"

## Describe alternatives you've considered

Screm

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected file for syntax and lint errors.
2. Load-tested in compiled test build.
3. Confirmed crafting menu shows I have glare protection quality whether a welding mask is raised or lowered.
4. Confirmed that I still get sun glare messages when the visor is raised.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
