### PR TITLE
build: gate debug prefix map to GitHub Actions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -270,10 +270,13 @@ if (NOT MSVC)
     # Add debug symbols for non-release builds or when backtrace is enabled
     if (BACKTRACE OR NOT RELEASE)
         set(CATA_OTHER_FLAGS "${CATA_OTHER_FLAGS} -g1")
-        # Use debug prefix map for ccache compatibility with git worktrees
+        # Use debug prefix map on GitHub Actions for ccache compatibility
+        # while preserving local debug source paths for IDE/GDB breakpoints.
         # see https://ccache.dev/manual/latest.html#_compiling_in_different_directories
-        file(RELATIVE_PATH REL_SRC_PATH "${CMAKE_BINARY_DIR}" "${CMAKE_SOURCE_DIR}")
-        set(CATA_OTHER_FLAGS "${CATA_OTHER_FLAGS} -ffile-prefix-map=${REL_SRC_PATH}=.")
+        if (DEFINED ENV{GITHUB_ACTIONS} AND "$ENV{GITHUB_ACTIONS}")
+            file(RELATIVE_PATH REL_SRC_PATH "${CMAKE_BINARY_DIR}" "${CMAKE_SOURCE_DIR}")
+            set(CATA_OTHER_FLAGS "${CATA_OTHER_FLAGS} -ffile-prefix-map=${REL_SRC_PATH}=.")
+        endif ()
     endif()
     # Compact the whitespace in the warning string
     string(REGEX REPLACE "[\t ]+" " " CATA_WARNINGS "${CATA_WARNINGS}")


### PR DESCRIPTION
## Purpose of change (The Why)

Regression from #7678 remapped local debug file paths to build-dir-relative paths, which breaks IDE/GDB breakpoints in local builds.

## Describe the solution (The How)

Apply `-ffile-prefix-map=${REL_SRC_PATH}=.` only when running on GitHub Actions (`GITHUB_ACTIONS` is set), while keeping local debug symbols mapped to real source paths.

## Describe alternatives you've considered

- Remove `-ffile-prefix-map` entirely (keeps local debugging but drops CI/worktree ccache path normalization).

## Testing

- `cmake --preset linux-full -DLUA_DOCS_ON_BUILD=OFF`
- `cmake --build --preset linux-full --target cataclysm-bn-tiles cata_test-tiles`
- `./out/build/linux-full/tests/cata_test-tiles "time_duration_to_string"`
- Confirmed no `ffile-prefix-map` in `out/build/linux-full/compile_commands.json` in local env.

## Additional context

`LUA_DOCS_ON_BUILD` was disabled for local verification because docs generation in this environment expects a root-level `./cataclysm-bn-tiles` path and fails post-link.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

- [x] This is a PR that modifies build process or code organization.
- [ ] Please document the changes in the appropriate location in the `docs/` folder.
- [ ] If documentation for this feature or process does not exist, please write it.
- [ ] If the change alters versions of software required to build or work with the game, please document it.