### PR TITLE
fix: smoking rack allow removing everything + replace mentions of "food" with "items" to be more complete

### DIFF
--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -7167,8 +7167,12 @@ void iexamine::smoker_options( player &p, const tripoint &examp )
 
     for( const item * const &it : items_here ) {
         const bool has_smokable_item = it->typeId() != itype_charcoal && it->has_flag( flag_SMOKABLE );
-        if( has_smokable_item ) {
+        const bool has_removable_item = it->typeId() != itype_charcoal &&
+                                        it->typeId() != itype_fake_smoke_plume;
+        if( has_removable_item ) {
             f_check = true;
+        }
+        if( has_smokable_item ) {
             f_volume += it->volume();
         }
         if( active && it->typeId() == itype_fake_smoke_plume ) {


### PR DESCRIPTION
## Purpose of change (The Why)

Wielders of arcane secret knowledge knew that it was possible to cure hides on a smoking rack, and were disappointed to learn that that when finished products started going onto the rack, they could not be removed after. I will now break their hold on knowing about curable hides by describing such ability inside the smoking rack's menu. Also a fix for removing anything from smoking racks if wrong items end up on the tile somehow.

## Describe the solution (The How)

Players can now remove all non-charcoal items from smoking racks. Should handle anything thrown around by shrapnel or failed tosses as well now.

Previously, the code checked if items were food using is_food(), which excluded cured hides (GENERIC type) even though raw hides (COMESTIBLE) could be placed and smoked.

The fix simplifies the logic: 'remove food' now removes everything except charcoal, while 'remove charcoal' removes only charcoal.

Similar rework for other checks for already cooked or wrong things present on rack.

Add mention of being able to smoke hides to the rack, and replace all references to "food" with more generic "item"

## Describe alternatives you've considered

Roundhouse kicking a smoking rack into a volcano. What a weird implementation.
Maybe rewriting it in lua for fun because there's support for that now.

## Testing

Put hide on a smoker, smoke it, remove cured hide. 
Put an apple on smoker, remove dehydrated fruit.
Try starting smoking with finished items on smoker and fail.

Look at a mill.

## Additional context

Mills are still fine 👍 

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.