### PR TITLE
feat: add crafting recipes for umbrella variants

### DIFF
--- a/data/json/recipes/other/tools.json
+++ b/data/json/recipes/other/tools.json
@@ -3293,12 +3293,7 @@
     "time": "25 m",
     "autolearn": true,
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "HAMMER", "level": 1 } ],
-    "components": [
-      [ [ "plastic_chunk", 3 ] ],
-      [ [ "scrap", 1 ] ],
-      [ [ "wire", 5 ] ],
-      [ [ "spike", 1 ], [ "pointy_stick", 1 ] ]
-    ]
+    "components": [ [ [ "plastic_chunk", 3 ] ], [ [ "scrap", 1 ] ], [ [ "wire", 5 ] ], [ [ "spike", 1 ], [ "pointy_stick", 1 ] ] ]
   },
   {
     "type": "recipe",


### PR DESCRIPTION
## Purpose of change (The Why)

Adds craft recipes for umbrella and telescoping umbrella so both variants are player-craftable.

## Describe the solution (The How)

Added two recipes in `data/json/recipes/other/tools.json`:
- `umbrella` from plastic chunks, scrap, wire, and a pointed tip component.
- `teleumbrella` from plastic chunks, scrap, wire, and a spring.

## Describe alternatives you've considered

- Making telescoping umbrella only as an umbrella-upgrade recipe; skipped to keep direct parity with its uncraft material set.

## Testing

- Ran `./build-scripts/lint-json.sh`.

## Additional context

- None.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
