### PR TITLE
fix(i18n): improper bread pluralizing in containers

### DIFF
--- a/data/json/items/comestibles/bread.json
+++ b/data/json/items/comestibles/bread.json
@@ -96,7 +96,7 @@
   {
     "type": "COMESTIBLE",
     "id": "sourdough_bread",
-    "name": "sourdough bread",
+    "name": { "str_sp": "sourdough bread" },
     "weight": "56 g",
     "color": "brown",
     "spoils_in": "8 days",
@@ -119,7 +119,7 @@
   {
     "type": "COMESTIBLE",
     "id": "flatbread",
-    "name": "flatbread",
+    "name": { "str_sp": "flatbread" },
     "weight": "85 g",
     "color": "brown",
     "spoils_in": "11 days 16 hours",
@@ -138,7 +138,7 @@
   {
     "type": "COMESTIBLE",
     "id": "bread",
-    "name": "bread",
+    "name": { "str_sp": "bread" },
     "weight": "60 g",
     "color": "brown",
     "spoils_in": "10 days",
@@ -184,7 +184,7 @@
   {
     "type": "COMESTIBLE",
     "id": "cornbread",
-    "name": "cornbread",
+    "name": { "str_sp": "cornbread" },
     "weight": "60 g",
     "color": "yellow",
     "spoils_in": "30 days",


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

I like engrish. But I don't like casually finding it in every restaurant. Breads (2/48)? No thank you.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

Applies strict naming to all the breads so that they do not incorrectly pluralize anymore when in packaging. Flatbread, Sourdough Bread, and Bread are affected.

In testing before making the change, the naming was for some reason not affected with loose individual units of bread. It appears to only affect itemgroup spawns with packaged bread [thus, breads (2/48), plastic bag]

## Describe alternatives you've considered

Going further and making them each "loaf of bread" with plurals as "loaves of bread"

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

Loaded a test character. Hopped into restaurant with bread in it. Name changed from breads to bread.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
