### PR TITLE
fix: CTD when doing some activities in the dark

### DIFF
--- a/src/activity_speed.h
+++ b/src/activity_speed.h
@@ -87,7 +87,7 @@ class activity_speed
 
         //Returns total amonut of moves based on factors
         inline int total_moves() const {
-            return std::max(1.0f, std::roundf( total() * 100.0f ));
+            return std::max( 1.0f, std::roundf( total() * 100.0f ) );
         }
 
         //Calculates all factors


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

Fix oversight from #6064 and its follow-ups

`activity_speed::total_moves()` is used by division in all its use-cases
when one factor is zero (e.g light when blindfolded / blind), it causes a division by zero, and CTD

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)

Adds a `std::min(1.0f, ...)` to the result

<!-- e.g nerfs monster A -->

## Describe alternatives you've considered

## Testing

* Wear Blindfold
* Open MRE
* No CTD

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<img width="781" height="82" alt="image" src="https://github.com/user-attachments/assets/8e215e1c-c252-4078-9823-9764a6764d7b" />

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
