### PR TITLE
feat(UI): skip showing furniture transform dialogue if only one option avaliable

### DIFF
--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -1814,14 +1814,14 @@ void iexamine::transform( player &p, const tripoint &pos )
         prompt = g->m.ter( pos ).obj().prompt;
     }
 
-    if (has_lootable_items || furn_is_deployed || can_climb) {
+    if( has_lootable_items || furn_is_deployed || can_climb ) {
 
         uilist selection_menu;
         selection_menu.text = _( "Select an action" );
-        if ( has_lootable_items ) {
+        if( has_lootable_items ) {
             selection_menu.addentry( 0, true, 'g', _( "Get items" ) );
         }
-            selection_menu.addentry( 1, true, 't', !prompt.empty() ? _( prompt ) : _( "Transform furniture" ) );
+        selection_menu.addentry( 1, true, 't', !prompt.empty() ? _( prompt ) : _( "Transform furniture" ) );
         if( furn_is_deployed ) {
             selection_menu.addentry( 2, true, 'T', _( "Take down the %s" ), g->m.furnname( pos ) );
         }
@@ -1832,9 +1832,9 @@ void iexamine::transform( player &p, const tripoint &pos )
 
         switch( selection_menu.ret ) {
             case 0:
-               none( p, pos );
-               pickup::pick_up( pos, 0 );
-               return;
+                none( p, pos );
+                pickup::pick_up( pos, 0 );
+                return;
             case 1: {
                 if( !message.empty() ) {
                     add_msg( _( message ) );


### PR DESCRIPTION
## Purpose of change (The Why)

Examining transformable furniture/terrain always show a dialogue popup, even if the only valid option is to actually transform the furniture/terrain
This is both kinda pointless and inconvenient

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)

Only show a dialogue popup when examining transformable furniture/terrain if the player can take an action other then transforming the furniture/terrain, and simply immediately transform the furniture/terrain if that isnt the case

Also hides the Get Items option if the dialogue does show up but the furniture/terrain lacks an item on it
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered

Not doing this?

## Testing

Spawned in a table and drop an item on it
Examined the table and select the get items option to remove the item from the table
Examined the table again, no item was on the table so it was instantly flipped over
Examined the now flipped over table and the dialogue popped up as you can climb flipped tables
Climbed the table and then examined the table and unflipped it

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.