### PR TITLE
fix: add missing flags to adobe floors to allow completing roof construction

### DIFF
--- a/data/json/furniture_and_terrain/terrain-floors-indoor.json
+++ b/data/json/furniture_and_terrain/terrain-floors-indoor.json
@@ -995,7 +995,7 @@
     "looks_like": "t_thconc_floor",
     "move_cost": 2,
     "roof": "t_flat_roof",
-    "flags": [ "TRANSPARENT", "FLAT", "ROAD" ],
+    "flags": [ "TRANSPARENT", "FLAT", "ROAD", "SUPPORTS_ROOF", "COLLAPSES" ],
     "bash": {
       "sound": "SMASH!",
       "ter_set": "t_null",

--- a/data/json/furniture_and_terrain/terrain-walls.json
+++ b/data/json/furniture_and_terrain/terrain-walls.json
@@ -515,6 +515,7 @@
     "looks_like": "t_brick_wall",
     "move_cost": 0,
     "coverage": 100,
+    "roof": "t_flat_roof",
     "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
     "connects_to": "WALL",
     "bash": {


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

Fixes https://github.com/cataclysmbn/Cataclysm-BN/issues/8101

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. Adds `SUPPORTS_ROOF` and `COLLAPSES` to adobe brick floors to match over indoor floors you can construct, allowing you to complete an adobe house.
2. Misc: Spotted that adobe walls lacked a roof for some reason.

## Describe alternatives you've considered

screm

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Load-tested in compiled test build.
3. Spawned an adobe box and placed adobe floors in the corners.
4. Confirmed it shows I can extend the floors now.
<img width="466" height="262" alt="image" src="https://github.com/user-attachments/assets/bbaa7c7d-bbbe-4142-b3cb-ffff96209646" />

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

Oversight in https://github.com/cataclysmbn/Cataclysm-BN/pull/6885

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
