### PR TITLE
fix: make electric well pump constructible

### DIFF
--- a/data/json/construction/construct.json
+++ b/data/json/construction/construct.json
@@ -1128,8 +1128,8 @@
     "required_skills": [ [ "fabrication", 4 ], [ "mechanics", 2 ], [ "electronics", 2 ] ],
     "time": "240 m",
     "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "WRENCH", "level": 1 } ], [ { "id": "SCREW", "level": 1 } ] ],
-    "components": [ [ [ "well_pump", 1 ] ], [ [ "pipe", 6 ] ], [ [ "motor_small", 1 ] ], [ [ "power_supply", 1 ] ], [ [ "cable", 10 ] ] ],
-    "pre_terrain": "t_covered_well",
+    "components": [ [ [ "motor_small", 1 ] ], [ [ "power_supply", 1 ] ], [ [ "cable", 10 ] ] ],
+    "pre_terrain": "t_water_pump",
     "post_furniture": "f_electric_well_pump"
   },
   {


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

Resolves #8161.

## Describe the solution (The How)

Changed Electric Well Pump's terrain requirement from covered well to water pump.
Also removed the duplicate materials (1 mechanical pump, 6 pipes).
After this PR, players can upgrade an existing Water Pump to an Electric Well Pump by adding a motor and electrical wiring.

<!-- e.g nerfs monster A -->

## Describe alternatives you've considered

Adding some seperate menu to pop up when player tries to build a water well?

## Testing

<img width="1032" height="634" alt="스크린샷 2026-02-16 031216" src="https://github.com/user-attachments/assets/a88f9fce-906b-4b73-824f-97dc3deacc12" />

Tested in a sample (base mod only) world and my own save file.
After waiting for about 30 minutes, the Electric Well Pump successfully stored water in the Water Tank which connected to the fluid grid.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

About the Stage/Variant, which the water pump should go to 2 and electric water pump should go to 3, but I couldn't find how to fix it.
Maybe someone can fix it?

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.