### PR TITLE
feat(lua): getall/getrandom bodypart id bindings

### DIFF
--- a/src/catalua_bindings_creature.cpp
+++ b/src/catalua_bindings_creature.cpp
@@ -264,7 +264,7 @@ void cata::detail::reg_creature( sol::state &lua )
         SET_FX_T( mod_all_parts_hp_cur, void( int ) );
         SET_FX_T( set_all_parts_hp_to_max, void() );
 
-        SET_FX_T( get_random_body_part, bodypart_id ( bool) const);
+        SET_FX_T( get_random_body_part, bodypart_id( bool ) const );
         SET_FX_T( get_all_body_parts, std::vector<bodypart_id>( bool ) const );
 
         SET_FX_T( set_armor_bash_bonus, void( int ) );


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

Its currently rather difficult to iterate over a player/npcs bodyparts to perform actions over them, or grab a random body part to damage it

## Describe the solution (The How)

Adds bindings to get_random_body_part and get_all_body_parts

## Describe alternatives you've considered

Not doing this

## Testing

```
local avatar = gapi.get_avatar()
local parts = avatar:get_all_body_parts(true)

for _, part in ipairs(parts) do
print("Grabbed " .. part:str_id():str())
local mod = math.random(-15, -1)
avatar:mod_part_hp_cur(part, mod)
print("Reduced " .. part:str_id():str() .. " by " .. mod .. "hp to " .. avatar:get_part_hp_cur(part) )
end

local randompart = avatar:get_random_body_part(true)
print("Grabbed " .. randompart:str_id():str())
print(randompart:str_id():str().. " is at " .. avatar:get_part_hp_cur(randompart) .. "hp")
local mod = math.random(1, 15)
avatar:mod_part_hp_cur(randompart, mod)
print("Healed " .. randompart:str_id():str() .. " by " .. mod)
```


## Additional context

checked all the open lua prs and as far as I could see none of them added this, but theres a chance I missed something idk

<img width="680" height="562" alt="2026-02-23-21:58:39" src="https://github.com/user-attachments/assets/8f7c1bc2-a022-4e46-bb30-91affbd651f3" />

works

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

<!-- please remove checkboxes unrelated to this PR. -->

- [x] This PR modifies lua scripts or the lua API.
  - [x] I have added [`lua` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#lua%3A-changes-to-lua-api) to the PR title.
  - [ ] I have added [type annotations](https://emmylua.github.io/annotation.html) to functions so that it's safe and easy to maintain.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
