### PR TITLE
feat(balance): buff law enforcement zombie loot

### DIFF
--- a/data/json/monsterdrops/zombie_cop.json
+++ b/data/json/monsterdrops/zombie_cop.json
@@ -13,7 +13,7 @@
       { "group": "cop_shoes", "damage": [ 1, 4 ] },
       { "group": "cop_torso", "damage": [ 1, 4 ] },
       { "group": "cop_weapons", "prob": 60, "damage": [ 0, 3 ], "dirt": [ 1500, 7050 ] },
-	  { "group": "cop_contraband", "prob": 10 },
+      { "group": "cop_contraband", "prob": 10 },
       { "group": "underwear", "damage": [ 1, 4 ] },
       { "group": "clothing_glasses", "prob": 5 },
       { "group": "clothing_watch", "prob": 5 },
@@ -36,7 +36,7 @@
     "items": [
       [ "1st_aid", 30 ],
       [ "gasbomb", 5 ],
-	  [ "airhorn", 5],
+      [ "airhorn", 5 ],
       [ "bandages", 20 ],
       [ "tacvest", 10 ],
       [ "heavy_flashlight", 35 ],
@@ -61,7 +61,7 @@
   {
     "id": "cop_helmet",
     "type": "item_group",
-	"//": "Cotton hat represents the watch cap sometimes worn instead of a five point police cap.",
+    "//": "Cotton hat represents the watch cap sometimes worn instead of a five point police cap.",
     "items": [ [ "cowboy_hat", 10 ], [ "hat_cotton", 20 ], [ "helmet_riot", 30 ] ]
   },
   {
@@ -89,7 +89,7 @@
     "type": "item_group",
     "items": [ { "group": "cop_melee", "prob": 60 }, { "group": "carried_guns_cop", "prob": 40 } ]
   },
-   {
+  {
     "type": "item_group",
     "id": "cop_contraband",
     "items": [
@@ -105,19 +105,19 @@
       [ "pipe_glass_bong", 50 ],
       { "item": "light_battery_cell", "charges": 100, "container-item": "dab_pen", "prob": 20 },
       [ "dab_pen_disposable", 20 ],
-	  ["improvised_grenade", 2],
-	  [ "molotov", 6],
-	  [ "improvised_pipebomb", 2 ], 
-	  [ "tool_small_improvised_fragmentation_device", 2 ],
-	  [ "switchblade", 6 ],
-	  [ "knife_folding", 10 ], 
-	  [ "knife_hunting", 2 ],
-	  [ "tazer", 6 ],
-	  [ "knuckle_brass", 8],
-	  [ "knuckle_steel", 5], 
-	  [ "chem_chloroform", 1],
-	  [ "ether", 1],
-	  [ "ghb", 1 ]
+      [ "improvised_grenade", 2 ],
+      [ "molotov", 6 ],
+      [ "improvised_pipebomb", 2 ],
+      [ "tool_small_improvised_fragmentation_device", 2 ],
+      [ "switchblade", 6 ],
+      [ "knife_folding", 10 ],
+      [ "knife_hunting", 2 ],
+      [ "tazer", 6 ],
+      [ "knuckle_brass", 8 ],
+      [ "knuckle_steel", 5 ],
+      [ "chem_chloroform", 1 ],
+      [ "ether", 1 ],
+      [ "ghb", 1 ]
     ]
   },
   {
@@ -128,12 +128,12 @@
     "ammo": 40,
     "entries": [
       { "group": "swat_zombie_gear", "prob": 100, "damage": [ 0, 2 ] },
-      { "group": "swat_gloves",  "damage": [ 0, 4 ] },
-      { "group": "swat_helmet",  "damage": [ 0, 4 ] },
+      { "group": "swat_gloves", "damage": [ 0, 4 ] },
+      { "group": "swat_helmet", "damage": [ 0, 4 ] },
       { "group": "swat_pants", "damage": [ 0, 4 ] },
       { "group": "swat_shoes", "damage": [ 0, 4 ] },
       { "group": "swat_torso", "damage": [ 0, 4 ] },
-      { "group": "swat_weapons",  "damage": [ 0, 3 ], "dirt": [ 0, 7050 ] },
+      { "group": "swat_weapons", "damage": [ 0, 3 ], "dirt": [ 0, 7050 ] },
       { "group": "underwear", "damage": [ 0, 4 ] },
       { "group": "clothing_glasses", "prob": 5 },
       { "group": "clothing_watch", "prob": 10 },
@@ -165,7 +165,7 @@
           { "item": "grenade", "prob": 5 },
           { "item": "two_way_radio", "prob": 30 },
           { "item": "gasbomb", "prob": 15 },
-		  { "item": "smokebomb", "prob": 10 },
+          { "item": "smokebomb", "prob": 10 },
           { "item": "flashbang", "prob": 10 },
           { "item": "sm_extinguisher", "prob": 5 },
           { "item": "rope_30", "prob": 10 }
@@ -178,9 +178,9 @@
           { "item": "chestpouch", "prob": 15 },
           { "item": "ammo_satchel", "prob": 10 },
           { "item": "bholster", "prob": 25 },
-		  { "item": "smokebomb", "prob": 3 },
-		  { "item": "gasbomb", "prob": 3 },
-		  { "item": "flashbang", "prob": 3 },
+          { "item": "smokebomb", "prob": 3 },
+          { "item": "gasbomb", "prob": 3 },
+          { "item": "flashbang", "prob": 3 },
           { "item": "bandolier_shotgun", "prob": 10 },
           { "item": "legpouch_large", "prob": 25 },
           { "item": "police_belt", "prob": 25 }


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->
Resolves #6197 

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

Added more interesting loot to zombie cops and rearranged a couple things. I took riot armor out of cop_gear where it was competing with accessories like flashlights and police belts, and put it into the torso gear group to compete with the shirts instead.

I added tear gas to the cop_gear accessory group, and swapped whistle for dog whistle since the air horn was already present as a possible - and much more effective - noisemaker.

I added a small-chance contraband item group that includes the kinds of things a police officer might be expected to have confiscated from a common small time crook, a junkie, an anarchist, or a chemical hustler. 

The most likely things to actually get are going to be glass pipes, bongs, and syringes. Second will be weed and dab pens. Finally, you'll have a small chance of hard drugs, brass knuckles, switchblades, hunting knives, and small improvised explosives such as the pipe bomb and improvised grenade. A tiny chance exists for ether, chloroform, and ghb, which are commonly smuggled out of hospitals for sale toward illicit club activities.

Zombie swat now have a small chance of dropping fragmentation grenades, tear gas grenades, and smoke grenades, in addition to flashbangs they were already dropping. The chances are skewed toward tear gas highest and frag grenades lowest. You have two chances to get the non-lethal grenades, although the second chance is astronomically small. 

Also, I made their gloves, helmets, and weapons mandatory, so they _will_ drop something from those groups every single time. You will no longer kill a swat zombie only for it to not even give you so much as a baton.

## Describe alternatives you've considered

I couldn't really think of any good alternatives.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

Spawned and killed 50 zombie cops and 50 zombie swat.

Zombie cops spawned with more riot armor than before, but it was still a ratio of 1 riot armor for every 10 riot helmets and riot shields. The contraband item group only engaged once, and it spawned a switchblade. Despite tear gas inclusion in the cop_gear itemgroup, it was never once spawned.

In a normal city-sweep you are unlikely to see anything radically different, but you now have an rng motivation to seek out cops on the off chance they bless you with a hunting knife or a pipe bomb.

Zombie swat produced a total of 3 fragmentation grenades and 2 smoke grenades; the rest were flashbangs and tear gas grenades [of limited quantity.] 

Beyond that, fairly standard drops. A lot of batons, a lot of pistols, a few M4A1s, a decent spread of MP5s. 

I would say those are fairly good RNG for having killed 50 at a time.

You now have a good reason to seek swat out too, although they are in my playthroughs reasonably rare to find compared to the other zombie types. If you find one, you just might get a frag grenade. _Maybe._

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

It is important to keep in mind that you are not likely to ever encounter 50 zombie cops or anywhere close to 50 zombie swat in one place at any one time - so rng will be heavily stacked against you on finding anything noteworthy. But with these changes, every kill will be worth pursuing.

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.