### PR TITLE
perf: fix extreme lag (20x) when crafting in item-heavy area

### DIFF
--- a/src/crafting.h
+++ b/src/crafting.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <list>
+#include <optional>
 #include <set>
 #include <vector>
 
@@ -45,7 +46,8 @@ float morale_crafting_speed_multiplier( const Character &who, const recipe &rec 
 float lighting_crafting_speed_multiplier( const Character &who, const recipe &rec );
 float crafting_speed_multiplier( const Character &who, const recipe &rec, bool );
 float crafting_speed_multiplier( const Character &who, const item &craft,
-                                 const bench_location &bench );
+                                 const bench_location &bench,
+                                 std::optional<float> tools_multi_override = std::nullopt );
 void complete_craft( Character &who, item &craft );
 
 namespace crafting

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -8669,6 +8669,10 @@ int iuse::craft( player *p, item *it, bool, const tripoint &pos )
         return 0;
     }
 
+    if( it->get_var( "craft_tools_fully_prepaid", 0 ) == 0 ) {
+        it->set_var( "craft_tools_fully_prepaid", 1 );
+    }
+
     bench_location best_bench = find_best_bench( *p, *it );
     p->add_msg_player_or_npc(
         pgettext( "in progress craft", "You start working on the %s." ),
@@ -8700,6 +8704,8 @@ int iuse::craft( player *p, item *it, bool, const tripoint &pos )
     p->activity->values.push_back( 0 ); // Not a long craft
     // Ugly
     p->activity->values.push_back( static_cast<int>( best_bench.type ) );
+    p->activity->values.push_back( 100 );
+    p->activity->values.push_back( 0 );
 
     return 0;
 }

--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -53,6 +53,8 @@ static const activity_id ACT_CONSUME_DRINK_MENU( "ACT_CONSUME_DRINK_MENU" );
 static const activity_id ACT_CONSUME_FOOD_MENU( "ACT_CONSUME_FOOD_MENU" );
 static const activity_id ACT_CONSUME_MEDS_MENU( "ACT_CONSUME_MEDS_MENU" );
 static const activity_id ACT_CRAFT( "ACT_CRAFT" );
+static constexpr auto craft_bench_type_idx = 1;
+static constexpr auto craft_tools_mult_percent_idx = 2;
 static const activity_id ACT_DIG( "ACT_DIG" );
 static const activity_id ACT_DIG_CHANNEL( "ACT_DIG_CHANNEL" );
 static const activity_id ACT_EAT_MENU( "ACT_EAT_MENU" );
@@ -207,14 +209,16 @@ static std::string craft_progress_message( const avatar &u, const player_activit
     const recipe &rec = craft->get_making();
     const tripoint bench_pos = act.coords.front();
     // Ugly
-    bench_type bench_t = bench_type( act.values[1] );
+    const auto bench_t = bench_type( act.values[craft_bench_type_idx] );
 
     const bench_location bench{ bench_t, bench_pos };
 
     const float light_mult = lighting_crafting_speed_multiplier( u, rec );
     const float bench_mult = workbench_crafting_speed_multiplier( *craft, bench );
     const float morale_mult = morale_crafting_speed_multiplier( u, rec );
-    const auto tools_mult = crafting_tools_speed_multiplier( u, rec );
+    const auto tools_mult = ( act.values.size() > craft_tools_mult_percent_idx )
+                            ? static_cast<float>( act.values[craft_tools_mult_percent_idx] ) / 100.0f
+                            : crafting_tools_speed_multiplier( u, rec );
     const int assistants = u.available_assistant_count( craft->get_making() );
     const float base_total_moves = std::max( 1, rec.batch_time( craft->charges, 1.0f, 0 ) );
     const float assist_total_moves = std::max( 1, rec.batch_time( craft->charges, 1.0f, assistants ) );


### PR DESCRIPTION
## Purpose of change (The Why)

fixes #8243

## Describe the solution (The How)

- Cache tool-speed multiplier in `ACT_CRAFT` activity and reuse it during craft turns.
- Reuse cached tool multiplier in craft progress calculation instead of recomputing each update.
- Initialize cache fields for both fresh craft start and resume paths.

## Testing

<img width="1410" height="850" alt="image" src="https://github.com/user-attachments/assets/4b2d8bf8-0df2-4c96-87f0-384ed980f75f" />

spawn a vehicle, fill it with gazillion cargo, craft something. i used private save file from original issue raiser.

result: 32.7s -> 2.7s (12.11x, initial), 1.5s (21.8x, cached)

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.