### PR TITLE
fix(i18n): guard mapgen extraction when object is missing

### DIFF
--- a/lang/extract_json_strings.py
+++ b/lang/extract_json_strings.py
@@ -500,6 +500,8 @@ def extract_scenario(state, item):
 
 def extract_mapgen(state, item):
     # writestr will not write string if it is None.
+    if "object" not in item or type(item["object"]) != dict:
+        return
     for (objkey, objval) in sorted(item["object"].items(), key=lambda x: x[0]):
         if objkey == "place_specials" or objkey == "place_signs":
             for special in objval:


### PR DESCRIPTION
## Summary
- Prevent `lang/extract_json_strings.py` from crashing on `mapgen` entries without an `object` payload.
- Return early in `extract_mapgen` when `object` is missing or not a dictionary.
- Regression source: #8055 introduced a `method: "lua"` mapgen entry (`data/json/mapgen/slimepit.json`) without `object`, which triggered `KeyError: 'object'` in `check-extraction`.

## Testing
- Run `lang/update_pot.sh`