### PR TITLE
fix: prevent low-speed vehicle collision infinite loop after SI migration

### DIFF
--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -887,7 +887,11 @@ veh_collision vehicle::part_collision( int part, const tripoint &p,
         }
 
         if( critter == nullptr || !critter->is_hallucination() ) {
-            coll_velocity = mps_to_cmps( vel1_a * ( smashed ? 1 : 0.9 ) );
+            const auto new_velocity = mps_to_cmps( vel1_a * ( smashed ? 1.0 : 0.9 ) );
+            // Guarantee convergence: rounding must not prevent velocity from decreasing
+            coll_velocity = ( !smashed && std::abs( new_velocity ) >= std::abs( coll_velocity ) )
+                            ? 0
+                            : new_velocity;
         }
         // Stop processing when sign inverts, not when we reach 0
     } while( !smashed && sgn( coll_velocity ) == vel_sign );

--- a/tests/vehicle_collision_test.cpp
+++ b/tests/vehicle_collision_test.cpp
@@ -1,0 +1,60 @@
+#include "catch/catch.hpp"
+
+#include "map.h"
+#include "map_helpers.h"
+#include "point.h"
+#include "state_helpers.h"
+#include "type_id.h"
+#include "vehicle.h"
+
+TEST_CASE( "mps_cmps_round_trip_converges_to_zero", "[vehicle]" )
+{
+    constexpr auto max_iterations = 200;
+
+    for( auto v = 1; v <= 50; ++v ) {
+        auto coll_velocity = v;
+        auto iterations = 0;
+        while( coll_velocity > 0 && iterations < max_iterations ) {
+            auto const vel_mps = cmps_to_mps( coll_velocity );
+            auto const new_velocity = mps_to_cmps( vel_mps * 0.9 );
+            coll_velocity = ( std::abs( new_velocity ) >= std::abs( coll_velocity ) )
+                            ? 0
+                            : new_velocity;
+            ++iterations;
+        }
+        CAPTURE( v );
+        CHECK( coll_velocity == 0 );
+        CHECK( iterations < max_iterations );
+    }
+}
+
+TEST_CASE( "vehicle_collision_with_wall_terminates", "[vehicle]" )
+{
+    clear_all_state();
+    auto &here = get_map();
+    build_test_map( ter_id( "t_pavement" ) );
+    clear_vehicles();
+
+    auto const veh_pos = tripoint( 60, 60, 0 );
+    auto const wall_pos = tripoint( 60, 59, 0 );
+
+    auto *veh_ptr = here.add_vehicle( vproto_id( "bicycle" ), veh_pos, 270_degrees, 0, 0 );
+    REQUIRE( veh_ptr != nullptr );
+
+    REQUIRE( here.ter_set( wall_pos, ter_id( "t_concrete_wall" ) ) );
+    here.build_map_cache( 0, true );
+
+    CAPTURE( here.ter( wall_pos ).id().str() );
+    CAPTURE( here.move_cost_ter_furn( wall_pos ) );
+    REQUIRE( here.impassable_ter_furn( wall_pos ) );
+
+    veh_ptr->velocity = 222;
+    auto const probe = veh_ptr->part_collision( 0, wall_pos, true, false );
+    REQUIRE( probe.type != veh_coll_nothing );
+
+    veh_ptr->velocity = 222;
+    auto const ret = veh_ptr->part_collision( 0, wall_pos, false, false );
+
+    CHECK( ret.type != veh_coll_nothing );
+    CHECK( std::abs( veh_ptr->velocity ) < 222 );
+}


### PR DESCRIPTION
## Purpose of change (The Why)

fixes an infinite loop in vehicle collision processing introduced by the SI-unit migration in #8181, where low speeds could fail to decay because of rounding.

## Describe the solution (The How)
- In `vehicle::part_collision`, added a convergence guard so `coll_velocity` is forced to `0` when rounding would keep it from decreasing.
- Added `tests/vehicle_collision_test.cpp` with regression coverage for the rounding-convergence path and an integration collision case.

## Describe alternatives you've considered
- Reverting `mps_to_cmps` back to truncation. Rejected because it would undo the SI-rounding behavior globally instead of fixing the collision loop convergence condition directly.

## Testing

<img width="1410" height="850" alt="image" src="https://github.com/user-attachments/assets/d5cebe3c-402b-41d9-81e1-dc3da4d1a6ee" />

spawned a car and drove it 6km/s into wall, did not infinite loop.
there's also a test

## Additional context
- This targets the specific low-speed non-converging loop behavior that appears when velocity updates are rounded to cm/s.