### PR TITLE
refactor: make manual iterators iterable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,5 @@
 # Cataclysm: Bright Nights - Agent Guidelines
 
-> **⚠️ CRITICAL**: Follow this guide EXACTLY. Use the exact commands shown below, not alternatives.
-> Do NOT search for alternative build tools or improvise. The commands are tested and work.
-
 - **MUST** RE-READ AGENTS.md BETWEEN subtasks.
 - **MUST** FOLLOW for all code changes.
 
@@ -17,7 +14,7 @@ Before writing **ANY** code, verify:
 | `Type x = value`                       | `auto x = value`                                                                 |
 | `void fn(a, b, c, d, e)`               | `void fn(options_struct)`                                                        |
 
-**Prefer `std::ranges`/`std::views` for collection work. Use range-based `for` when it is clearer than `std::ranges::for_each`. Avoid manual iterator increment loops unless required by mutation semantics.**
+**Prefer `std::ranges`/`std::views`/`std::ranges::to`/cata_algo.h for collection work. Avoid manual iterator increment loops unless required by mutation semantics.**
 
 ## Coding Convention
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,5 @@
 # Cataclysm: Bright Nights - Agent Guidelines
 
-- **MUST** RE-READ AGENTS.md BETWEEN subtasks.
-- **MUST** FOLLOW for all code changes.
-
 ## HARD CONSTRAINTS (NEVER VIOLATE)
 
 Before writing **ANY** code, verify:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,15 +10,14 @@
 
 Before writing **ANY** code, verify:
 
-| ❌ VIOLATION                       | ✅ REQUIRED                                       |
-| ---------------------------------- | ------------------------------------------------- |
-| nested `for (auto x : collection)` | `std::ranges::*` or `collection \| std::views::*` |
-| `int foo()`                        | `auto foo() -> int`                               |
-| `Type x = value`                   | `auto x = value`                                  |
-| `void fn(a, b, c, d, e)`           | `void fn(options_struct)`                         |
+| ❌ VIOLATION                           | ✅ REQUIRED                                                                      |
+| -------------------------------------- | -------------------------------------------------------------------------------- |
+| manual iterator loops (`it++`, `++it`) | `std::ranges::*`, `collection \| std::views::*`, or range-based `for` if clearer |
+| `int foo()`                            | `auto foo() -> int`                                                              |
+| `Type x = value`                       | `auto x = value`                                                                 |
+| `void fn(a, b, c, d, e)`               | `void fn(options_struct)`                                                        |
 
-- **If you write a nested for-loop over a collection, your code is WRONG. Rewrite with `std::ranges`.**
-- single, unnested `for (auto x : collection)` loop is OK.
+**Prefer `std::ranges`/`std::views` for collection work. Use range-based `for` when it is clearer than `std::ranges::for_each`. Avoid manual iterator increment loops unless required by mutation semantics.**
 
 ## Coding Convention
 
@@ -46,7 +45,7 @@ struct comparable {
 auto values = xs
   | std::views::filter( []( const auto & v ) { return v.is_valid(); } )
   | std::views::transform( []( const auto & v ) { return v.get_value(); } )
-  | std::ranges::to<std::vector>(); //< **MUST** use `std::ranges` over for loops for collections.
+  | std::ranges::to<std::vector>(); //< **SHOULD** prefer `std::ranges`/`std::views`; range-based `for` is allowed when clearer than `std::ranges::for_each`.
 
 namespace { // **MUST** use anonymous namespace for internal linkage over `static`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,9 @@
 # Cataclysm: Bright Nights - Agent Guidelines
 
+> **⚠️ CRITICAL**: Follow this guide EXACTLY. Use the exact commands shown below, not alternatives.
+> Do NOT search for alternative build tools or improvise. The commands are tested and work.
+
+- **MUST** RE-READ AGENTS.md BETWEEN subtasks.
 - **MUST** FOLLOW for all code changes.
 
 ## HARD CONSTRAINTS (NEVER VIOLATE)

--- a/docs/en/dev/guides/ranges.md
+++ b/docs/en/dev/guides/ranges.md
@@ -1,0 +1,70 @@
+# C++20 Range Compatibility
+
+To enable `std::ranges` algorithms, iterators must satisfy `std::default_initializable`, `std::copyable` (assignable), and provide postfix increment.
+
+## Guidelines
+
+- **Enable Copy Assignment**: Replace `const Container&` members with `const Container*`. References delete the assignment operator; pointers do not.
+- **Enable Default Construction**: Provide `iterator() = default` and initialize member pointers to `nullptr`.
+- **Define Concepts**: Add `using iterator_concept = std::forward_iterator_tag;`.
+- **Enforce Trailing Return Types**: Convert signatures to `auto fn() -> Type`.
+- **Implement Postfix Increment**: Required by standard concepts (`it++`).
+- **Modernize Comparisons**: Implement `operator==`. Remove `operator!=` (synthesized automatically). Implement `operator<=>` only for Random Access iterators.
+- **Utilize View Interface**: Inherit from `std::ranges::view_interface` to automatically generate `empty()`, `front()`, `back()`, and `data()`.
+
+## Refactoring Diff
+
+```diff
+- template<typename Tripoint>
+- class tripoint_range
++ template<typename Tripoint>
++ class tripoint_range : public std::ranges::view_interface<tripoint_range<Tripoint>>
+  {
+-         const tripoint_range &range;
++         const tripoint_range *range = nullptr;
+
+      public:
++         using iterator_concept = std::forward_iterator_tag;
+
+-         point_generator( const Tripoint &_p, const tripoint_range &_range )
+-             : p( _p ), range( _range ) {
+-         }
++         point_generator() = default;
++         point_generator( const Tripoint &_p, const tripoint_range *_range )
++             : p( _p ), range( _range ) {}
+
+-         point_generator &operator++() {
++         auto operator++() -> point_generator& {
+              // ... logic ...
+              return *this;
+          }
+
++         auto operator++(int) -> point_generator { auto tmp = *this; ++(*this); return tmp; }
+
+-         const Tripoint &operator*() const {
+-             return p;
+-         }
++         auto operator*() const -> reference { return p; }
+
+-         bool operator!=( const point_generator &other ) const {
+-             const Tripoint &pt = other.p;
+-             return traits::z( p ) != traits::z( pt ) || p.xy() != pt.xy();
+-         }
+-
+-         bool operator==( const point_generator &other ) const {
+-             return !( *this != other );
+-         }
++         // C++20 synthesizes != from ==.
++         // If Tripoint supports ==, use default. Otherwise implement manual ==.
++         auto operator==( const point_generator &rhs ) const -> bool { return p == rhs.p; }
+  };
+```
+
+## Verification
+
+Add static assertions to ensure compliance.
+
+```cpp
+static_assert( std::forward_iterator<tripoint_range<Tripoint>::iterator> );
+static_assert( std::ranges::forward_range<tripoint_range<Tripoint>> );
+```

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -922,15 +922,14 @@ bool Character::activate_bionic( bionic &bio, bool eff_only, bool *close_bionics
             }
 
             map_stack stack = here.i_at( p );
-            for( auto it = stack.begin(); it != stack.end(); it++ ) {
-                if( ( *it )->weight() < weight_cap &&
-                    ( *it )->made_of_any( affected_materials ) ) {
-                    detached_ptr<item> obj;
-                    stack.erase( it, &obj );
+            const auto it = std::ranges::find_if( stack, [&]( item * const candidate ) {
+                return candidate->weight() < weight_cap && candidate->made_of_any( affected_materials );
+            } );
+            if( it != stack.end() ) {
+                detached_ptr<item> obj;
+                stack.erase( it, &obj );
 
-                    affected.emplace_back( std::move( obj ), p );
-                    break;
-                }
+                affected.emplace_back( std::move( obj ), p );
             }
         }
 

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -250,7 +250,7 @@ itype_id bionic_data::itype() const
 
 bool bionic_data::is_included( const bionic_id &id ) const
 {
-    return std::ranges::find( included_bionics, id ) != included_bionics.end();
+    return std::ranges::contains( included_bionics, id );
 }
 
 void bionic_data::load_bionic( const JsonObject &jo, const std::string &src )
@@ -2987,7 +2987,7 @@ int bionic::get_quality( const quality_id &quality ) const
 bool bionic::is_this_fuel_powered( const itype_id &this_fuel ) const
 {
     const std::vector<itype_id> fuel_op = info().fuel_opts;
-    return std::ranges::find( fuel_op, this_fuel ) != fuel_op.end();
+    return std::ranges::contains( fuel_op, this_fuel );
 }
 
 void bionic::toggle_safe_fuel_mod()

--- a/src/catalua_bindings_game.cpp
+++ b/src/catalua_bindings_game.cpp
@@ -208,16 +208,22 @@ void cata::detail::reg_game_api( sol::state &lua )
         auto mon_rng = g->all_monsters();
         int idx = 1;
         out[idx++] = static_cast<Creature *>( &g->u );
-        std::ranges::for_each(
-            npc_rng.items
-        | std::views::transform( []( const weak_ptr_fast<npc> &wp ) { return wp.lock(); } )
-        | std::views::filter( []( const shared_ptr_fast<npc> &sp ) -> bool { return sp && !sp->is_dead(); } ),
-        [&out, &idx]( const shared_ptr_fast<npc> &sp ) { out[idx++] = static_cast<Creature *>( sp.get() ); } );
-        std::ranges::for_each(
-            mon_rng.items
-        | std::views::transform( []( const weak_ptr_fast<monster> &wp ) { return wp.lock(); } )
-        | std::views::filter( []( const shared_ptr_fast<monster> &sp ) -> bool { return sp && !sp->is_dead(); } ),
-        [&out, &idx]( const shared_ptr_fast<monster> &sp ) { out[idx++] = static_cast<Creature *>( sp.get() ); } );
+        if( npc_rng.items )
+        {
+            std::ranges::for_each(
+                *npc_rng.items
+            | std::views::transform( []( const weak_ptr_fast<npc> &wp ) { return wp.lock(); } )
+            | std::views::filter( []( const shared_ptr_fast<npc> &sp ) -> bool { return sp && !sp->is_dead(); } ),
+            [&out, &idx]( const shared_ptr_fast<npc> &sp ) { out[idx++] = static_cast<Creature *>( sp.get() ); } );
+        }
+        if( mon_rng.items )
+        {
+            std::ranges::for_each(
+                *mon_rng.items
+            | std::views::transform( []( const weak_ptr_fast<monster> &wp ) { return wp.lock(); } )
+            | std::views::filter( []( const shared_ptr_fast<monster> &sp ) -> bool { return sp && !sp->is_dead(); } ),
+            [&out, &idx]( const shared_ptr_fast<monster> &sp ) { out[idx++] = static_cast<Creature *>( sp.get() ); } );
+        }
         return out;
     } );
 
@@ -227,11 +233,14 @@ void cata::detail::reg_game_api( sol::state &lua )
         auto out = lua.create_table();
         auto rng = g->all_npcs();
         int idx = 1;
-        std::ranges::for_each(
-            rng.items
-        | std::views::transform( []( const weak_ptr_fast<npc> &wp ) { return wp.lock(); } )
-        | std::views::filter( []( const shared_ptr_fast<npc> &sp ) -> bool { return sp && !sp->is_dead(); } ),
-        [&out, &idx]( const shared_ptr_fast<npc> &sp ) { out[idx++] = sp.get(); } );
+        if( rng.items )
+        {
+            std::ranges::for_each(
+                *rng.items
+            | std::views::transform( []( const weak_ptr_fast<npc> &wp ) { return wp.lock(); } )
+            | std::views::filter( []( const shared_ptr_fast<npc> &sp ) -> bool { return sp && !sp->is_dead(); } ),
+            [&out, &idx]( const shared_ptr_fast<npc> &sp ) { out[idx++] = sp.get(); } );
+        }
         return out;
     } );
 
@@ -241,11 +250,14 @@ void cata::detail::reg_game_api( sol::state &lua )
         auto out = lua.create_table();
         auto rng = g->all_monsters();
         int idx = 1;
