### PR TITLE
fix: Graphical issues with tint_config implementation

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1299,17 +1299,17 @@ static void apply_surf_blend_effect(
 
     auto postprocess = [&tint]( SDL_Color c ) -> SDL_Color {
         auto [h, s, v, a] = rgb2hsv( c );
-        if( tint.contrast != 1.0f )
+        if( fabs( tint.contrast - 1.0f ) > 0.001f )
         {
             const float adjusted = ( ( static_cast<float>( v ) - 128.0f ) * tint.contrast ) + 128.0f;
             v =  static_cast<uint8_t>( std::clamp( adjusted, 0.0f, 255.0f ) );
         }
-        if( tint.saturation != 1.0f )
+        if( fabs( tint.saturation - 1.0f ) > 0.001f )
         {
             s = static_cast<uint16_t>( std::clamp( static_cast<float>( s ) * tint.saturation, 0.0f,
                                                    65535.0f ) );
         }
-        if( tint.brightness != 1.0f )
+        if( fabs( tint.brightness - 1.0f ) > 0.001f )
         {
             v = static_cast<uint8_t>( std::clamp( static_cast<float>( v ) * tint.brightness, 0.0f,
                                                   255.0f ) );

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -247,9 +247,9 @@ struct tint_config {
 
     bool has_value() const {
         return color != TILESET_NO_COLOR
-               || contrast != 1.0f
-               || saturation != 1.0f
-               || brightness != 1.0f;
+               || fabs( contrast - 1.0f ) > 0.001f
+               || fabs( saturation - 1.0f ) > 0.001f
+               || fabs( brightness - 1.0f ) > 0.001f;
     }
 
     bool operator==( const tint_config &other ) const {


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

Fix graphical issues introduced by #8026

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)

`tint_config` made use of `std::optional<SDL_Color>`, `but std::nullopt` and `TILESET_NO_COLOR` evaluated to different tiles (hash mismatch), when they should be the same, causing issues with dynamic tile lookup

## Describe alternatives you've considered

N/A

## Testing

Load Game
Change Tileset (e.g UltiCa) when the game is open
or Debug - Reload Tileset

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

~~Note: Reloading/Changing the Tileset at z-level != 0 has its own issues, unrelated to this PR, and will be dealt with later.~~

Aditionally:
```c++
std::optional<float> contrast;    
std::optional<float> saturation;
std::optional<float> brightness;
```
Are prone to the same issue, and should also be changed to be always present values, with bias (-1 ~ 1 range), and 0 being treated as no-op like TILESET_NO_COLOR

Tagging @AzmodiusX  for this

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.