### PR TITLE
fix: allow removing broken door-lock pairs

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1694,13 +1694,18 @@ bool vehicle::can_unmount( const int p, std::string &reason ) const
     const auto no_remove_open =  part_info( p ).has_flag( "NOREMOVE_OPEN" );
     for( const auto &elem : parts_here ) {
         const auto is_openable = part_info( elem ).has_flag( "OPENABLE" );
-        if( no_remove_closed && is_openable && !parts[elem].open ) {
+        const auto is_working = !parts[elem].is_broken();
+        if( no_remove_closed && is_openable && is_working && !parts[elem].open ) {
             reason = string_format( _( "Open the attached %s first." ), part_info( elem ).name() );
             return false;
         }
-        if( no_remove_open && is_openable &&  parts[elem].open ) {
+        if( no_remove_open && is_openable && is_working && parts[elem].open ) {
             reason = string_format( _( "Close the attached %s first." ), part_info( elem ).name() );
             return false;
+        }
+
+        if( !is_working ) {
+            continue;
         }
 
         for( const std::string &flag : part_info( elem ).get_flags() ) {


### PR DESCRIPTION
## Purpose of change (The Why)
- Fixes a vehicle part removal deadlock when both a door and its door lock are broken: each part could require removing/opening the other first.

## Describe the solution (The How)
- In `vehicle::can_unmount`, dependency and open/close prerequisite checks now ignore broken attached parts.
- Added a regression test that breaks both a door and its lock on `cross_split_test` and verifies both parts are removable.

## Describe alternatives you've considered
- Special-casing only `DOOR_LOCKING` interactions, but that would miss similar deadlocks from other broken dependent parts.

## Testing
- `cmake --build --preset linux-full --target astyle`
- `cmake --build --preset linux-full --target cata_test-tiles`
- `./out/build/linux-full/tests/cata_test-tiles "broken_door_and_lock_can_be_removed"`
- `cmake --build --preset linux-full --target cataclysm-bn-tiles cata_test-tiles` *(fails in docs generation step: `scripts/gen_cli_docs.ts` cannot find `./cataclysm-bn-tiles` from repo root; unrelated to this change)*

## Additional context
- None.

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysm-bn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.