### PR TITLE
feat(balance): allow the PA leg mount to holster small launchers

### DIFF
--- a/data/json/items/armor/power_armor.json
+++ b/data/json/items/armor/power_armor.json
@@ -468,7 +468,7 @@
       "max_volume": "3 L",
       "min_volume": "250 ml",
       "flags": [ "SHEATH_KNIFE", "SHEATH_SWORD", "BELT_CLIP" ],
-      "skills": [ "pistol", "smg", "shotgun", "rifle" ]
+      "skills": [ "pistol", "smg", "shotgun", "rifle", "launcher" ]
     },
     "flags": [ "POWERARMOR_MOD", "COMPACT", "STURDY", "WAIST" ]
   },


### PR DESCRIPTION
## Purpose of change (The Why)

Several grenade launchers were too small to be holstered in the power armor weapons rack, this enables them to be stored in the leg mount hardpoint instead. The M79 launcher, M320 standalone launcher, and spraycan flamethrower prompt this change, being below the 1.5 L minimum limit of the weapon rack hardpoint. This is an incidental buff to many grenade launchers, but I don't think anyone will complain.
Items impacted (volume below 3L):
- M320 standalone launcher
- M79 Launcher
- M72 LAW
- Milkor MGL
- Mininuke Launcher (!!!)
- RM802 Grenade Launcher
- Spraycan flamethrower
- Tube 40mm Launcher
- Triple-Barrel 40mm Launcher

## Describe the solution (The How)

single line change to power_armor.json, adding the "launchers" skill to the holsterable weapons in the leg hard point

## Describe alternatives you've considered

1. Do nothing. Status quo forces players who want to use the M79 or M302 standalone launchers to use the power armor XL holster. Most other launchers can instead use the weapons rack.
2. Maybe if holsters worked on weapon categories instead of weapon skills? That's a big change, this is much easier. 

## Testing

Made the change locally, loaded up my save. Now able to holster launcher skill weapons in the leg mount.

## Additional context

Has the unfortunate side effect of allowing the mininuke launcher to be holstered in the leg mount. My recommendation is to increase the size of the mininuke launcher, which is currently an order of magnitude smaller in volume than the ammo it caries, but that is out of scope for this PR.

## Checklist

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.