-        std::ranges::for_each(
-            rng.items
-        | std::views::transform( []( const weak_ptr_fast<monster> &wp ) { return wp.lock(); } )
-        | std::views::filter( []( const shared_ptr_fast<monster> &sp ) -> bool { return sp && !sp->is_dead(); } ),
-        [&out, &idx]( const shared_ptr_fast<monster> &sp ) { out[idx++] = sp.get(); } );
+        if( rng.items )
+        {
+            std::ranges::for_each(
+                *rng.items
+            | std::views::transform( []( const weak_ptr_fast<monster> &wp ) { return wp.lock(); } )
+            | std::views::filter( []( const shared_ptr_fast<monster> &sp ) -> bool { return sp && !sp->is_dead(); } ),
+            [&out, &idx]( const shared_ptr_fast<monster> &sp ) { out[idx++] = sp.get(); } );
+        }
         return out;
     } );
 
@@ -255,13 +267,16 @@ void cata::detail::reg_game_api( sol::state &lua )
         auto out = lua.create_table();
         auto rng = g->all_npcs();
         int idx = 1;
-        std::ranges::for_each(
-            rng.items
-        | std::views::transform( []( const weak_ptr_fast<npc> &wp ) { return wp.lock(); } )
-        | std::views::filter( []( const shared_ptr_fast<npc> &sp ) -> bool {
-            return sp && !sp->is_dead() && sp->is_simulated();
-        } ),
-        [&out, &idx]( const shared_ptr_fast<npc> &sp ) { out[idx++] = sp.get(); } );
+        if( rng.items )
+        {
+            std::ranges::for_each(
+                *rng.items
+            | std::views::transform( []( const weak_ptr_fast<npc> &wp ) { return wp.lock(); } )
+            | std::views::filter( []( const shared_ptr_fast<npc> &sp ) -> bool {
+                return sp && !sp->is_dead() && sp->is_simulated();
+            } ),
+            [&out, &idx]( const shared_ptr_fast<npc> &sp ) { out[idx++] = sp.get(); } );
+        }
         return out;
     } );
 

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -958,7 +958,7 @@ bool Character::has_alarm_clock() const
     map &here = get_map();
     return ( has_item_with_flag( flag_ALARMCLOCK, true ) ||
              ( here.veh_at( pos() ) &&
-               !empty( here.veh_at( pos() )->vehicle().get_avail_parts( "ALARMCLOCK" ) ) ) ||
+               !here.veh_at( pos() )->vehicle().get_avail_parts( "ALARMCLOCK" ).empty() ) ||
              has_bionic( bio_infolink ) );
 }
 
@@ -967,7 +967,7 @@ bool Character::has_watch() const
     map &here = get_map();
     return ( has_item_with_flag( flag_WATCH, true ) ||
              ( here.veh_at( pos() ) &&
-               !empty( here.veh_at( pos() )->vehicle().get_avail_parts( "WATCH" ) ) ) ||
+               !here.veh_at( pos() )->vehicle().get_avail_parts( "WATCH" ).empty() ) ||
              has_bionic( bio_infolink ) );
 }
 

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -7155,7 +7155,7 @@ const std::vector<material_id> Character::fleshy = { material_id( "flesh" ), mat
 bool Character::made_of( const material_id &m ) const
 {
     // TODO: check for mutations that change this.
-    return std::ranges::find( fleshy, m ) != fleshy.end();
+    return std::ranges::contains( fleshy, m );
 }
 bool Character::made_of_any( const std::set<material_id> &ms ) const
 {
@@ -10272,7 +10272,7 @@ bool Character::has_activity( const activity_id &type ) const
 
 bool Character::has_activity( const std::vector<activity_id> &types ) const
 {
-    return std::ranges::find( types, activity->id() ) != types.end();
+    return std::ranges::contains( types, activity->id() );
 }
 
 void Character::cancel_activity()

--- a/src/character_display.cpp
+++ b/src/character_display.cpp
@@ -360,7 +360,7 @@ static bool is_cqb_skill( const skill_id &id )
             skill_id( "bashing" ), skill_id( "stabbing" ),
         }
     };
