### PR TITLE
fix: silence compiler warnings in tiles and lua bindings

### DIFF
--- a/src/cata_tiles_color.cpp
+++ b/src/cata_tiles_color.cpp
@@ -91,7 +91,7 @@ auto cata_tiles::get_effect_color(
 }
 
 auto cata_tiles::get_effect_color(
-    const effect &eff, const Character &c ) -> color_tint_pair
+    const effect &eff, const Character & ) -> color_tint_pair
 {
     const color_tint_pair *tint = tileset_ptr->get_tint( eff.get_id().str() );
     if( tint != nullptr ) {
@@ -107,7 +107,7 @@ auto cata_tiles::get_bionic_color(
 }
 
 auto cata_tiles::get_bionic_color(
-    const bionic &bio, const Character &c )-> color_tint_pair
+    const bionic &bio, const Character & )-> color_tint_pair
 {
     const auto &data = bio.id.obj();
     for( const flag_id &flag : data.flags ) {

--- a/src/catalua_bindings.cpp
+++ b/src/catalua_bindings.cpp
@@ -361,9 +361,6 @@ void cata::detail::reg_date_time_api( sol::state &lua )
     DOC( "System date and time API." );
     luna::userlib lib = luna::begin_lib( lua, "date_time" ) ;
 
-    const time_t timestamp = time( nullptr );
-    const tm *loc = localtime( &timestamp );
-
     luna::set_fx( lib, "year", []() { return local_time_impl()->tm_year + 1900; } );
     // It makes sense to start month at 1, not 0
     luna::set_fx( lib, "month", []() { return local_time_impl()->tm_mon + 1; } );

--- a/src/catalua_bindings_map.cpp
+++ b/src/catalua_bindings_map.cpp
@@ -251,9 +251,9 @@ void cata::detail::reg_map( sol::state &lua )
 
         luna::set_fx( ut, "is_outside", sol::resolve<bool( const tripoint & ) const>( &map::is_outside ) );
         // Actually sheltered or in sunlight doesn't need map, but it's convenient to have it here
-        luna::set_fx( ut, "is_sheltered", []( map & m, tripoint & pos ) -> bool { return g->is_sheltered( pos ); } );
+        luna::set_fx( ut, "is_sheltered", []( map &, tripoint & pos ) -> bool { return g->is_sheltered( pos ); } );
 
-        luna::set_fx( ut, "is_in_sunlight", []( map & m, tripoint & pos ) -> bool { return g->is_in_sunlight( pos ); } );
+        luna::set_fx( ut, "is_in_sunlight", []( map &, tripoint & pos ) -> bool { return g->is_in_sunlight( pos ); } );
 
         // Mapgen stuffs
 

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -1293,8 +1293,8 @@ int place_monster_iuse::use( player &p, item &it, bool, const tripoint &pos ) co
     }
     /** @EFFECT_INT increases chance of a placed turret being friendly */
     /** Full-on pets also auto-succeed if we've already succeeded before deactivating it */
-    if( rng( 0, p.int_cur ) + skill_offset < rng( 0, 2 * ( difficulty * diff_mod ) ) &&
-        !it.has_flag( flag_SPAWN_FRIENDLY ) || it.has_flag( flag_SPAWN_HOSTILE ) ) {
+    if( ( rng( 0, p.int_cur ) + skill_offset < rng( 0, 2 * ( difficulty * diff_mod ) ) &&
+          !it.has_flag( flag_SPAWN_FRIENDLY ) ) || it.has_flag( flag_SPAWN_HOSTILE ) ) {
         if( hostile_msg.empty() ) {
             p.add_msg_if_player( m_bad, _( "The %s scans you and makes angry beeping noises!" ),
                                  newmon.name() );


### PR DESCRIPTION
## Summary
- Remove unused parameter names in tile color and Lua map binding helpers to eliminate `-Wunused-parameter` warnings.
- Remove an unused localtime variable in Lua date/time API registration.
- Parenthesize mixed `&&`/`||` condition in `place_monster_iuse::use` to silence `-Wlogical-op-parentheses` without changing behavior.

## Verification
- `cmake --build --preset linux-full --target src/CMakeFiles/cataclysm-bn-tiles-common.dir/cata_tiles_color.cpp.o src/CMakeFiles/cataclysm-bn-tiles-common.dir/catalua_bindings_map.cpp.o src/CMakeFiles/cataclysm-bn-tiles-common.dir/catalua_bindings.cpp.o src/CMakeFiles/cataclysm-bn-tiles-common.dir/iuse_actor.cpp.o`
- Full `cataclysm-bn-tiles` link reaches a pre-existing docs generation runner path issue in this worktree (`scripts/gen_cli_docs.ts` looking for `./cataclysm-bn-tiles`), unrelated to these warning fixes.