### PR TITLE
ci: skip obsolete mods in all-mod test list

### DIFF
--- a/build-scripts/get_all_mods.py
+++ b/build-scripts/get_all_mods.py
@@ -30,6 +30,8 @@ for info in glob.glob('data/mods/*/modinfo.json'):
         if e["type"] == "MOD_INFO":
             if not do_lua and "lua_api_version" in e:
                 continue
+            if e.get("obsolete", False):
+                continue
             ident = e["id"]
             if not ident in blacklist:
                 all_mod_dependencies[ident] = e.get("dependencies", [])


### PR DESCRIPTION
## Summary
- Fix CI all-mod smoke test to ignore obsolete mods when building the `--mods` list.
- This prevents obsolete/inactive content from being force-loaded in the PR curses test job.

## Why curses segfaulted
- The matrix workflow runs an all-mod smoke invocation (`cata_test ... "~*" --mods=...`) using `build-scripts/get_all_mods.py`.
- That script previously included every `MOD_INFO` entry that was not blacklisted, including entries marked `"obsolete": true`.
- One of those obsolete entries is `callback_lua_test`, which should not be part of normal runtime mod sets.
- Loading obsolete callback-lua test content in the all-mod smoke path could leave the process in an unstable teardown state; in failing PR runs this showed up as an exit-139 segfault right after the "No tests ran" phase.

## Why a Python script fix resolves a native segfault
- The segfault was input/data-driven, not caused by Python itself.
- `get_all_mods.py` defines the exact mod set passed into the C++ test binary.
- By filtering out obsolete mods at source, the C++ binary no longer loads the problematic obsolete callback-lua content during the all-mod smoke run.
- Result: the same test stage completes without the crash condition being triggered.