### PR TITLE
feat(UI): display worn techniques in item description

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -3772,6 +3772,22 @@ void item::combat_info( std::vector<iteminfo> &info, const iteminfo_query *parts
         if( !all_techniques.empty() ) {
             const std::vector<matec_id> all_tec_sorted = sorted_lex( all_techniques );
             insert_separation_line( info );
+            if( has_flag( flag_BLOCK_WHILE_WORN ) ) {
+                matec_id tid;
+                if( has_technique( matec_id( "WBLOCK_3" ) ) ) {
+                    tid = matec_id( "WBLOCK_3" );
+                } else if( has_technique( matec_id( "WBLOCK_2" ) ) ) {
+                    tid = matec_id( "WBLOCK_2" );
+                } else if( has_technique( matec_id( "WBLOCK_1" ) ) ) {
+                    tid = matec_id( "WBLOCK_1" );
+                }
+                if( tid ) {
+                    info.emplace_back( "DESCRIPTION", _( "<bold>Techniques when worn</bold>: " ) +
+                                       string_format( "<stat>%s</stat>: <info>%s</info>", _( tid.obj().name ),
+                                                      _( tid.obj().description ) ) );
+                }
+
+            }
             info.emplace_back( "DESCRIPTION", _( "<bold>Techniques when wielded</bold>: " ) +
             enumerate_as_string( all_tec_sorted.begin(), all_tec_sorted.end(), []( const matec_id & tid ) {
                 return string_format( "<stat>%s</stat>: <info>%s</info>", _( tid.obj().name ),


### PR DESCRIPTION
## Purpose of change (The Why)
Before only stated wielded technique; Confused players

## Describe the solution (The How)
Also state worn techniques

## Describe alternatives you've considered
Adopt proper worn technique support

## Testing
<img width="1920" height="1080" alt="2026-03-02-131437_1920x1080_scrot" src="https://github.com/user-attachments/assets/6ed444ed-6838-4e68-a5d4-450ba4d921f9" />

Behold it works

## Additional context
Scrungle

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.