### PR TITLE
feat: allow integrated toolset (e)xamine prying locked objects

### DIFF
--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -224,6 +224,9 @@ static const bionic_id bio_fingerhack( "bio_fingerhack" );
 static const bionic_id bio_lighter( "bio_lighter" );
 static const bionic_id bio_lockpick( "bio_lockpick" );
 static const bionic_id bio_painkiller( "bio_painkiller" );
+static const bionic_id bio_tools( "bio_tools" );
+
+static const itype_id itype_toolset( "toolset" );
 
 static const std::string flag_AUTODOC( "AUTODOC" );
 static const std::string flag_AUTODOC_COUCH( "AUTODOC_COUCH" );
@@ -1481,36 +1484,55 @@ void iexamine::slot_machine( player &p, const tripoint & )
     }
 }
 
-static item *find_best_prying_tool( player &p )
+static auto find_best_prying_tool( player &p,
+                                   std::vector<detached_ptr<item>> &pseudo_prying_tools ) -> item *
 {
-    std::vector<item *> prying_items = p.items_with( []( const item & it ) {
+    auto prying_items = p.items_with( []( const item & it ) {
         // we want to get worn items (eg crowbar in toolbelt), so no check on item position
         return it.has_quality( quality_id( "PRY" ), 1 );
     } );
 
-    // Sort by their quality level.
-    std::ranges::sort( prying_items, []( const item * a, const item * b ) -> bool {
-        return a->get_quality( quality_id( "PRY" ) ) > b->get_quality( quality_id( "PRY" ) );
-    } );
+    if( p.has_active_bionic( bio_tools ) ) {
+        pseudo_prying_tools.push_back( item::spawn( itype_toolset, calendar::turn ) );
+        auto *toolset = pseudo_prying_tools.back().get();
+        const auto *iuse_fn = toolset->type->get_use( "CROWBAR" );
+        if( iuse_fn && iuse_fn->can_call( p, *toolset, false, p.pos() ).success() ) {
+            prying_items.push_back( toolset );
+        } else {
+            pseudo_prying_tools.pop_back();
+        }
+    }
 
-    // if crowbar() ever eats charges or otherwise alters the passed item, rewrite this to reflect
-    // changes to the original item.
     if( prying_items.empty() ) {
         return nullptr;
     }
-    return prying_items[0];
+
+    const auto best_tool = std::ranges::max_element( prying_items, []( const item * a,
+    const item * b ) -> bool {
+        return a->get_quality( quality_id( "PRY" ) ) < b->get_quality( quality_id( "PRY" ) );
+    } );
+    return *best_tool;
 }
 
-static void apply_prying_tool( player &p, item *it, const tripoint &examp )
+static auto apply_prying_tool( player &p, item *it, const tripoint &examp ) -> bool
 {
     map &here = get_map();
+    const auto *iuse_fn = it->type->get_use( "CROWBAR" );
+    if( !iuse_fn ) {
+        return false;
+    }
+    const auto can_use = iuse_fn->can_call( p, *it, false, examp );
+    if( !can_use.success() ) {
+        p.add_msg_if_player( m_bad, can_use.str() );
+        return false;
+    }
+
     //~ %1$s: terrain/furniture name, %2$s: prying tool name
     p.add_msg_if_player( _( "You attempt to pry open the %1$s using your %2$s…" ),
                          here.has_furn( examp ) ? here.furnname( examp ) : here.tername( examp ), it->tname() );
 
-    // if crowbar() ever eats charges or otherwise alters the passed item, rewrite this to reflect
-    // changes to the original item.
-    iuse::crowbar( &p, it, false, examp );
+    p.invoke_item( it, "CROWBAR", examp );
+    return true;
 }
 
 static time_duration safecracking_time( const player &p )
@@ -1541,13 +1563,14 @@ void iexamine::safe( player &p, const tripoint &examp )
 {
 
     map &here = get_map();
-    safe_reference<item> prying_tool = find_best_prying_tool( p );
+    auto pseudo_prying_tools = std::vector<detached_ptr<item>>{};
+    auto *prying_tool = find_best_prying_tool( p, pseudo_prying_tools );
     const int target_diff = here.has_furn( examp ) ? here.furn( examp )->pry.pry_quality : here.ter(
                                 examp )->pry.pry_quality;
     if( target_diff > 0 && prying_tool && !p.movement_mode_is( CMM_CROUCH ) ) {
         // keep going in case we have a prying tool that can't be used against the target, so we can try lockpicking
-        if( prying_tool->get_quality( quality_id( "PRY" ) ) >= target_diff ) {
-            apply_prying_tool( p, prying_tool.get(), examp );
+        if( prying_tool->get_quality( quality_id( "PRY" ) ) >= target_diff &&
+            apply_prying_tool( p, prying_tool, examp ) ) {
             return;
         }
     }
@@ -1605,13 +1628,14 @@ void iexamine::safe( player &p, const tripoint &examp )
 void iexamine::gunsafe_el( player &p, const tripoint &examp )
 {
     map &here = get_map();
-    safe_reference<item> prying_tool = find_best_prying_tool( p );
+    auto pseudo_prying_tools = std::vector<detached_ptr<item>>{};
+    auto *prying_tool = find_best_prying_tool( p, pseudo_prying_tools );
     const int target_diff = here.has_furn( examp ) ? here.furn( examp )->pry.pry_quality : here.ter(
                                 examp )->pry.pry_quality;
     if( target_diff > 0 && prying_tool && !p.movement_mode_is( CMM_CROUCH ) ) {
         // keep going in case we have a prying tool that can't be used against the target, so we can try lockpicking
-        if( prying_tool->get_quality( quality_id( "PRY" ) ) >= target_diff ) {
-            apply_prying_tool( p, prying_tool.get(), examp );
+        if( prying_tool->get_quality( quality_id( "PRY" ) ) >= target_diff &&
+            apply_prying_tool( p, prying_tool, examp ) ) {
             return;
         }
     }
@@ -1705,13 +1729,14 @@ void iexamine::locked_object( player &p, const tripoint &examp )
         }
     }
 
-    safe_reference<item> prying_tool = find_best_prying_tool( p );
+    auto pseudo_prying_tools = std::vector<detached_ptr<item>>{};
+    auto *prying_tool = find_best_prying_tool( p, pseudo_prying_tools );
     if( prying_tool ) {
         const int target_diff = here.has_furn( examp ) ? here.furn( examp )->pry.pry_quality : here.ter(
                                     examp )->pry.pry_quality;
         // keep going in case we have a prying tool that can't be used against the target, so we can try lockpicking
-        if( prying_tool->get_quality( quality_id( "PRY" ) ) >= target_diff ) {
-            apply_prying_tool( p, prying_tool.get(), examp );
+        if( prying_tool->get_quality( quality_id( "PRY" ) ) >= target_diff &&
+            apply_prying_tool( p, prying_tool, examp ) ) {
             return;
         }
     }

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -1563,7 +1563,7 @@ void iexamine::safe( player &p, const tripoint &examp )
 {
 
     map &here = get_map();
-    auto pseudo_prying_tools = std::vector<detached_ptr<item>>{};
+    auto pseudo_prying_tools = std::vector<detached_ptr<item>> {};
     auto *prying_tool = find_best_prying_tool( p, pseudo_prying_tools );
     const int target_diff = here.has_furn( examp ) ? here.furn( examp )->pry.pry_quality : here.ter(
                                 examp )->pry.pry_quality;
@@ -1628,7 +1628,7 @@ void iexamine::safe( player &p, const tripoint &examp )
 void iexamine::gunsafe_el( player &p, const tripoint &examp )
 {
     map &here = get_map();
-    auto pseudo_prying_tools = std::vector<detached_ptr<item>>{};
+    auto pseudo_prying_tools = std::vector<detached_ptr<item>> {};
     auto *prying_tool = find_best_prying_tool( p, pseudo_prying_tools );
     const int target_diff = here.has_furn( examp ) ? here.furn( examp )->pry.pry_quality : here.ter(
                                 examp )->pry.pry_quality;
@@ -1729,7 +1729,7 @@ void iexamine::locked_object( player &p, const tripoint &examp )
         }
     }
 
-    auto pseudo_prying_tools = std::vector<detached_ptr<item>>{};
+    auto pseudo_prying_tools = std::vector<detached_ptr<item>> {};
     auto *prying_tool = find_best_prying_tool( p, pseudo_prying_tools );
     if( prying_tool ) {
         const int target_diff = here.has_furn( examp ) ? here.furn( examp )->pry.pry_quality : here.ter(


### PR DESCRIPTION
## Purpose of change (The Why)

Examining locked doors/windows/containers did not consider the active integrated toolset as a valid prying tool, even though direct crowbar/halligan-style interaction does.

## Describe the solution (The How)

- Extend examine prying tool selection to include a temporary `toolset` pseudo-item when `bio_tools` is active and callable.
- Route examine prying through normal item invocation (`CROWBAR`) instead of calling `iuse::crowbar` directly.
- Rewrite function to fit the AGENTS.md requirements while keeping functionality the same.
- Keep existing pry-strength checks and lockpick fallbacks intact.

Related old closed issue: #2130.

## Describe alternatives you've considered

- Calling `iuse::crowbar` directly with a pseudo item was simpler but bypasses normal `can_call`/invoke behavior.
- Expanding `Character` inventory-quality queries globally was broader than needed for this focused UX bug.

## Testing

Pry open crate with activated toolset
Fail to pry open window without activated toolset
Pry open window with a halligan bar despite active toolset


## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