-    return std::ranges::find( cqb_skills, id ) != cqb_skills.end();
+    return std::ranges::contains( cqb_skills, id );
 }
 
 namespace

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -92,7 +92,7 @@ void load_recipe_category( const JsonObject &jsobj )
     }
 
     if( !is_hidden ) {
-        if( std::ranges::find( craft_cat_list, category ) == craft_cat_list.end() ) {
+        if( !std::ranges::contains( craft_cat_list, category ) ) {
             craft_cat_list.push_back( category );
         }
         const std::string cat_name = get_cat_unprefixed( category );

--- a/src/dependency_tree.cpp
+++ b/src/dependency_tree.cpp
@@ -176,7 +176,7 @@ std::vector<dependency_node *> dependency_node::get_dependencies_as_nodes() cons
     for( std::vector<dependency_node *>::reverse_iterator it =
              dependencies.rbegin();
          it != dependencies.rend(); ++it ) {
-        if( std::ranges::find( ret, *it ) == ret.end() ) {
+        if( !std::ranges::contains( ret, *it ) ) {
             ret.push_back( *it );
         }
     }
@@ -232,7 +232,7 @@ std::vector<dependency_node *> dependency_node::get_dependents_as_nodes() const
 
     // sort from front, keeping only one copy of the node
     for( auto &dependent : dependents ) {
-        if( std::ranges::find( ret, dependent ) == ret.end() ) {
+        if( !std::ranges::contains( ret, dependent ) ) {
             ret.push_back( dependent );
         }
     }

--- a/src/diary.cpp
+++ b/src/diary.cpp
@@ -363,7 +363,7 @@ void diary::kill_changes()
             bool flag = true;
             for( const std::string &npc_name : curr_page->npc_kills ) {
 
-                if( ( std::ranges::find( prev_npc_kills, npc_name ) == prev_npc_kills.end() ) ) {
+                if( !std::ranges::contains( prev_npc_kills, npc_name ) ) {
                     if( flag ) {
                         add_to_change_list( _( "NPC killed:" ) );
                         flag = false;

--- a/src/diary.cpp
+++ b/src/diary.cpp
@@ -363,8 +363,7 @@ void diary::kill_changes()
             bool flag = true;
             for( const std::string &npc_name : curr_page->npc_kills ) {
 
-                if( ( std::find( prev_npc_kills.begin(), prev_npc_kills.end(),
-                                 npc_name ) == prev_npc_kills.end() ) ) {
+                if( ( std::ranges::find( prev_npc_kills, npc_name ) == prev_npc_kills.end() ) ) {
                     if( flag ) {
                         add_to_change_list( _( "NPC killed:" ) );
                         flag = false;

--- a/src/dump.cpp
+++ b/src/dump.cpp
@@ -211,7 +211,7 @@ bool game::dump_stats( const std::string &what, dump_mode mode,
         // optionally filter recipes to include only those using specified skills
         recipe_subset dict;
         for( const auto &r : recipe_dict ) {
-            if( opts.empty() || std::any_of( opts.begin(), opts.end(), [&r]( const std::string & s ) {
+            if( opts.empty() || std::ranges::any_of( opts, [&r]( const std::string & s ) {
             if( r.second.skill_used == skill_id( s ) && r.second.difficulty > 0 ) {
                     return true;
                 }
@@ -226,7 +226,7 @@ bool game::dump_stats( const std::string &what, dump_mode mode,
         std::vector<Skill> sk;
         std::copy_if( Skill::skills.begin(), Skill::skills.end(),
         std::back_inserter( sk ), [&dict]( const Skill & s ) {
-            return std::any_of( dict.begin(), dict.end(), [&s]( const recipe * r ) {
+            return std::ranges::any_of( dict, [&s]( const recipe * r ) {
                 return r->skill_used == s.ident() ||
                        r->required_skills.contains( s.ident() );
             } );

--- a/src/font_loader.cpp
+++ b/src/font_loader.cpp
@@ -4,7 +4,7 @@
 
 void ensure_unifont_loaded( std::vector<std::string> &font_list )
 {
-    if( std::ranges::find( font_list, "unifont" ) == font_list.end() ) {
+    if( !std::ranges::contains( font_list, "unifont" ) ) {
         font_list.emplace_back( PATH_INFO::fontdir() + "unifont.ttf" );
     }
 }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -15117,20 +15117,20 @@ bool game::non_dead_range<Creature>::iterator::valid()
 game::monster_range::monster_range( game &game_ref )
 {
     const auto &monsters = game_ref.critter_tracker->get_monsters_list();
-    items.insert( items.end(), monsters.begin(), monsters.end() );
+    items->insert( items->end(), monsters.begin(), monsters.end() );
 }
 
 game::Creature_range::Creature_range( game &game_ref ) : u( &game_ref.u, []( Character * ) { } )
 {
     const auto &monsters = game_ref.critter_tracker->get_monsters_list();
-    items.insert( items.end(), monsters.begin(), monsters.end() );
-    items.insert( items.end(), game_ref.active_npc.begin(), game_ref.active_npc.end() );
-    items.emplace_back( u );
+    items->insert( items->end(), monsters.begin(), monsters.end() );
+    items->insert( items->end(), game_ref.active_npc.begin(), game_ref.active_npc.end() );
+    items->emplace_back( u );
 }
 
 game::npc_range::npc_range( game &game_ref )
 {
-    items.insert( items.end(), game_ref.active_npc.begin(), game_ref.active_npc.end() );
+    items->insert( items->end(), game_ref.active_npc.begin(), game_ref.active_npc.end() );
 }
 
 game::Creature_range game::all_creatures()

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5214,8 +5214,9 @@ void game::monmove()
     // distance is calculated exactly once.  The pair is (dist, monster*) so
     // the default comparator orders by distance first.
     std::vector<std::pair<int, monster *>> eligible;
-    eligible.reserve( all_monsters().items.size() );
-    for( monster &critter : all_monsters() ) {
+    auto monsters = all_monsters();
+    eligible.reserve( monsters.items ? monsters.items->size() : 0 );
+    for( monster &critter : monsters ) {
         if( !critter.is_dead() &&
             !critter.has_effect( effect_ridden ) &&
             critter.moves > 0 &&

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -7750,24 +7750,20 @@ void game::print_items_info( const tripoint &lp, const catacurses::window &w_loo
         }
 
         const int max_width = getmaxx( w_look ) - column - 1;
-        size_t item_index = 0;
-        const size_t item_count = item_names.size();
-        for( const auto &item_entry : item_names ) {
+        for( auto it = item_names.begin(); it != item_names.end(); ++it ) {
             // last line but not last item
-            if( line + 1 >= last_line && item_index + 1 < item_count ) {
+            if( line + 1 >= last_line && std::next( it ) != item_names.end() ) {
                 mvwprintz( w_look, point( column, ++line ), c_yellow, _( "More items here…" ) );
                 break;
             }
 
-            if( item_entry.second.first > 1 ) {
-                trim_and_print( w_look, point( column, ++line ), max_width, item_entry.second.second,
+            if( it->second.first > 1 ) {
+                trim_and_print( w_look, point( column, ++line ), max_width, it->second.second,
                                 pgettext( "%s is the name of the item.  %d is the quantity of that item.", "%s [%d]" ),
-                                item_entry.first.c_str(), item_entry.second.first );
+                                it->first.c_str(), it->second.first );
             } else {
-                trim_and_print( w_look, point( column, ++line ), max_width, item_entry.second.second,
-                                item_entry.first );
+                trim_and_print( w_look, point( column, ++line ), max_width, it->second.second, it->first );
             }
-            ++item_index;
         }
     }
 }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -7749,20 +7749,24 @@ void game::print_items_info( const tripoint &lp, const catacurses::window &w_loo
         }
 
         const int max_width = getmaxx( w_look ) - column - 1;
-        for( auto it = item_names.begin(); it != item_names.end(); ++it ) {
+        size_t item_index = 0;
+        const size_t item_count = item_names.size();
+        for( const auto &item_entry : item_names ) {
             // last line but not last item
-            if( line + 1 >= last_line && std::next( it ) != item_names.end() ) {
+            if( line + 1 >= last_line && item_index + 1 < item_count ) {
                 mvwprintz( w_look, point( column, ++line ), c_yellow, _( "More items here…" ) );
                 break;
             }
 
-            if( it->second.first > 1 ) {
-                trim_and_print( w_look, point( column, ++line ), max_width, it->second.second,
+            if( item_entry.second.first > 1 ) {
+                trim_and_print( w_look, point( column, ++line ), max_width, item_entry.second.second,
                                 pgettext( "%s is the name of the item.  %d is the quantity of that item.", "%s [%d]" ),
-                                it->first.c_str(), it->second.first );
+                                item_entry.first.c_str(), item_entry.second.first );
             } else {
-                trim_and_print( w_look, point( column, ++line ), max_width, it->second.second, it->first );
+                trim_and_print( w_look, point( column, ++line ), max_width, item_entry.second.second,
+                                item_entry.first );
             }
+            ++item_index;
         }
     }
 }
@@ -10667,17 +10671,17 @@ void game::butcher()
     // Split into corpses, disassemble-able, and salvageable items
     // It's not much additional work to just generate a corpse list and
     // clear it later, but does make the splitting process nicer.
-    for( map_stack::iterator it = items.begin(); it != items.end(); ++it ) {
-        if( ( *it )->is_corpse() ) {
-            corpses.push_back( *it );
+    for( item *const current_item : items ) {
+        if( current_item->is_corpse() ) {
+            corpses.push_back( current_item );
         } else {
-            if( salvage::try_salvage( **it, q_cache ).success() ) {
-                salvageables.push_back( *it );
+            if( salvage::try_salvage( *current_item, q_cache ).success() ) {
+                salvageables.push_back( current_item );
             }
-            if( crafting::can_disassemble( u, **it, crafting_inv ).success() ) {
-                disassembles.push_back( *it );
+            if( crafting::can_disassemble( u, *current_item, crafting_inv ).success() ) {
+                disassembles.push_back( current_item );
             } else if( !first_item_without_tools ) {
-                first_item_without_tools = *it;
+                first_item_without_tools = current_item;
             }
         }
     }

--- a/src/game.h
+++ b/src/game.h
@@ -392,50 +392,77 @@ class game : public submap_load_listener
         friend class Creature_range;
 
         template<typename T>
-        class non_dead_range
+        class non_dead_range : public std::ranges::view_interface<non_dead_range<T>>
         {
             public:
-                std::vector<weak_ptr_fast<T>> items;
+                std::shared_ptr<std::vector<weak_ptr_fast<T>>> items;
+                non_dead_range() : items( std::make_shared<std::vector<weak_ptr_fast<T>>>() ) {}
 
                 class iterator
                 {
                     private:
-                        bool valid();
-                    public:
-                        std::vector<weak_ptr_fast<T>> &items;
+                        std::shared_ptr<std::vector<weak_ptr_fast<T>>> data_ref;
                         typename std::vector<weak_ptr_fast<T>>::iterator iter;
+
+                        auto valid() -> bool;
+
+                    public:
+                        using value_type = T;
+                        using difference_type = std::ptrdiff_t;
+                        using pointer = T *;
+                        using reference = T &;
+                        using iterator_category = std::forward_iterator_tag;
+                        using iterator_concept = std::forward_iterator_tag;
+
                         shared_ptr_fast<T> current;
 
-                        iterator( std::vector<weak_ptr_fast<T>> &i,
-                                  const typename std::vector<weak_ptr_fast<T>>::iterator t ) : items( i ), iter( t ) {
-                            while( iter != items.end() && !valid() ) {
-                                ++iter;
+                        iterator() = default;
+
+                        iterator( std::shared_ptr<std::vector<weak_ptr_fast<T>>> ref,
+                                  typename std::vector<weak_ptr_fast<T>>::iterator t )
+                            : data_ref( std::move( ref ) ), iter( t ) {
+                            if( data_ref ) {
+                                while( iter != data_ref->end() && !valid() ) {
+                                    ++iter;
+                                }
                             }
                         }
+
                         iterator( const iterator & ) = default;
                         iterator &operator=( const iterator & ) = default;
 
-                        bool operator==( const iterator &rhs ) const {
+                        auto operator==( const iterator &rhs ) const -> bool {
                             return iter == rhs.iter;
                         }
-                        bool operator!=( const iterator &rhs ) const {
-                            return !operator==( rhs );
-                        }
-                        iterator &operator++() {
+
+                        auto operator++() -> iterator& { // *NOPAD*
+                            if( !data_ref ) { return *this; }
+
                             do {
                                 ++iter;
-                            } while( iter != items.end() && !valid() );
+                            } while( iter != data_ref->end() && !valid() );
                             return *this;
                         }
-                        T &operator*() const {
+
+                        auto operator++( int ) -> iterator {
+                            auto tmp = *this;
+                            ++( *this );
+                            return tmp;
+                        }
+
+                        auto operator*() const -> reference {
                             return *current;
                         }
                 };
-                iterator begin() {
-                    return iterator( items, items.begin() );
+
+                auto begin() -> iterator {
+                    if( !items ) { return end(); }
+                    return iterator( items, items->begin() );
                 }
-                iterator end() {
-                    return iterator( items, items.end() );
+
+                auto end() -> iterator {
+                    if( !items ) { return iterator(); }
+                    return iterator( items, items->end() );
                 }
         };
 

--- a/src/game.h
+++ b/src/game.h
@@ -10,6 +10,7 @@
 #include <map>
 #include <memory>
 #include <optional>
+#include <ranges>
 #include <set>
 #include <shared_mutex>
 #include <string>

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -493,7 +493,7 @@ static void pldrive( const tripoint &p )
             return;
         }
     } else {
-        if( empty( veh->get_avail_parts( "REMOTE_CONTROLS" ) ) ) {
+        if( veh->get_avail_parts( "REMOTE_CONTROLS" ).empty() ) {
             add_msg( m_info, _( "Can't drive this vehicle remotely.  It has no working controls." ) );
             return;
         }

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -2793,7 +2793,7 @@ itype_id iexamine::choose_fertilizer( player &p, const std::string &pname, bool 
     std::vector<itype_id> f_types;
     std::vector<std::string> f_names;
     for( auto &f : f_inv ) {
-        if( std::ranges::find( f_types, f->typeId() ) == f_types.end() ) {
+        if( !std::ranges::contains( f_types, f->typeId() ) ) {
             f_types.push_back( f->typeId() );
             f_names.push_back( f->tname() );
         }
@@ -3324,7 +3324,7 @@ void iexamine::fvat_empty( player &p, const tripoint &examp )
         std::vector<itype_id> b_types;
         std::vector<std::string> b_names;
         for( auto &b : b_inv ) {
-            if( std::ranges::find( b_types, b->typeId() ) == b_types.end() ) {
+            if( !std::ranges::contains( b_types, b->typeId() ) ) {
                 b_types.push_back( b->typeId() );
                 b_names.push_back( item::nname( b->typeId() ) );
             }

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -4500,22 +4500,19 @@ void iexamine::recycle_compactor( player &, const tripoint &examp )
     sounds::sound( examp, 80, sounds::sound_t::combat, _( "Ka-klunk!" ), true, "tool", "compactor" );
     bool out_desired = false;
     bool out_any = false;
-    auto is_first_output = true;
-    for( const itype_id &compact_to : m.compacts_into() | std::views::drop( o_idx ) ) {
-        const units::mass ow = item::spawn_temporary( compact_to, calendar::start_of_cataclysm,
-                               item::solitary_tag{} )->weight();
+    for( auto it = m.compacts_into().begin() + o_idx; it != m.compacts_into().end(); ++it ) {
+        const units::mass ow = item::spawn_temporary( *it, calendar::start_of_cataclysm, item::solitary_tag{} )->weight();
         int count = sum_weight / ow;
         sum_weight -= count * ow;
         if( count > 0 ) {
-            here.spawn_item( examp, compact_to, count, 1, calendar::turn );
+            here.spawn_item( examp, *it, count, 1, calendar::turn );
             if( !out_any ) {
                 out_any = true;
-                if( is_first_output ) {
+                if( it == m.compacts_into().begin() + o_idx ) {
                     out_desired = true;
                 }
             }
         }
-        is_first_output = false;
     }
 
     // feedback to user

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -4500,19 +4500,22 @@ void iexamine::recycle_compactor( player &, const tripoint &examp )
     sounds::sound( examp, 80, sounds::sound_t::combat, _( "Ka-klunk!" ), true, "tool", "compactor" );
     bool out_desired = false;
     bool out_any = false;
-    for( auto it = m.compacts_into().begin() + o_idx; it != m.compacts_into().end(); ++it ) {
-        const units::mass ow = item::spawn_temporary( *it, calendar::start_of_cataclysm, item::solitary_tag{} )->weight();
+    auto is_first_output = true;
+    for( const itype_id &compact_to : m.compacts_into() | std::views::drop( o_idx ) ) {
+        const units::mass ow = item::spawn_temporary( compact_to, calendar::start_of_cataclysm,
+                               item::solitary_tag{} )->weight();
         int count = sum_weight / ow;
         sum_weight -= count * ow;
         if( count > 0 ) {
-            here.spawn_item( examp, *it, count, 1, calendar::turn );
+            here.spawn_item( examp, compact_to, count, 1, calendar::turn );
             if( !out_any ) {
                 out_any = true;
-                if( it == m.compacts_into().begin() + o_idx ) {
+                if( is_first_output ) {
                     out_desired = true;
                 }
             }
         }
+        is_first_output = false;
     }
 
     // feedback to user

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -1135,7 +1135,7 @@ void inventory::assign_empty_invlet( item &it, const Character &p, const bool fo
                 // don't overwrite assigned keys
                 continue;
             }
-            if( std::ranges::find( binds, inv_char ) != binds.end() ) {
+            if( std::ranges::contains( binds, inv_char ) ) {
                 // don't auto-assign bound keys
                 continue;
             }

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -373,7 +373,8 @@ void inventory::restack( player &p )
     items_type_cached = false;
     std::vector<item *> to_restack;
     int idx = 0;
-    std::ranges::for_each( items, [&]( std::vector<item *> &stack ) {
+    for( invstack::iterator iter = items.begin(); iter != items.end(); ++iter, ++idx ) {
+        std::vector<item *> &stack = *iter;
         // Sort the inner stack itself, so the most recently used item is at front and keeps the invlet
         std::ranges::sort( stack, []( auto * lhs, auto * rhs ) {
             return *lhs < *rhs;
@@ -390,17 +391,16 @@ void inventory::restack( player &p )
         }
         // remove non-matching items, stripping off end of stack so the first item keeps the invlet.
         while( stack.size() > 1 && !topmost.stacks_with( *stack.back() ) ) {
-            to_restack.push_back( stack.back() );
-            stack.pop_back();
+            to_restack.push_back( iter->back() );
+            iter->pop_back();
         }
-        ++idx;
-    } );
+    }
 
     // combine matching stacks
     // separate loop to ensure that ALL stacks are homogeneous
-    for( auto iter = items.begin(); iter != items.end(); iter = std::next( iter ) ) {
-        for( auto other = std::next( iter ); other != items.end(); ) {
-            if( iter->front()->stacks_with( *other->front() ) ) {
+    for( invstack::iterator iter = items.begin(); iter != items.end(); ++iter ) {
+        for( invstack::iterator other = iter; other != items.end(); ++other ) {
+            if( iter != other && iter->front()->stacks_with( *other->front() ) ) {
                 if( other->front()->count_by_charges() ) {
                     iter->front()->charges += other->front()->charges;
                 } else {
@@ -409,8 +409,7 @@ void inventory::restack( player &p )
                     }
                 }
                 other = items.erase( other );
-            } else {
-                other = std::next( other );
+                --other;
             }
         }
     }
@@ -627,29 +626,29 @@ void inventory::form_from_map( map &m, std::vector<tripoint> pts, const Characte
 std::vector<detached_ptr<item>> location_inventory::reduce_stack( const int position,
                              const int quantity )
 {
+    int pos = 0;
     std::vector<detached_ptr<item>> ret;
-    auto pos = 0;
-    const auto iter = std::ranges::find_if( inv.items, [&position,
-    &pos]( const std::vector<item *> & ) {
-        return position == pos++;
-    } );
-    if( iter != inv.items.end() ) {
-        inv.binned = false;
-        inv.items_type_cached = false;
-        if( quantity >= static_cast<int>( iter->size() ) || quantity < 0 ) {
-            std::vector<item *> stack = *iter;
-            inv.items.erase( iter );
-            for( item *&it : stack ) {
-                it->remove_location();
-                ret.push_back( detached_ptr<item>( it ) );
+    for( invstack::iterator iter = inv.items.begin(); iter != inv.items.end(); ++iter ) {
+        if( position == pos ) {
+            inv.binned = false;
+            inv.items_type_cached = false;
+            if( quantity >= static_cast<int>( iter->size() ) || quantity < 0 ) {
+                std::vector<item *> stack = *iter;
+                inv.items.erase( iter );
+                for( item *&it : stack ) {
+                    it->remove_location();
+                    ret.push_back( detached_ptr<item>( it ) );
+                }
+            } else {
+                for( int i = 0 ; i < quantity ; i++ ) {
+                    item *it = &inv.remove_item( iter->front() );
+                    it->remove_location();
+                    ret.push_back( detached_ptr<item>( it ) );
+                }
             }
-        } else {
-            for( int i = 0 ; i < quantity ; i++ ) {
-                item *it = &inv.remove_item( iter->front() );
-                it->remove_location();
-                ret.push_back( detached_ptr<item>( it ) );
-            }
+            break;
         }
+        ++pos;
     }
     return ret;
 }
@@ -670,25 +669,25 @@ item &inventory::remove_item( const item *it )
 
 item &inventory::remove_item( const int position )
 {
-    auto pos = 0;
-    const auto iter = std::ranges::find_if( items, [&position, &pos]( const std::vector<item *> & ) {
-        return position == pos++;
-    } );
-    if( iter != items.end() ) {
-        binned = false;
-        items_type_cached = false;
-        if( iter->size() > 1 ) {
-            std::vector<item *>::iterator stack_member = iter->begin();
-            char invlet = ( *stack_member )->invlet;
-            ++stack_member;
-            ( *stack_member )->invlet = invlet;
+    int pos = 0;
+    for( invstack::iterator iter = items.begin(); iter != items.end(); ++iter ) {
+        if( position == pos ) {
+            binned = false;
+            items_type_cached = false;
+            if( iter->size() > 1 ) {
+                std::vector<item *>::iterator stack_member = iter->begin();
+                char invlet = ( *stack_member )->invlet;
+                ++stack_member;
+                ( *stack_member )->invlet = invlet;
+            }
+            item &ret = *iter->front();
+            iter->erase( iter->begin() );
+            if( iter->empty() ) {
+                items.erase( iter );
+            }
+            return ret;
         }
-        item &ret = *iter->front();
-        iter->erase( iter->begin() );
-        if( iter->empty() ) {
-            items.erase( iter );
-        }
-        return ret;
+        ++pos;
     }
 
     return null_item_reference();

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -9,6 +9,7 @@
 #include <iterator>
 #include <memory>
 #include <optional>
+#include <ranges>
 #include <unordered_set>
 
 #include "avatar.h"
@@ -669,28 +670,25 @@ item &inventory::remove_item( const item *it )
 
 item &inventory::remove_item( const int position )
 {
-    int pos = 0;
-    for( invstack::iterator iter = items.begin(); iter != items.end(); ++iter ) {
-        if( position == pos ) {
-            binned = false;
-            items_type_cached = false;
-            if( iter->size() > 1 ) {
-                std::vector<item *>::iterator stack_member = iter->begin();
-                char invlet = ( *stack_member )->invlet;
-                ++stack_member;
-                ( *stack_member )->invlet = invlet;
-            }
-            item &ret = *iter->front();
-            iter->erase( iter->begin() );
-            if( iter->empty() ) {
-                items.erase( iter );
-            }
-            return ret;
-        }
-        ++pos;
+    if( position < 0 || static_cast<size_t>( position ) >= items.size() ) {
+        return null_item_reference();
     }
 
-    return null_item_reference();
+    const auto iter = std::ranges::next( std::ranges::begin( items ), position );
+    binned = false;
+    items_type_cached = false;
+    if( iter->size() > 1 ) {
+        std::vector<item *>::iterator stack_member = iter->begin();
+        char invlet = ( *stack_member )->invlet;
+        ++stack_member;
+        ( *stack_member )->invlet = invlet;
+    }
+    item &ret = *iter->front();
+    iter->erase( iter->begin() );
+    if( iter->empty() ) {
+        items.erase( iter );
+    }
+    return ret;
 }
 
 std::vector<detached_ptr<item>> location_inventory::remove_randomly_by_volume(

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -204,7 +204,7 @@ const item_category *inventory_entry::get_category_ptr() const
 
 bool inventory_column::activatable() const
 {
-    return std::any_of( entries.begin(), entries.end(), []( const inventory_entry & e ) {
+    return std::ranges::any_of( entries, []( const inventory_entry & e ) {
         return e.is_selectable();
     } );
 }

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -794,15 +794,13 @@ void inventory_column::prepare_paging( const std::string &filter )
     }
     // Recover categories
     const item_category *current_category = nullptr;
-    for( size_t index = 0; index < entries.size(); ++index ) {
-        if( entries[index].get_category_ptr() == current_category ) {
+    for( auto iter = entries.begin(); iter != entries.end(); ++iter ) {
+        if( iter->get_category_ptr() == current_category ) {
             continue;
         }
-        current_category = entries[index].get_category_ptr();
-        entries.insert( entries.begin() + static_cast<ptrdiff_t>( index ),
-                        inventory_entry( current_category ) );
-        expand_to_fit( entries[index] );
-        ++index;
+        current_category = iter->get_category_ptr();
+        iter = entries.insert( iter, inventory_entry( current_category ) );
+        expand_to_fit( *iter );
     }
     // Determine the new height.
     entries_per_page = height;
@@ -1077,19 +1075,18 @@ static std::vector<std::list<item *>> restack_items( const item_stack::const_ite
 {
     std::vector<std::list<item *>> res;
 
-    std::ranges::for_each( std::ranges::subrange( from, to ),
-    [&res, check_components]( item * const current_item ) {
+    for( auto it = from; it != to; ++it ) {
         auto match = std::find_if( res.begin(), res.end(),
-        [ current_item, check_components ]( const std::list<item *> &e ) {
-            return current_item->display_stacked_with( *const_cast<item *>( e.back() ), check_components );
+        [ &it, check_components ]( const std::list<item *> &e ) {
+            return ( *it )->display_stacked_with( *const_cast<item *>( e.back() ), check_components );
         } );
 
         if( match != res.end() ) {
-            match->push_back( current_item );
+            match->push_back( const_cast<item *>( *it ) );
         } else {
-            res.emplace_back( 1, current_item );
+            res.emplace_back( 1, const_cast<item *>( *it ) );
         }
-    } );
+    }
 
     return res;
 }
@@ -1100,19 +1097,18 @@ static std::vector<std::list<item *>> restack_items( const std::vector<item *>::
 {
     std::vector<std::list<item *>> res;
 
-    std::ranges::for_each( std::ranges::subrange( from, to ),
-    [&res, check_components]( item * const current_item ) {
+    for( auto it = from; it != to; ++it ) {
         auto match = std::find_if( res.begin(), res.end(),
-        [ current_item, check_components ]( const std::list<item *> &e ) {
-            return current_item->display_stacked_with( *const_cast<item *>( e.back() ), check_components );
+        [ &it, check_components ]( const std::list<item *> &e ) {
+            return ( *it )->display_stacked_with( *const_cast<item *>( e.back() ), check_components );
         } );
 
         if( match != res.end() ) {
-            match->push_back( current_item );
+            match->push_back( const_cast<item *>( *it ) );
         } else {
-            res.emplace_back( 1, current_item );
+            res.emplace_back( 1, const_cast<item *>( *it ) );
         }
-    } );
+    }
 
     return res;
 }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -8879,12 +8879,13 @@ void item::gun_cycle_mode()
     const gun_mode_id cur = gun_get_mode_id();
     const std::map<gun_mode_id, gun_mode> modes = gun_all_modes();
 
-    for( auto iter = modes.begin(); iter != modes.end(); ++iter ) {
-        if( iter->first == cur ) {
-            if( std::next( iter ) == modes.end() ) {
-                break;
-            }
-            gun_set_mode( std::next( iter )->first );
+    const auto current_mode = std::ranges::find( modes, cur, []( const auto & pair ) {
+        return pair.first;
+    } );
+    if( current_mode != modes.end() ) {
+        const auto next_mode = std::next( current_mode );
+        if( next_mode != modes.end() ) {
+            gun_set_mode( next_mode->first );
             return;
         }
     }
@@ -11456,12 +11457,11 @@ std::vector<detached_ptr<item>> item::remove_components()
 
 detached_ptr<item> item::remove_component( item &it )
 {
-    for( auto iter = components.begin(); iter != components.end(); iter++ ) {
-        if( *iter == &it ) {
-            detached_ptr<item> ret;
-            components.erase( iter, &ret );
-            return ret;
-        }
+    const auto iter = std::ranges::find( components, &it );
+    if( iter != components.end() ) {
+        detached_ptr<item> ret;
+        components.erase( iter, &ret );
+        return ret;
     }
     debugmsg( "Could not find component for removal" );
     return detached_ptr<item>();

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -7279,7 +7279,7 @@ bool item::only_made_of( const std::set<material_id> &mat_idents ) const
 bool item::made_of( const material_id &mat_ident ) const
 {
     const std::vector<material_id> &materials = made_of();
-    return std::ranges::find( materials, mat_ident ) != materials.end();
+    return std::ranges::contains( materials, mat_ident );
 }
 
 bool item::contents_made_of( const phase_id phase ) const
@@ -10956,7 +10956,7 @@ bool item::has_effect_when_wielded( art_effect_passive effect ) const
         return false;
     }
     const std::vector<art_effect_passive> &ew = type->artifact->effects_wielded;
-    return std::ranges::find( ew, effect ) != ew.end();
+    return std::ranges::contains( ew, effect );
 }
 
 bool item::has_effect_when_worn( art_effect_passive effect ) const
@@ -10965,7 +10965,7 @@ bool item::has_effect_when_worn( art_effect_passive effect ) const
         return false;
     }
     const std::vector<art_effect_passive> &ew = type->artifact->effects_worn;
-    return std::ranges::find( ew, effect ) != ew.end();
+    return std::ranges::contains( ew, effect );
 }
 
 bool item::has_effect_when_carried( art_effect_passive effect ) const
@@ -10974,7 +10974,7 @@ bool item::has_effect_when_carried( art_effect_passive effect ) const
         return false;
     }
     const std::vector<art_effect_passive> &ec = type->artifact->effects_carried;
-    if( std::ranges::find( ec, effect ) != ec.end() ) {
+    if( std::ranges::contains( ec, effect ) ) {
         return true;
     }
     for( const item *i : contents.all_items_top() ) {

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -53,7 +53,7 @@ detached_ptr<item> Single_item_creator::create_single( const time_point &birthda
             tmp = item::spawn( id, birthday );
         }
     } else if( type == S_ITEM_GROUP ) {
-        if( std::ranges::find( rec, id ) != rec.end() ) {
+        if( std::ranges::contains( rec, id ) ) {
             debugmsg( "recursion in item spawn list %s", id.c_str() );
             return detached_ptr<item>();
         }
@@ -97,7 +97,7 @@ std::vector<detached_ptr<item>> Single_item_creator::create( const time_point &b
                 result.push_back( std::move( itm ) );
             }
         } else {
-            if( std::ranges::find( rec, id ) != rec.end() ) {
+            if( std::ranges::contains( rec, id ) ) {
                 debugmsg( "recursion in item spawn list %s", id.c_str() );
                 return result;
             }

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -7201,7 +7201,7 @@ int iuse::camera( player *p, item *it, bool, const tripoint & )
                               e.c_str() );
                 }
 
-                const bool selfie = std::ranges::find( player_vec, p ) != player_vec.end();
+                const bool selfie = std::ranges::contains( player_vec, p );
 
                 if( selfie ) {
                     p->add_msg_if_player( _( "You took a selfie." ) );

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -5574,7 +5574,10 @@ auto get_hackable_friendly_monsters( game &game_ref ) -> std::vector<shared_ptr_
     auto monsters = game_ref.all_monsters();
     auto &items = monsters.items;
     auto results = std::vector<shared_ptr_fast<monster>> {};
-    std::ranges::for_each( items, [&]( const auto & weak_monster ) {
+    if( !items ) {
+        return results;
+    }
+    std::ranges::for_each( *items, [&]( const auto & weak_monster ) {
         auto current = weak_monster.lock();
         if( !current || current->is_dead() ) {
             return;

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -7743,7 +7743,7 @@ static bool hackveh( player &p, item &it, vehicle &veh )
     if( !veh.is_locked || !veh.has_security_working() ) {
         return true;
     }
-    const bool advanced = !empty( veh.get_avail_parts( "REMOTE_CONTROLS" ) );
+    const auto advanced = !veh.get_avail_parts( "REMOTE_CONTROLS" ).empty();
     if( advanced && veh.is_alarm_on ) {
         p.add_msg_if_player( m_bad, _( "This vehicle's security system has locked you out!" ) );
         return false;
@@ -7806,8 +7806,8 @@ static vehicle *pickveh( const tripoint &center, bool advanced )
         auto &v = veh.v;
         if( rl_dist( center, v->global_pos3() ) < 40 &&
             v->fuel_left( itype_battery, true ) > 0 &&
-            ( !empty( v->get_avail_parts( advctrl ) ) ||
-              ( !advanced && !empty( v->get_avail_parts( ctrl ) ) ) ) ) {
+            ( !v->get_avail_parts( advctrl ).empty() ||
+              ( !advanced && !v->get_avail_parts( ctrl ).empty() ) ) ) {
             vehs.push_back( v );
         }
     }
@@ -7901,7 +7901,7 @@ int iuse::remoteveh( player *p, item *it, bool t, const tripoint &pos )
     } else if( choice == 1 ) {
         const auto rctrl_parts = veh->get_avail_parts( "REMOTE_CONTROLS" );
         // Revert to original behavior if we can't find remote controls.
-        if( empty( rctrl_parts ) ) {
+        if( rctrl_parts.empty() ) {
             veh->use_controls( pos );
         } else {
             veh->use_controls( rctrl_parts.begin()->pos() );

--- a/src/language.cpp
+++ b/src/language.cpp
@@ -235,7 +235,7 @@ static std::vector<language_info> load_languages( const std::string &filepath )
 
     for( language_info &info : ret ) {
         for( const std::string &g : info.genders ) {
-            if( std::ranges::find( all_genders, g ) == all_genders.end() ) {
+            if( !std::ranges::contains( all_genders, g ) ) {
                 debugmsg( "Unexpected gender '%s' in grammatical gender list for language '%d'",
                           g, info.id );
             }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -5980,15 +5980,14 @@ void map::process_items_in_vehicle( vehicle &cur_veh, submap &current_submap )
     }
 
     for( item *active_item_ref : cur_veh.active_items.get_for_processing() ) {
-        if( empty( cargo_parts ) ) {
+        if( cargo_parts.empty() ) {
             return;
         }
-        const auto it = std::find_if( begin( cargo_parts ),
-        end( cargo_parts ), [&]( const vpart_reference & part ) {
+        const auto it = std::ranges::find_if( cargo_parts, [&]( const vpart_reference & part ) {
             return active_item_ref->position() == cur_veh.mount_to_tripoint( part.mount() );
         } );
 
-        if( it == end( cargo_parts ) ) {
+        if( it == cargo_parts.end() ) {
             continue; // Can't find a cargo part matching the active item.
         }
         const item &target = *active_item_ref;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1619,15 +1619,17 @@ bool map::deregister_vehicle_zone( zone_data &zone )
 {
     if( const std::optional<vpart_reference> vp = veh_at( getlocal(
                 zone.get_start_point() ) ).part_with_feature( "CARGO", false ) ) {
-        auto bounds = vp->vehicle().loot_zones.equal_range( vp->mount() );
-        for( auto it = bounds.first; it != bounds.second; it++ ) {
-            if( &zone == &( it->second ) ) {
-                vp->vehicle().loot_zones.erase( it );
-                if( vp->vehicle().loot_zones.empty() ) {
-                    get_cache( vp->vehicle().sm_pos.z ).zone_vehicles.erase( &vp->vehicle() );
-                }
-                return true;
+        const auto bounds = vp->vehicle().loot_zones.equal_range( vp->mount() );
+        const auto it = std::ranges::find_if( std::ranges::subrange( bounds.first, bounds.second ),
+        [&zone]( const auto & entry ) {
+            return &zone == &entry.second;
+        } );
+        if( it != bounds.second ) {
+            vp->vehicle().loot_zones.erase( it );
+            if( vp->vehicle().loot_zones.empty() ) {
+                get_cache( vp->vehicle().sm_pos.z ).zone_vehicles.erase( &vp->vehicle() );
             }
+            return true;
         }
     }
     return false;

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -6600,7 +6600,7 @@ std::unique_ptr<vehicle> map::add_vehicle_to_map(
     //Check for boat type vehicles that should be placeable in deep water
     //WARNING: CURSED CODE
     //If changed to veh->can_float mass calculations are messed up
-    const bool can_float = size( veh->get_avail_parts( "FLOATS" ) ) >= 1;
+    const bool can_float = std::ranges::distance( veh->get_avail_parts( "FLOATS" ) ) >= 1;
 
     //When hitting a wall, only smash the vehicle once (but walls many times)
     bool needs_smashing = false;

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -6600,7 +6600,7 @@ std::unique_ptr<vehicle> map::add_vehicle_to_map(
     //Check for boat type vehicles that should be placeable in deep water
     //WARNING: CURSED CODE
     //If changed to veh->can_float mass calculations are messed up
-    const bool can_float = std::ranges::distance( veh->get_avail_parts( "FLOATS" ) ) >= 1;
+    const bool can_float = !veh->get_avail_parts( "FLOATS" ).empty();
 
     //When hitting a wall, only smash the vehicle once (but walls many times)
     bool needs_smashing = false;

--- a/src/missiondef.cpp
+++ b/src/missiondef.cpp
@@ -467,7 +467,7 @@ mission_type_id mission_type::get_random_id( const mission_origin origin,
 {
     std::vector<mission_type_id> valid;
     for( auto &t : get_all() ) {
-        if( std::ranges::find( t.origins, origin ) == t.origins.end() ) {
+        if( !std::ranges::contains( t.origins, origin ) ) {
             continue;
         }
         if( t.place( p ) ) {

--- a/src/mod_manager.cpp
+++ b/src/mod_manager.cpp
@@ -457,7 +457,7 @@ void mod_manager::load_mods_list( WORLDINFO *world ) const
     read_from_file_json( get_mods_list_file( world ), [&]( JsonIn & jsin ) {
         for( const std::string line : jsin.get_array() ) {
             const mod_id mod( line );
-            if( std::ranges::find( amo, mod ) != amo.end() ) {
+            if( std::ranges::contains( amo, mod ) ) {
                 continue;
             }
             const auto iter = mod_replacements.find( mod );

--- a/src/mod_manager.cpp
+++ b/src/mod_manager.cpp
@@ -457,7 +457,7 @@ void mod_manager::load_mods_list( WORLDINFO *world ) const
     read_from_file_json( get_mods_list_file( world ), [&]( JsonIn & jsin ) {
         for( const std::string line : jsin.get_array() ) {
             const mod_id mod( line );
-            if( std::find( amo.begin(), amo.end(), mod ) != amo.end() ) {
+            if( std::ranges::find( amo, mod ) != amo.end() ) {
                 continue;
             }
             const auto iter = mod_replacements.find( mod );

--- a/src/mod_manager_ui.cpp
+++ b/src/mod_manager_ui.cpp
@@ -166,7 +166,7 @@ static void check_conflicts( const mod_id &mod, const std::vector<mod_id> &activ
 
 ret_val<bool> mod_ui::try_add( const mod_id &mod_to_add, std::vector<mod_id> &active_list )
 {
-    if( std::ranges::find( active_list, mod_to_add ) != active_list.end() ) {
+    if( std::ranges::contains( active_list, mod_to_add ) ) {
         // The same mod can not be added twice. That makes no sense.
         return ret_val<bool>::make_failure( _( "The mod is already on the list." ) );
     }
@@ -212,7 +212,7 @@ ret_val<bool> mod_ui::try_add( const mod_id &mod_to_add, std::vector<mod_id> &ac
         std::vector<mod_id> mods_to_add;
         bool new_core = false;
         for( auto &i : dependencies ) {
-            if( std::ranges::find( active_list, i ) == active_list.end() ) {
+            if( !std::ranges::contains( active_list, i ) ) {
                 if( i->core ) {
                     mods_to_add.insert( mods_to_add.begin(), i );
                     new_core = true;
@@ -326,7 +326,7 @@ bool mod_ui::can_shift_up( size_t selection, const std::vector<mod_id> &active_l
 
     mod_id newsel_id = active_list[newsel];
     bool newsel_is_dependency =
-        std::ranges::find( dependencies, newsel_id ) != dependencies.end();
+        std::ranges::contains( dependencies, newsel_id );
 
     return !newsel_id->core && !newsel_is_dependency;
 }
@@ -351,7 +351,7 @@ bool mod_ui::can_shift_down( size_t selection, const std::vector<mod_id> &active
     mod_id modstring = active_list[newsel];
     mod_id selstring = active_list[oldsel];
     bool sel_is_dependency =
-        std::ranges::find( dependents, selstring ) != dependents.end();
+        std::ranges::contains( dependents, selstring );
 
     return !modstring->core && !sel_is_dependency;
 }

--- a/src/mtype.cpp
+++ b/src/mtype.cpp
@@ -89,7 +89,7 @@ void mtype::set_flag( m_flag flag, bool state )
 
 bool mtype::made_of( const material_id &material ) const
 {
-    return std::ranges::find( mat,  material ) != mat.end();
+    return std::ranges::contains( mat,  material );
 }
 
 bool mtype::made_of_any( const std::set<material_id> &materials ) const

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -1216,7 +1216,7 @@ bool Character::mutate_towards( const trait_id &mut )
 
     // Check mutations of the same type - except for the ones we might need for pre-reqs
     for( const auto &consider : same_type ) {
-        if( std::ranges::find( all_prereqs, consider ) == all_prereqs.end() ) {
+        if( !std::ranges::contains( all_prereqs, consider ) ) {
             cancel.push_back( consider );
         }
     }
@@ -1842,7 +1842,7 @@ bool are_same_type_traits( const trait_id &trait_a, const trait_id &trait_b )
 
 bool contains_trait( std::vector<string_id<mutation_branch>> traits, const trait_id &trait )
 {
-    return std::ranges::find( traits, trait ) != traits.end();
+    return std::ranges::contains( traits, trait );
 }
 
 bool can_use_mutation( const trait_id &mut, const Character &character )

--- a/src/npctalk_funcs.cpp
+++ b/src/npctalk_funcs.cpp
@@ -428,7 +428,7 @@ void talk_function::bionic_remove( npc &p )
     std::vector<itype_id> bionic_types;
     std::vector<std::string> bionic_names;
     for( const bionic &bio : all_bio ) {
-        if( std::ranges::find( bionic_types, bio.info().itype() ) == bionic_types.end() ) {
+        if( !std::ranges::contains( bionic_types, bio.info().itype() ) ) {
             bionic_types.push_back( bio.info().itype() );
             if( bio.info().itype().is_valid() ) {
                 item *tmp = item::spawn_temporary( bio.id.str(), calendar::start_of_cataclysm );

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1112,7 +1112,7 @@ std::vector<options_manager::id_and_option> options_manager::build_tilesets_list
     std::vector<options_manager::id_and_option> user_tilesets = load_tilesets_from(
                 PATH_INFO::user_gfx() );
     for( const options_manager::id_and_option &id : user_tilesets ) {
-        if( std::ranges::find( result, id ) == result.end() ) {
+        if( !std::ranges::contains( result, id ) ) {
             result.emplace_back( id );
         }
     }

--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -669,7 +669,7 @@ bool player_activity::can_resume_with( const player_activity &other, const Chara
             return false;
         }
         for( int foo : other.values ) {
-            if( std::ranges::find( values, foo ) == values.end() ) {
+            if( !std::ranges::contains( values, foo ) ) {
                 return false;
             }
         }

--- a/src/profession.cpp
+++ b/src/profession.cpp
@@ -768,7 +768,7 @@ bool json_item_substitution::trait_requirements::meets_condition( const std::vec
         &traits ) const
 {
     const auto pred = [&traits]( const trait_id & s ) {
-        return std::ranges::find( traits, s ) != traits.end();
+        return std::ranges::contains( traits, s );
     };
     return std::ranges::all_of( present, pred ) &&
            std::ranges::none_of( absent, pred );

--- a/src/rect_range.h
+++ b/src/rect_range.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cassert>
 #include <ranges>
 
 #include "point.h"
@@ -26,7 +27,13 @@ class rect_range : public std::ranges::view_interface<rect_range<RectType>>
                 int width = 0;
                 int height = 0;
                 int count_x = 0;
+                int range_size = 0;
                 int index = 0;
+
+                auto same_range( const iterator &rhs ) const -> bool {
+                    return width == rhs.width && height == rhs.height &&
+                           count_x == rhs.count_x && range_size == rhs.range_size;
+                }
 
             public:
                 using value_type = RectType;
@@ -43,26 +50,36 @@ class rect_range : public std::ranges::view_interface<rect_range<RectType>>
                         width = r->width;
                         height = r->height;
                         count_x = r->count.x;
+                        range_size = r->count.x * r->count.y;
                     }
                 }
 
-                auto operator==( const iterator &rhs ) const -> bool {
-                    return index == rhs.index;
-                }
-
-                auto operator<=>( const iterator &rhs ) const { return index <=> rhs.index; } // *NOPAD*
+                auto operator==( const iterator &rhs ) const -> bool = default;
+                auto operator<=>( const iterator &rhs ) const = default; // *NOPAD*
 
                 auto operator*() const -> reference {
                     return { ( index % count_x ) *width, ( index / count_x ) *height, width, height };
                 }
 
                 auto operator+( const int offset ) const -> iterator {
-                    iterator tmp = *this;
+                    auto tmp = *this;
                     tmp.index += offset;
                     return tmp;
                 }
 
+                auto operator-( const int offset ) const -> iterator {
+                    auto tmp = *this;
+                    tmp.index -= offset;
+                    return tmp;
+                }
+
+                friend auto operator+( const difference_type offset, iterator it ) -> iterator {
+                    it += offset;
+                    return it;
+                }
+
                 auto operator-( const iterator &rhs ) const -> difference_type {
+                    assert( same_range( rhs ) );
                     return index - rhs.index;
                 }
 
@@ -111,5 +128,3 @@ class rect_range : public std::ranges::view_interface<rect_range<RectType>>
             return iterator( this, count.x * count.y );
         }
 };
-
-

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -486,7 +486,7 @@ bool scenario::has_flag( const std::string &flag ) const
 bool scenario::allowed_start( const start_location_id &loc ) const
 {
     auto &vec = _allowed_locs;
-    return std::ranges::find( vec, loc ) != vec.end();
+    return std::ranges::contains( vec, loc );
 }
 
 bool scenario::can_pick( const scenario &current_scenario, const int points ) const

--- a/src/start_location.cpp
+++ b/src/start_location.cpp
@@ -122,7 +122,7 @@ static void add_boardable( const map &m, const tripoint &p, std::vector<tripoint
         // Don't board up the outside
         return;
     }
-    if( std::ranges::find( vec, p ) != vec.end() ) {
+    if( std::ranges::contains( vec, p ) ) {
         // Already registered to be boarded
         return;
     }
@@ -164,7 +164,7 @@ static void board_up( map &m, const tripoint_range<tripoint> &range )
     }
     // Find all furniture that can be used to board up some place
     for( const tripoint &p : range ) {
-        if( std::ranges::find( boardables, p ) != boardables.end() ) {
+        if( std::ranges::contains( boardables, p ) ) {
             continue;
         }
         if( !m.has_furn( p ) ) {

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -604,13 +604,13 @@ void Character::suffer_from_schizophrenia()
         // Weapon is concerned for player if bleeding
         // Weapon is concerned for itself if damaged
         // Otherwise random chit-chat
-        std::vector<weak_ptr_fast<monster>> mons = g->all_monsters().items;
+        auto mons = g->all_monsters().items;
 
         std::string i_talk_w;
         bool does_talk = false;
-        if( !mons.empty() && one_turn_in( 12_minutes ) ) {
+        if( !mons->empty() && one_turn_in( 12_minutes ) ) {
             std::vector<std::string> seen_mons;
-            for( weak_ptr_fast<monster> &n : mons ) {
+            for( auto &n : *mons ) {
                 if( sees( *n.lock() ) ) {
                     seen_mons.emplace_back( n.lock()->get_name() );
                 }

--- a/src/trait_group.cpp
+++ b/src/trait_group.cpp
@@ -188,7 +188,7 @@ Trait_list Trait_group_creator::create( RecursionList &rec ) const
 {
 
     Trait_list result;
-    if( std::ranges::find( rec, id ) != rec.end() ) {
+    if( std::ranges::contains( rec, id ) ) {
         debugmsg( "recursion in trait creation list %s", id.c_str() );
         return result;
     }

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1440,7 +1440,7 @@ bool vehicle::is_alternator_on( const int a ) const
         return false;
     }
 
-    return std::any_of( engines.begin(), engines.end(), [this, &alt]( int idx ) {
+    return std::ranges::any_of( engines, [this, &alt]( int idx ) {
         const auto &eng = parts [ idx ];
         //fuel_left checks that the engine can produce power to be absorbed
         return eng.is_available() && eng.enabled && fuel_left( eng.fuel_current() ) &&
@@ -2837,7 +2837,7 @@ item &vehicle::part_base( int p )
 
 int vehicle::find_part( const item &it ) const
 {
-    auto idx = std::find_if( parts.begin(), parts.end(), [&it]( const vehicle_part & e ) {
+    auto idx = std::ranges::find_if( parts, [&it]( const vehicle_part & e ) {
         return e.base == &it;
     } );
     return idx != parts.end() ? std::distance( parts.begin(), idx ) : INT_MIN;
@@ -3000,14 +3000,14 @@ int vehicle::avail_part_with_feature( point pt, const std::string &flag,
 
 bool vehicle::has_part( const std::string &flag, bool enabled ) const
 {
-    return std::any_of( parts.begin(), parts.end(), [&flag, &enabled]( const vehicle_part & e ) {
+    return std::ranges::any_of( parts, [&flag, &enabled]( const vehicle_part & e ) {
         return !e.removed && ( !enabled || e.enabled ) && !e.is_broken() && e.info().has_flag( flag );
     } );
 }
 
 bool vehicle::has_part( const vpart_bitflags &flag, bool enabled ) const
 {
-    return std::any_of( parts.begin(), parts.end(), [&flag, &enabled]( const vehicle_part & e ) {
+    return std::ranges::any_of( parts, [&flag, &enabled]( const vehicle_part & e ) {
         return !e.removed && ( !enabled || e.enabled ) && !e.is_broken() && e.info().has_flag( flag );
     } );
 }

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -655,7 +655,7 @@ void vehicle::init_state( const int init_veh_fuel, const int init_veh_status,
         //Leave engine running in some vehicles, if the engine has not been destroyed
         //chance decays from 1 in 4 vehicles on day 0 to 1 in (day + 4) in the future.
         int current_day = std::max( to_days<int>( calendar::turn - calendar::turn_zero ), 0 );
-        if( veh_fuel_mult > 0 && !empty( get_avail_parts( "ENGINE" ) ) &&
+        if( veh_fuel_mult > 0 && !get_avail_parts( "ENGINE" ).empty() &&
             one_in( current_day + 4 ) && !destroyEngine && !needsHotwire &&
             has_engine_type_not( fuel_type_muscle, true ) ) {
             engine_on = true;
@@ -3292,7 +3292,7 @@ std::vector<std::vector<int>> vehicle::find_lines_of_parts( int part, const std:
 {
     const auto possible_parts = get_avail_parts( flag );
     std::vector<std::vector<int>> ret_parts;
-    if( empty( possible_parts ) ) {
+    if( possible_parts.empty() ) {
         return ret_parts;
     }
 

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -3263,9 +3263,9 @@ int vehicle::get_next_shifted_index( int original_index, Character &who )
 {
     int ret_index = original_index;
     bool found_shifted_index = false;
-    for( std::vector<vehicle_part>::reverse_iterator it = parts.rbegin(); it != parts.rend(); ++it ) {
-        if( who.get_value( "veh_index_type" ) == it->info().name() ) {
-            ret_index = index_of_part( &*it );
+    for( vehicle_part &part : parts | std::views::reverse ) {
+        if( who.get_value( "veh_index_type" ) == part.info().name() ) {
+            ret_index = index_of_part( &part );
             found_shifted_index = true;
             break;
         }

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -114,7 +114,7 @@ void vehicle::add_toggle_to_opts( std::vector<uilist_entry> &options,
 {
     // fetch matching parts and abort early if none found
     const auto found = get_avail_parts( flag );
-    if( empty( found ) ) {
+    if( found.empty() ) {
         return;
     }
 
@@ -190,7 +190,7 @@ void vehicle::control_doors()
     // Locations used to display the doors
     std::vector< tripoint > locations;
     // it is possible to have one door to open and one to close for single motor
-    if( empty( door_motors ) ) {
+    if( door_motors.empty() ) {
         debugmsg( "vehicle::control_doors called but no door motors found" );
         return;
     }

--- a/src/world.cpp
+++ b/src/world.cpp
@@ -104,7 +104,7 @@ void WORLDINFO::COPY_WORLD( const WORLDINFO *world_to_copy )
 
 bool WORLDINFO::save_exists( const save_t &name ) const
 {
-    return std::ranges::find( world_saves, name ) != world_saves.end();
+    return std::ranges::contains( world_saves, name );
 }
 
 void WORLDINFO::add_save( const save_t &name )

--- a/tests/item_test.cpp
+++ b/tests/item_test.cpp
@@ -1,6 +1,7 @@
 #include "catch/catch.hpp"
 
 #include <initializer_list>
+#include <iterator>
 #include <limits>
 #include <memory>
 
@@ -52,6 +53,26 @@ TEST_CASE( "gun_layer", "[item]" )
     CHECK( gun.is_gunmod_compatible( *mod ).success() );
     gun.put_in( std::move( mod ) );
     CHECK( gun.get_layer() == BELTED_LAYER );
+}
+
+TEST_CASE( "gun_cycle_mode_wraps_from_last_to_first", "[item]" )
+{
+    item &reach_bow = *item::spawn_temporary( "reach_bow" );
+    const auto modes = reach_bow.gun_all_modes();
+
+    REQUIRE( modes.size() >= 2 );
+
+    const auto first_mode = modes.begin()->first;
+    const auto second_mode = std::next( modes.begin() )->first;
+    const auto last_mode = std::prev( modes.end() )->first;
+
+    REQUIRE( reach_bow.gun_set_mode( first_mode ) );
+    reach_bow.gun_cycle_mode();
+    CHECK( reach_bow.gun_get_mode_id() == second_mode );
+
+    REQUIRE( reach_bow.gun_set_mode( last_mode ) );
+    reach_bow.gun_cycle_mode();
+    CHECK( reach_bow.gun_get_mode_id() == first_mode );
 }
 
 TEST_CASE( "stacking_cash_cards", "[item]" )

--- a/tests/iterator_safety_test.cpp
+++ b/tests/iterator_safety_test.cpp
@@ -1,0 +1,250 @@
+#include "catch/catch.hpp"
+
+#include "map_iterator.h"
+#include "rect_range.h"
+#include "vpart_range.h"
+#include "vehicle.h"
+#include "vpart_position.h"
+#include "point.h"
+
+#include <algorithm>
+#include <ranges>
+#include <vector>
+
+namespace
+{
+
+auto make_temp_tripoint_range() -> tripoint_range<tripoint>
+{
+    return tripoint_range<tripoint>( tripoint( 0, 0, 0 ), tripoint( 1, 1, 0 ) );
+}
+
+} // namespace
+
+TEST_CASE( "tripoint_range_iterator_safety", "[iterator][safety]" )
+{
+    // Get iterator from a temporary range object.
+    // The range object is destroyed at the end of this statement.
+    auto it = make_temp_tripoint_range().begin();
+
+    // If the iterator held a pointer to the range, accessing it would be undefined behavior.
+    // Since it stores range_min and range_max by value, this is safe.
+    REQUIRE( *it == tripoint( 0, 0, 0 ) );
+
+    ++it;
+    REQUIRE( *it == tripoint( 1, 0, 0 ) );
+
+    ++it;
+    REQUIRE( *it == tripoint( 0, 1, 0 ) );
+
+    ++it;
+    REQUIRE( *it == tripoint( 1, 1, 0 ) );
+}
+
+TEST_CASE( "rect_range_iterator_safety_numeric", "[iterator][safety]" )
+{
+    // rect_range iterator stores width, height by value, so it's safe.
+    // Using a simple struct that can be constructed from brace initializer.
+    struct test_rect {
+        int x, y, w, h;
+    };
+    
+    auto it = rect_range<test_rect>( 10, 10, point( 2, 2 ) ).begin();
+
+    // The dereference returns {x, y, width, height} struct where x,y are computed.
+    // For this test we just verify we can dereference without crashing after
+    // the temporary range is destroyed.
+    auto rect = *it;
+    REQUIRE( rect.x == 0 );
+    REQUIRE( rect.y == 0 );
+
+    ++it;
+    auto rect2 = *it;
+    REQUIRE( rect2.x == 10 ); // Second element (width=10)
+}
+
+TEST_CASE( "vehicle_part_range_iterator_safety", "[iterator][safety]" )
+{
+    vehicle v;
+
+    // Add some dummy parts to the vehicle.
+    v.install_part( point_zero, vpart_id( "frame_vertical" ) );
+    v.install_part( point_zero, vpart_id( "seat" ) );
+
+    // Get an iterator from a temporary range object.
+    // CRITICAL: This temporary object is destroyed at the end of this statement.
+    auto it_begin = v.get_all_parts().begin();
+    auto it_end = v.get_all_parts().end();
+
+    // Before the fix: it_begin held a const pointer to the temporary range,
+    // making it a dangling pointer after the temporary was destroyed.
+    // After the fix: it_begin stores a copy of the range (lightweight: vehicle* + filter state),
+    // so it remains valid even after the temporary is destroyed.
+
+    REQUIRE( it_begin != it_end );
+    REQUIRE( it_begin->part_index() == 0 );
+
+    ++it_begin;
+    REQUIRE( it_begin != it_end );
+    REQUIRE( it_begin->part_index() == 1 );
+
+    ++it_begin;
+    REQUIRE( it_begin == it_end );
+}
+
+
+TEST_CASE( "vehicle_part_with_feature_range_iterator_safety", "[iterator][safety]" )
+{
+    vehicle v;
+
+    // Add parts with different features.
+    v.install_part( point_zero, vpart_id( "frame_vertical" ) );
+    v.install_part( point_zero, vpart_id( "seat" ) );
+    v.install_part( point_zero, vpart_id( "frame_vertical" ) );
+    v.install_part( point_zero, vpart_id( "seat" ) );
+
+    // Create a filtered range (temporary) and get iterators.
+    // The range_type stores the feature filter by value in vehicle_part_iterator.
+    // Even though the temporary range is destroyed, the iterator carries its own copy of the filter.
+    auto it_begin = v.get_avail_parts( std::string( "seat" ) ).begin();
+    auto it_end = v.get_avail_parts( std::string( "seat" ) ).end();
+
+    // Verify we can safely dereference after the temporary range is gone.
+    // We just check that iteration works, without assuming specific part indices.
+    int count = 0;
+    while( it_begin != it_end ) {
+        ++count;
+        ++it_begin;
+    }
+    // There should be at least the seat parts we installed.
+    REQUIRE( count >= 2 );
+}
+
+TEST_CASE( "vehicle_part_iterator_copy_semantics", "[iterator][safety]" )
+{
+    vehicle v;
+
+    v.install_part( point_zero, vpart_id( "frame_vertical" ) );
+    v.install_part( point_zero, vpart_id( "seat" ) );
+    v.install_part( point_zero, vpart_id( "frame_vertical" ) );
+
+    auto range = v.get_all_parts();
+    auto it1 = range.begin();
+    auto it2 = it1; // Copy construction
+
+    // Advance it1
+    ++it1;
+    ++it1;
+
+    // it2 should still point to the first element
+    REQUIRE( it2->part_index() == 0 );
+    REQUIRE( it1->part_index() == 2 );
+    REQUIRE( it1 != it2 );
+}
+
+TEST_CASE( "vehicle_part_range_for_temporary_safety", "[iterator][safety]" )
+{
+    vehicle v;
+
+    v.install_part( point_zero, vpart_id( "frame_vertical" ) );
+    v.install_part( point_zero, vpart_id( "seat" ) );
+    v.install_part( point_zero, vpart_id( "frame_vertical" ) );
+
+    std::vector<int> indices;
+
+    // This range-for loop creates iterators from a temporary range.
+    // Before the fix: Undefined behavior / potential dangling iterators.
+    // After the fix: Safe, because each iterator owns its range state.
+    for( const auto &part : v.get_all_parts() ) {
+        indices.push_back( part.part_index() );
+    }
+
+    REQUIRE( indices.size() == 3 );
+    REQUIRE( indices[0] == 0 );
+    REQUIRE( indices[1] == 1 );
+    REQUIRE( indices[2] == 2 );
+}
+
+TEST_CASE( "vehicle_part_filtered_range_for_temporary_safety",
+           "[iterator][safety]" )
+{
+    vehicle v;
+
+    v.install_part( point_zero, vpart_id( "frame_vertical" ) );
+    v.install_part( point_zero, vpart_id( "seat" ) );
+    v.install_part( point_zero, vpart_id( "frame_vertical" ) );
+    v.install_part( point_zero, vpart_id( "seat" ) );
+
+    std::vector<int> indices;
+    int count = 0;
+
+    // Iterate over filtered temporary range.
+    // The filter state is now safely copied into each iterator.
+    for( const auto &part : v.get_avail_parts( std::string( "seat" ) ) ) {
+        indices.push_back( part.part_index() );
+        ++count;
+    }
+
+    // Should have found at least 2 seat parts
+    REQUIRE( count >= 2 );
+}
+
+TEST_CASE( "vehicle_part_range_empty_method", "[iterator][safety]" )
+{
+    vehicle v;
+
+    // Empty vehicle should have empty range.
+    REQUIRE( v.get_all_parts().empty() );
+
+    v.install_part( point_zero, vpart_id( "frame_vertical" ) );
+
+    // Non-empty vehicle should have non-empty range.
+    REQUIRE_FALSE( v.get_all_parts().empty() );
+
+    // Filtered range for non-existent feature should be empty.
+    REQUIRE( v.get_avail_parts( std::string( "non_existent_feature" ) ).empty() );
+
+    // Filtered range for existing feature should not be empty.
+    v.install_part( point_zero, vpart_id( "seat" ) );
+    REQUIRE_FALSE( v.get_avail_parts( std::string( "seat" ) ).empty() );
+}
+
+TEST_CASE( "vehicle_part_range_std_ranges_algorithms", "[iterator][safety][ranges]" )
+{
+    vehicle v;
+
+    v.install_part( point_zero, vpart_id( "frame_vertical" ) );
+    v.install_part( point_zero, vpart_id( "seat" ) );
+    v.install_part( point_zero, vpart_id( "frame_vertical" ) );
+    v.install_part( point_zero, vpart_id( "seat" ) );
+
+    // Test std::ranges::distance on temporary range (borrowed_range)
+    // This tests that enable_borrowed_range allows ranges algorithms on temporaries
+    const int seat_count = std::ranges::distance( v.get_avail_parts( std::string( "seat" ) ) );
+    REQUIRE( seat_count == 2 );
+
+    const int all_count = std::ranges::distance( v.get_all_parts() );
+    REQUIRE( all_count == 4 );
+
+    // Test iteration with std::ranges
+    std::vector<int> indices;
+    for( auto part : v.get_all_parts() ) {
+        indices.push_back( part.part_index() );
+    }
+    REQUIRE( indices.size() == 4 );
+}
+
+TEST_CASE( "vehicle_part_range_concepts", "[iterator][safety][ranges]" )
+{
+    // Verify that our ranges satisfy std::ranges concepts
+    static_assert( std::ranges::range<vehicle_part_range> );
+    static_assert( std::ranges::input_range<vehicle_part_range> );
+    static_assert( std::ranges::forward_range<vehicle_part_range> );
+    static_assert( std::ranges::borrowed_range<vehicle_part_range> );
+
+    using filtered_range = vehicle_part_with_feature_range<std::string>;
+    static_assert( std::ranges::range<filtered_range> );
+    static_assert( std::ranges::input_range<filtered_range> );
+    static_assert( std::ranges::forward_range<filtered_range> );
+    static_assert( std::ranges::borrowed_range<filtered_range> );
+}

--- a/tests/iterator_safety_test.cpp
+++ b/tests/iterator_safety_test.cpp
@@ -48,7 +48,7 @@ TEST_CASE( "rect_range_iterator_safety_numeric", "[iterator][safety]" )
     struct test_rect {
         int x, y, w, h;
     };
-    
+
     auto it = rect_range<test_rect>( 10, 10, point( 2, 2 ) ).begin();
 
     // The dereference returns {x, y, width, height} struct where x,y are computed.

--- a/tests/iterator_safety_test.cpp
+++ b/tests/iterator_safety_test.cpp
@@ -14,9 +14,24 @@
 namespace
 {
 
+struct test_rect {
+    int x;
+    int y;
+    int w;
+    int h;
+
+    auto operator<=>( const test_rect & ) const = default; // *NOPAD*
+};
+
 auto make_temp_tripoint_range() -> tripoint_range<tripoint>
 {
     return tripoint_range<tripoint>( tripoint( 0, 0, 0 ), tripoint( 1, 1, 0 ) );
+}
+
+auto make_temp_rect_range( const int width, const int height,
+                           const point count ) -> rect_range<test_rect>
+{
+    return rect_range<test_rect>( width, height, count );
 }
 
 } // namespace
@@ -43,13 +58,7 @@ TEST_CASE( "tripoint_range_iterator_safety", "[iterator][safety]" )
 
 TEST_CASE( "rect_range_iterator_safety_numeric", "[iterator][safety]" )
 {
-    // rect_range iterator stores width, height by value, so it's safe.
-    // Using a simple struct that can be constructed from brace initializer.
-    struct test_rect {
-        int x, y, w, h;
-    };
-
-    auto it = rect_range<test_rect>( 10, 10, point( 2, 2 ) ).begin();
+    auto it = make_temp_rect_range( 10, 10, point( 2, 2 ) ).begin();
 
     // The dereference returns {x, y, width, height} struct where x,y are computed.
     // For this test we just verify we can dereference without crashing after
@@ -61,6 +70,40 @@ TEST_CASE( "rect_range_iterator_safety_numeric", "[iterator][safety]" )
     ++it;
     auto rect2 = *it;
     REQUIRE( rect2.x == 10 ); // Second element (width=10)
+}
+
+TEST_CASE( "rect_range models a C++20 random_access_range", "[iterator][safety][ranges]" )
+{
+    using test_rect_range = rect_range<test_rect>;
+
+    STATIC_REQUIRE( std::random_access_iterator<test_rect_range::iterator> );
+    STATIC_REQUIRE( std::ranges::random_access_range<test_rect_range> );
+    STATIC_REQUIRE( std::ranges::view<test_rect_range> );
+
+    auto range = test_rect_range( 10, 20, point( 3, 2 ) );
+    auto it = range.begin();
+    auto end = range.end();
+
+    REQUIRE( *it == test_rect{ 0, 0, 10, 20 } );
+    REQUIRE( *( it + 4 ) == test_rect{ 10, 20, 10, 20 } );
+    REQUIRE( *( 2 + it ) == test_rect{ 20, 0, 10, 20 } );
+    REQUIRE( *( end - 2 ) == test_rect{ 10, 20, 10, 20 } );
+    REQUIRE( it[5] == test_rect{ 20, 20, 10, 20 } );
+    REQUIRE( end - it == 6 );
+    REQUIRE( std::ranges::distance( range ) == 6 );
+}
+
+TEST_CASE( "rect_range iterator comparisons include range geometry", "[iterator][safety][ranges]" )
+{
+    const auto base_range = rect_range<test_rect>( 10, 10, point( 2, 2 ) );
+    const auto different_step = rect_range<test_rect>( 20, 10, point( 2, 2 ) );
+    const auto different_size = rect_range<test_rect>( 10, 10, point( 2, 3 ) );
+
+    CHECK( base_range.begin() != different_step.begin() );
+    CHECK( base_range.begin() + 1 != different_step.begin() + 1 );
+    CHECK( base_range.end() != different_size.begin() + 4 );
+    CHECK( *( base_range.begin() + 1 ) == test_rect{ 10, 0, 10, 10 } );
+    CHECK( *( different_step.begin() + 1 ) == test_rect{ 20, 0, 20, 10 } );
 }
 
 TEST_CASE( "vehicle_part_range_iterator_safety", "[iterator][safety]" )

--- a/tests/map_iterator_test.cpp
+++ b/tests/map_iterator_test.cpp
@@ -19,7 +19,7 @@ TEST_CASE( "Radius one 2D square centered at origin." )
 {
     for( const tripoint &candidate :
          tripoint_range<tripoint>( tripoint_north_west, tripoint_south_east ) ) {
-        REQUIRE( std::ranges::find( range_1_2d_centered, candidate ) != range_1_2d_centered.end() );
+        REQUIRE( std::ranges::contains( range_1_2d_centered, candidate ) );
     }
 }
 
@@ -33,7 +33,7 @@ static std::array<tripoint, 9> range_1_2d_offset = {
 TEST_CASE( "Radius one 2D square centered at -4/-4/0." )
 {
     for( const tripoint &candidate : tripoint_range<tripoint>( {-5, -5, 0}, {-3, -3, 0} ) ) {
-        REQUIRE( std::ranges::find( range_1_2d_offset, candidate ) != range_1_2d_offset.end() );
+        REQUIRE( std::ranges::contains( range_1_2d_offset, candidate ) );
     }
 }
 
@@ -41,7 +41,7 @@ TEST_CASE( "Radius one 2D square centered at -4/-4/0 in abs_omt coords." )
 {
     for( const tripoint_abs_omt &candidate :
          tripoint_range<tripoint_abs_omt>( {-5, -5, 0}, {-3, -3, 0} ) ) {
-        REQUIRE( std::ranges::find( range_1_2d_offset, candidate.raw() ) != range_1_2d_offset.end() );
+        REQUIRE( std::ranges::contains( range_1_2d_offset, candidate.raw() ) );
     }
 }
 
@@ -107,7 +107,7 @@ static std::array<tripoint, 343> range_3_3d_offset = {
 TEST_CASE( "Radius three 3D square centered at 8/8/1." )
 {
     for( const tripoint &candidate : tripoint_range<tripoint>( {5, 5, -2}, {11, 11, 4} ) ) {
-        REQUIRE( std::ranges::find( range_3_3d_offset, candidate ) != range_3_3d_offset.end() );
+        REQUIRE( std::ranges::contains( range_3_3d_offset, candidate ) );
     }
 }
 

--- a/tests/map_iterator_test.cpp
+++ b/tests/map_iterator_test.cpp
@@ -2,12 +2,13 @@
 
 #include <algorithm>
 #include <array>
+#include <ranges>
 
 #include "coordinates.h"
 #include "map_iterator.h"
 #include "point.h"
 
-std::array<tripoint, 9> range_1_2d_centered = {
+static std::array<tripoint, 9> range_1_2d_centered = {
     {   {tripoint_north_west}, { tripoint_north}, { tripoint_north_east},
         {tripoint_west}, { tripoint_zero}, { tripoint_east},
         {tripoint_south_west}, { tripoint_south}, { tripoint_south_east}
@@ -18,12 +19,11 @@ TEST_CASE( "Radius one 2D square centered at origin." )
 {
     for( const tripoint &candidate :
          tripoint_range<tripoint>( tripoint_north_west, tripoint_south_east ) ) {
-        REQUIRE( std::find( range_1_2d_centered.begin(), range_1_2d_centered.end(), candidate ) !=
-                 range_1_2d_centered.end() );
+        REQUIRE( std::ranges::find( range_1_2d_centered, candidate ) != range_1_2d_centered.end() );
     }
 }
 
-std::array<tripoint, 9> range_1_2d_offset = {
+static std::array<tripoint, 9> range_1_2d_offset = {
     {   {-5, -5, 0}, {-4, -5, 0}, {-3, -5, 0},
         {-5, -4, 0}, {-4, -4, 0}, {-3, -4, 0},
         {-5, -3, 0}, {-4, -3, 0}, {-3, -3, 0}
@@ -33,8 +33,7 @@ std::array<tripoint, 9> range_1_2d_offset = {
 TEST_CASE( "Radius one 2D square centered at -4/-4/0." )
 {
     for( const tripoint &candidate : tripoint_range<tripoint>( {-5, -5, 0}, {-3, -3, 0} ) ) {
-        REQUIRE( std::find( range_1_2d_offset.begin(), range_1_2d_offset.end(), candidate ) !=
-                 range_1_2d_offset.end() );
+        REQUIRE( std::ranges::find( range_1_2d_offset, candidate ) != range_1_2d_offset.end() );
     }
 }
 
@@ -42,12 +41,11 @@ TEST_CASE( "Radius one 2D square centered at -4/-4/0 in abs_omt coords." )
 {
     for( const tripoint_abs_omt &candidate :
          tripoint_range<tripoint_abs_omt>( {-5, -5, 0}, {-3, -3, 0} ) ) {
-        REQUIRE( std::find( range_1_2d_offset.begin(), range_1_2d_offset.end(), candidate.raw() ) !=
-                 range_1_2d_offset.end() );
+        REQUIRE( std::ranges::find( range_1_2d_offset, candidate.raw() ) != range_1_2d_offset.end() );
     }
 }
 
-std::array<tripoint, 343> range_3_3d_offset = {
+static std::array<tripoint, 343> range_3_3d_offset = {
     {   { 5, 5, -2}, { 6, 5, -2}, { 7, 5, -2}, { 8, 5, -2}, { 9, 5, -2}, {10, 5, -2}, {11, 5, -2},
         { 5, 6, -2}, { 6, 6, -2}, { 7, 6, -2}, { 8, 6, -2}, { 9, 6, -2}, {10, 6, -2}, {11, 6, -2},
         { 5, 7, -2}, { 6, 7, -2}, { 7, 7, -2}, { 8, 7, -2}, { 9, 7, -2}, {10, 7, -2}, {11, 7, -2},
@@ -109,7 +107,96 @@ std::array<tripoint, 343> range_3_3d_offset = {
 TEST_CASE( "Radius three 3D square centered at 8/8/1." )
 {
     for( const tripoint &candidate : tripoint_range<tripoint>( {5, 5, -2}, {11, 11, 4} ) ) {
-        REQUIRE( std::find( range_3_3d_offset.begin(), range_3_3d_offset.end(), candidate ) !=
-                 range_3_3d_offset.end() );
+        REQUIRE( std::ranges::find( range_3_3d_offset, candidate ) != range_3_3d_offset.end() );
     }
+}
+
+TEST_CASE( "tripoint_range is a C++20 forward_range" )
+{
+    STATIC_REQUIRE( std::forward_iterator<tripoint_range<tripoint>::iterator> );
+    STATIC_REQUIRE( std::ranges::forward_range<tripoint_range<tripoint>> );
+    STATIC_REQUIRE( std::ranges::view<tripoint_range<tripoint>> );
+}
+
+TEST_CASE( "tripoint_range works with std::ranges algorithms" )
+{
+    auto range = tripoint_range<tripoint>( tripoint_north_west, tripoint_south_east );
+
+    // Test std::ranges::find
+    auto it = std::ranges::find( range, tripoint_zero );
+    REQUIRE( it != range.end() );
+    REQUIRE( *it == tripoint_zero );
+
+    // Test std::ranges::count
+    auto count = std::ranges::count( range, tripoint_north );
+    REQUIRE( count == 1 );
+
+    // Test std::ranges::any_of
+    bool has_zero = std::ranges::any_of( range, []( const tripoint & p ) {
+        return p == tripoint_zero;
+    } );
+    REQUIRE( has_zero );
+
+    // Test std::ranges::distance
+    auto dist = std::ranges::distance( range );
+    REQUIRE( dist == 9 );
+}
+
+TEST_CASE( "tripoint_range iterator is default constructible and copyable" )
+{
+    tripoint_range<tripoint>::iterator default_iter;
+    tripoint_range<tripoint>::iterator another_iter;
+
+    auto range = tripoint_range<tripoint>( tripoint_north_west, tripoint_south_east );
+    default_iter = range.begin();
+    another_iter = default_iter;
+
+    REQUIRE( default_iter == another_iter );
+    REQUIRE( *default_iter == *another_iter );
+}
+
+TEST_CASE( "tripoint_range works with std::ranges::views" )
+{
+    auto range = tripoint_range<tripoint>( {-1, -1, 0}, {1, 1, 0} );
+
+    // Test with filter view
+    auto filtered = range | std::views::filter( []( const tripoint & p ) { return p.x >= 0 && p.y >= 0; } );
+
+    int filtered_count = 0;
+    for( const auto &p : filtered ) {
+        ( void )p;
+        filtered_count++;
+    }
+    REQUIRE( filtered_count == 4 ); // (0,0), (1,0), (0,1), (1,1)
+
+    // Test with transform view
+    auto transformed = range | std::views::transform( []( const tripoint & p ) { return p.x + p.y; } );
+
+    REQUIRE( std::ranges::distance( transformed ) == 9 );
+}
+
+TEST_CASE( "tripoint_range iterator survives temporary range (no dangling)" )
+{
+    // Critical safety test: Iterator must store bounds by value, not pointer to parent
+    // This would crash with old implementation storing range*
+    auto it = points_in_radius( tripoint_zero, 1 ).begin();
+    // points_in_radius returns temporary, destroyed after this line
+    // Iterator must still be valid
+    REQUIRE( *it == tripoint( -1, -1, -1 ) );
+    ++it; // Would crash if iterator stored dangling pointer
+    REQUIRE( *it == tripoint( 0, -1, -1 ) );
+}
+
+TEST_CASE( "tripoint_range copied iterator remains valid" )
+{
+    auto range = tripoint_range<tripoint>( tripoint_zero, tripoint( 2, 2, 0 ) );
+    auto it1 = range.begin();
+    auto it2 = it1; // Copy iterator
+
+    ++it1;
+    REQUIRE( *it1 == tripoint( 1, 0, 0 ) );
+    REQUIRE( *it2 == tripoint( 0, 0, 0 ) ); // Original position
+
+    ++it2;
+    REQUIRE( *it2 == tripoint( 1, 0, 0 ) );
 }

--- a/tests/map_iterator_test.cpp
+++ b/tests/map_iterator_test.cpp
@@ -182,9 +182,9 @@ TEST_CASE( "tripoint_range iterator survives temporary range (no dangling)" )
     auto it = points_in_radius( tripoint_zero, 1 ).begin();
     // points_in_radius returns temporary, destroyed after this line
     // Iterator must still be valid
-    REQUIRE( *it == tripoint( -1, -1, -1 ) );
+    REQUIRE( *it == tripoint( -1, -1, 0 ) );
     ++it; // Would crash if iterator stored dangling pointer
-    REQUIRE( *it == tripoint( 0, -1, -1 ) );
+    REQUIRE( *it == tripoint( 0, -1, 0 ) );
 }
 
 TEST_CASE( "tripoint_range copied iterator remains valid" )

--- a/tests/ranged_aoe_test.cpp
+++ b/tests/ranged_aoe_test.cpp
@@ -87,7 +87,7 @@ static void shape_coverage_vs_distance_no_obstacle( const shape_factory_impl &c,
     for( const tripoint &p : here.points_in_rectangle( expanded_bb.p_min, expanded_bb.p_max ) ) {
         double signed_distance = s->distance_at( p );
         bool distance_on_shape_is_negative = signed_distance < 0.0;
-        bool point_is_covered = cov.find( p ) != cov.end() && cov.at( p ) > 0.0;
+        bool point_is_covered = cov.contains( p ) && cov.at( p ) > 0.0;
         bool in_bounding_box = bb.contains( p );
         CAPTURE( p );
         CAPTURE( signed_distance );

--- a/tests/salvage_test.cpp
+++ b/tests/salvage_test.cpp
@@ -76,7 +76,7 @@ auto cut_up_yields( const std::string &target ) -> void
             }
         }
         CHECK( has_quality );
-        CHECK( std::ranges::find( madeof, material ) != madeof.end() );
+        CHECK( std::ranges::contains( madeof, material ) );
     }
 }
 } // namespace


### PR DESCRIPTION
## Why

- i want to refactor code using `std::ranges` more but lots of custom iterators doesn't satisfy concepts required by `std::ranges`
- some detached iterators (tripoint_range, rect_range)  stored references or pointers to their parent range object which is unsafe to use from temporary object

## How

- store inner ranges by value like `range_type range_` 
- use `std::ranges::contains` more

<sub>PR opened by gpt-5.4 high on opencode</sub>