### PR TITLE
feat(balance): buff law enforcement zombie loot

### DIFF
--- a/data/json/monsterdrops/zombie_cop.json
+++ b/data/json/monsterdrops/zombie_cop.json
@@ -13,7 +13,7 @@
       { "group": "cop_shoes", "damage": [ 1, 4 ] },
       { "group": "cop_torso", "damage": [ 1, 4 ] },
       { "group": "cop_weapons", "prob": 60, "damage": [ 0, 3 ], "dirt": [ 1500, 7050 ] },
-	  { "group": "cop_contraband", "prob": 10 },
+      { "group": "cop_contraband", "prob": 10 },
       { "group": "underwear", "damage": [ 1, 4 ] },
       { "group": "clothing_glasses", "prob": 5 },
       { "group": "clothing_watch", "prob": 5 },
@@ -60,7 +60,7 @@
   {
     "id": "cop_helmet",
     "type": "item_group",
-	"//": "Cotton hat represents the watch cap sometimes worn instead of a five point police cap.",
+    "//": "Cotton hat represents the watch cap sometimes worn instead of a five point police cap.",
     "items": [ [ "cowboy_hat", 10 ], [ "hat_cotton", 20 ], [ "helmet_riot", 30 ] ]
   },
   {
@@ -88,7 +88,7 @@
     "type": "item_group",
     "items": [ { "group": "cop_melee", "prob": 60 }, { "group": "carried_guns_cop", "prob": 40 } ]
   },
-   {
+  {
     "type": "item_group",
     "id": "cop_contraband",
     "items": [
@@ -104,19 +104,19 @@
       [ "pipe_glass_bong", 50 ],
       { "item": "light_battery_cell", "charges": 100, "container-item": "dab_pen", "prob": 20 },
       [ "dab_pen_disposable", 20 ],
-	  ["improvised_grenade", 2],
-	  [ "molotov", 6],
-	  [ "improvised_pipebomb", 2 ], 
-	  [ "tool_small_improvised_fragmentation_device", 2 ],
-	  [ "switchblade", 6 ],
-	  [ "knife_folding", 10 ], 
-	  [ "knife_hunting", 2 ],
-	  [ "tazer", 6 ],
-	  [ "knuckle_brass", 8],
-	  [ "knuckle_steel", 5], 
-	  [ "chem_chloroform", 1],
-	  [ "ether", 1],
-	  [ "ghb", 1 ]
+      [ "improvised_grenade", 2 ],
+      [ "molotov", 6 ],
+      [ "improvised_pipebomb", 2 ],
+      [ "tool_small_improvised_fragmentation_device", 2 ],
+      [ "switchblade", 6 ],
+      [ "knife_folding", 10 ],
+      [ "knife_hunting", 2 ],
+      [ "tazer", 6 ],
+      [ "knuckle_brass", 8 ],
+      [ "knuckle_steel", 5 ],
+      [ "chem_chloroform", 1 ],
+      [ "ether", 1 ],
+      [ "ghb", 1 ]
     ]
   },
   {
@@ -127,12 +127,12 @@
     "ammo": 40,
     "entries": [
       { "group": "swat_zombie_gear", "prob": 100, "damage": [ 0, 2 ] },
-      { "group": "swat_gloves",  "damage": [ 0, 4 ] },
-      { "group": "swat_helmet",  "damage": [ 0, 4 ] },
+      { "group": "swat_gloves", "damage": [ 0, 4 ] },
+      { "group": "swat_helmet", "damage": [ 0, 4 ] },
       { "group": "swat_pants", "damage": [ 0, 4 ] },
       { "group": "swat_shoes", "damage": [ 0, 4 ] },
       { "group": "swat_torso", "damage": [ 0, 4 ] },
-      { "group": "swat_weapons",  "damage": [ 0, 3 ], "dirt": [ 0, 7050 ] },
+      { "group": "swat_weapons", "damage": [ 0, 3 ], "dirt": [ 0, 7050 ] },
       { "group": "underwear", "damage": [ 0, 4 ] },
       { "group": "clothing_glasses", "prob": 5 },
       { "group": "clothing_watch", "prob": 10 },
@@ -164,7 +164,7 @@
           { "item": "grenade", "prob": 5 },
           { "item": "two_way_radio", "prob": 30 },
           { "item": "gasbomb", "prob": 15 },
-		  { "item": "smokebomb", "prob": 10 },
+          { "item": "smokebomb", "prob": 10 },
           { "item": "flashbang", "prob": 10 },
           { "item": "sm_extinguisher", "prob": 5 },
           { "item": "rope_30", "prob": 10 }
@@ -177,9 +177,9 @@
           { "item": "chestpouch", "prob": 15 },
           { "item": "ammo_satchel", "prob": 10 },
           { "item": "bholster", "prob": 25 },
-		  { "item": "smokebomb", "prob": 3 },
-		  { "item": "gasbomb", "prob": 3 },
-		  { "item": "flashbang", "prob": 3 },
+          { "item": "smokebomb", "prob": 3 },
+          { "item": "gasbomb", "prob": 3 },
+          { "item": "flashbang", "prob": 3 },
           { "item": "bandolier_shotgun", "prob": 10 },
           { "item": "legpouch_large", "prob": 25 },
           { "item": "police_belt", "prob": 25 }


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

resolves #6197

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

Zombie cops were thought of as not worth going out of one's way to kill compared to zombie soldiers.

They were thought of as dropping not nearly enough interesting loot compared to soldiers who drop grenades, MREs, clean water, candy bars, heavy duty firepower, decent starting clothing and armor, et cetera.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

I rebalanced both the cop and the swat drops in a few different ways.

Zombie cop has gained a new small-chance itemgroup called cop_contraband which includes a small list of common illicit drugs and drug paraphernalia such as pipes and syringes. It also includes common anarchist and "rule of cool" carries, such as pipe bombs and molotovs, hunting knives, and brass knuckles. The things you are most likely to actually find will be the pipe, bong, syringe, or weed. If the rng is strong with you, you have a tiny chance of also finding one of the three commonly smuggled date rape chemicals - ether, chloroform, and ghb.

I also moved some things around - for example riot armor is now a possible option for torso gear rather than one of the many options of cop_gear. I kept the probability the same across all riot components - roughly between 20 and 30. 

You also have a chance of a cop dropping a knit hat instead of a cowboy hat or a riot helmet - standing in for a watch cap worn by both police and military when not in formal dress attire.

Tear gas replaces the air horn, and dog whistle replaces normal whistle as possible drops from the cop_gear group.

Swat zombie is now guaranteed to drop _something_ from each of the clothing slots, as well as _a_ weapon, whether it's a baton or a pistol.

Important to note: Swat zombies have a small chance of dropping tear gas, smoke, flashbang, or fragmentation grenades - with frags being the smallest chance at 5 and tear gas being the highest chance at 15. They have two chances to do this since two item groups allow for it. The second item group gives all grenades except fragmentation a probability of 3 to spawn [fragmentation has zero chance for balance purposes.]

## Describe alternatives you've considered

I couldn't really think of any other alternatives for this.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->


https://github.com/user-attachments/assets/65440441-c252-4407-8239-b4d3b6b8533e

Here's my results of testing several dozen zombie cops to ensure they weren't dropping ludicrous amounts of pipe bombs, drugs, or chloroform. To my delight not a single one dropped any contraband item - meaning it is an extremely rare occurrence. While they do spawn riot shields and riot helmets with decent frequency, the riot armor remains elusive. However you definitely, as a player, now have an incentive to roll rng on these particular shamblers.

I think this effectively closes the issue of zombie law enforcement being "not worth killing."

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
