### PR TITLE
ci: allow semantic script to read npm_package_config_libvips

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -90,4 +90,4 @@ jobs:
         run: |
           # deno lint
           deno test --allow-read
-          deno run --allow-read --allow-write scripts/semantic.ts
+          deno run --allow-read --allow-write --allow-env=npm_package_config_libvips scripts/semantic.ts


### PR DESCRIPTION
## Purpose of change (The Why)

- Fixes the `autofix` workflow failure from run [`22038946844`](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/22038946844) (job [`63676509091`](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/22038946844/job/63676509091)) where Deno denied access to `npm_package_config_libvips` during `scripts/semantic.ts`.
- This regression was introduced in [`#8155`](https://github.com/cataclysmbn/Cataclysm-BN/pull/8155).

## Describe the solution (The How)

- Adds `--allow-env=npm_package_config_libvips` to the `deno run` invocation in `.github/workflows/autofix.yml`.

## Describe alternatives you've considered

- `--allow-env` for all variables (broader than needed).

## Testing

- Reviewed failing job log for run 22038946844 and matched the denied variable name exactly.
- Verified workflow diff only changes the permission flag on the failing command.

## Additional context

- This keeps permissions narrow to the single env variable requested by Deno.
- Archived the failed run logs (downloaded from workflow artifacts and uploaded as gists for long-term access):
  - Full run log gist: https://gist.github.com/scarf005/1246d925ef27231bba79a946dcaad7dd
  - Failing step log gist: https://gist.github.com/scarf005/fd1233cf18f8a04663942814b497773d
