### PR TITLE
feat(balance): Locksmith kit takes no damage from failed lockpick attempts

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -806,6 +806,12 @@
     "info": "This item can be used to <info>pick locks</info> with <good>zero effort</good>."
   },
   {
+    "id": "DURABLE_LOCKPICK",
+    "type": "json_flag",
+    "context": [  ],
+    "//": "takes no damage from normal use"
+  },
+  {
     "id": "RAINPROOF",
     "type": "json_flag",
     "context": [ "ARMOR", "TOOL_ARMOR" ],

--- a/data/json/items/tool/entry_tools.json
+++ b/data/json/items/tool/entry_tools.json
@@ -108,7 +108,8 @@
     "material": "steel",
     "symbol": ";",
     "color": "light_gray",
-    "qualities": [ [ "LOCKPICK", 5 ] ]
+    "qualities": [ [ "LOCKPICK", 5 ] ],
+    "flags": [ "DURABLE_LOCKPICK" ]
   },
   {
     "id": "pseudo_bio_picklock",

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -1562,6 +1562,7 @@ void lockpick_activity_actor::finish( player_activity &act, Character &who )
     }
 
     bool perfect = it->has_flag( flag_PERFECT_LOCKPICK );
+    bool durable = it->has_flag( flag_DURABLE_LOCKPICK );
     bool destroy = false;
 
     /** @EFFECT_DEX improves chances of successfully picking door lock, reduces chances of bad outcomes */
@@ -1584,7 +1585,8 @@ void lockpick_activity_actor::finish( player_activity &act, Character &who )
         }
 
         who.add_msg_if_player( m_good, open_message );
-    } else if( lock_roll > ( 1.5 * pick_roll ) ) {
+    } else if( lock_roll > ( 1.5 * pick_roll ) && !durable ) {
+        // damage lockpick on a low result, unless it's durable
         if( it->inc_damage() ) {
             who.add_msg_if_player( m_bad,
                                    _( "The lock stumps your efforts to pick it, and you destroy your tool." ) );

--- a/src/flag.cpp
+++ b/src/flag.cpp
@@ -240,6 +240,7 @@ const flag_id flag_OUTER( "OUTER" );
 const flag_id flag_OVERSIZE( "OVERSIZE" );
 const flag_id flag_PARTIAL_DEAF( "PARTIAL_DEAF" );
 const flag_id flag_PERFECT_LOCKPICK( "PERFECT_LOCKPICK" );
+const flag_id flag_DURABLE_LOCKPICK( "DURABLE_LOCKPICK" );
 const flag_id flag_PERPETUAL( "PERPETUAL" );
 const flag_id flag_PERSONAL( "PERSONAL" );
 const flag_id flag_PLACE_RANDOMLY( "PLACE_RANDOMLY" );

--- a/src/flag.h
+++ b/src/flag.h
@@ -241,6 +241,7 @@ extern const flag_id flag_OUTER;
 extern const flag_id flag_OVERSIZE;
 extern const flag_id flag_PARTIAL_DEAF;
 extern const flag_id flag_PERFECT_LOCKPICK;
+extern const flag_id flag_DURABLE_LOCKPICK;
 extern const flag_id flag_PERPETUAL;
 extern const flag_id flag_PERSONAL;
 extern const flag_id flag_PLACE_RANDOMLY;


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

When you fail a lockpick attempt, there's a random chance for your lockpicking tool to take damage. This is fine for the common makeshift lockpicks, it just introduces a bit of a time cost to using them since you have to occasionally stop to make more, but it's a bit of a problem for the higher-end locksmithing kit. It's a rare find, requires fabrication 5 and blacksmithing gear to make, and is basically not worth using unless you're also carrying an arc welder to fix it on the go.

## Describe the solution (The How)

Locksmithing kit now has a flag DURABLE_LOCKPICK that makes it unbreakable. Unbreakable when opening locks, anyway.

## Describe alternatives you've considered

Giving it a smaller random chance to take damage, or maybe adding a skill threshold where you can be careful with your lockpick? I don't know, I feel like a binary flag is simpler. My goal here is just to make it so that you don't have to keep constantly fixing your good lockpick after making/finding it once.

Could also have tied it directly to lockpick quality, the locksmithing kit is 5 while the improvised lockpick is 3. But doing it with an item flag allows for hypothetical bad lockpicks that can't be broken, and really good lockpicks that can.

Oh, and there's currently no explicit mention in the item description that the locksmith kit works this way. All the other lockpicks already mention that they're "brittle", though, so it's implied.

## Testing

Attempted picking doors at a hotel with makeshift lockpick and locksmithing kit. Makeshift picks took damage, while the kit did not, even at very low DEX and mechanics skill.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
