### PR TITLE
perf: Remove hot air fields from underwater gas vents

### DIFF
--- a/data/json/furniture_and_terrain/furniture-emitters.json
+++ b/data/json/furniture_and_terrain/furniture-emitters.json
@@ -41,6 +41,7 @@
     "coverage": 30,
     "light_emitted": 1,
     "required_str": -1,
-    "flags": [ "TRANSPARENT" ]
+    "flags": [ "TRANSPARENT", "EMITTER" ],
+    "emissions": [ "emit_smoke_plume" ]
   }
 ]


### PR DESCRIPTION
## Purpose of change (The Why)

Underwater gas vents currently emit hot air fields that are useless.
These fields add avoidable per-turn field processing overhead, which hurts performance. Also, what's up with hot air underwater anyway?

## Describe the solution (The How)

Removed hot air emissions by updating `f_hot_spring` in `data/json/furniture_and_terrain/furniture-emitters.json`

## Describe alternatives you've considered

Reworking the entire field processing to be less processing heavy

## Testing

Looking at a gas field
No gameplay logic/C++ changes; JSON-only behavior adjustment.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
