### PR TITLE
fix: Preview Scale Offset

### DIFF
--- a/src/character_preview.cpp
+++ b/src/character_preview.cpp
@@ -19,12 +19,12 @@
 
 auto termx_to_pixel_value() -> int
 {
-    return projected_window_width() / TERMX;
+    return projected_window_width() / TERMX / get_scaling_factor();
 }
 
 auto termy_to_pixel_value() -> int
 {
-    return projected_window_height() / TERMY;
+    return projected_window_height() / TERMY / get_scaling_factor();
 }
 
 // @brief adapter to get access to protected functions of cata_tiles

--- a/src/vehicle_preview.cpp
+++ b/src/vehicle_preview.cpp
@@ -22,12 +22,12 @@ static const std::string empty_string;
 // We provide our own static definitions here to avoid duplicate symbols
 static int termx_to_pixel_value()
 {
-    return projected_window_width() / TERMX;
+    return projected_window_width() / TERMX / get_scaling_factor();
 }
 
 static int termy_to_pixel_value()
 {
-    return projected_window_height() / TERMY;
+    return projected_window_height() / TERMY / get_scaling_factor();
 }
 
 /**


### PR DESCRIPTION
## Purpose of change (The Why)

Preview offset error:

<img width="2560" height="1440" alt="cataclysm-bn-tiles_1M2EGP3di4" src="https://github.com/user-attachments/assets/f28b111e-b719-4972-b02f-2f5e2a0d7903" />
<img width="329" height="296" alt="cataclysm-bn-tiles_mzP6TL7IDK" src="https://github.com/user-attachments/assets/7e380917-bcf6-4f42-9344-9c2815be054d" />

## Describe the solution (The How)

Offset wasn't resetting scale in term calcs correctly
Fixed that

## Testing

<img width="2560" height="1440" alt="cataclysm-bn-tiles_RT0B7FHi8I" src="https://github.com/user-attachments/assets/76f5d587-8347-4800-937b-64b4c1401d92" />