### PR TITLE
fix: get passenger now works for vehicles with multiple boardable parts on one tile

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -3709,9 +3709,11 @@ std::vector<rider_data> vehicle::get_riders() const
 
 player *vehicle::get_passenger( int p ) const
 {
-    p = part_with_feature( p, VPFLAG_BOARDABLE, false );
-    if( p >= 0 && parts[p].has_flag( vehicle_part::passenger_flag ) ) {
-        return g->critter_by_id<player>( parts[p].passenger_id );
+    for( auto part : get_parts_at( mount_to_tripoint( parts[p].mount ), "BOARDABLE",
+                                   part_status_flag::any ) ) {
+        if( part && part->has_flag( vehicle_part::passenger_flag ) ) {
+            return g->critter_by_id<player>( part->passenger_id );
+        }
     }
     return nullptr;
 }


### PR DESCRIPTION
## Purpose of change (The Why)
In #8165 get_passenger was used
It broke on racing canoes
Determined issue was get_passenger when there is more then one boardable part on one tile

## Describe the solution (The How)
Check all boardable parts for a passenger on the tile

## Describe alternatives you've considered
Determine all bugs this may also fix

## Testing
Racing canoe works again

## Additional context
I screm

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.