### PR TITLE
feat(balance): make tank drone, chicken walker, and tripod spawn after 2 weeks

### DIFF
--- a/data/json/monstergroups/robots.json
+++ b/data/json/monstergroups/robots.json
@@ -56,7 +56,9 @@
       { "monster": "mon_talon_m202a1", "freq": 50, "cost_multiplier": 0 },
       { "monster": "mon_dispatch", "freq": 100, "cost_multiplier": 0 },
       { "monster": "mon_dispatch_military", "freq": 50, "cost_multiplier": 0 },
-      { "monster": "mon_tankbot", "freq": 20, "cost_multiplier": 0, "starts": 720 }
+      { "monster": "mon_tripod", "freq": 10, "cost_multiplier": 0, "starts": 336 },
+      { "monster": "mon_chickenbot", "freq": 10, "cost_multiplier": 0, "starts": 336 },
+      { "monster": "mon_tankbot", "freq": 20, "cost_multiplier": 0, "starts": 336 }
     ]
   }
 ]

--- a/data/mods/Aftershock/mobs/robot_groups.json
+++ b/data/mods/Aftershock/mobs/robot_groups.json
@@ -72,7 +72,7 @@
       { "monster": "mon_advbot_plasma", "freq": 1, "cost_multiplier": 0 },
       { "monster": "mon_molebot", "freq": 0, "cost_multiplier": 0 },
       { "monster": "mon_tripod", "freq": 10, "cost_multiplier": 0 },
-      { "monster": "mon_tankbot", "freq": 20, "cost_multiplier": 0, "starts": 1086 },
+      { "monster": "mon_tankbot", "freq": 20, "cost_multiplier": 0, "starts": 336 },
       { "monster": "mon_chickenbot", "freq": 10, "cost_multiplier": 0 },
       { "monster": "mon_bloodhound_drone", "freq": 220, "cost_multiplier": 0 }
     ]


### PR DESCRIPTION
Reduce robot rollout delays to 2 weeks (336h).

- Base game: add `mon_tripod` and `mon_chickenbot` to `GROUP_ROBOTS_MIL`, all three heavy bots start at 336h.
- Aftershock: keep `starts` only where it existed before (`mon_tankbot` in `GROUP_ROBOT`), set it to 336h.