### PR TITLE
feat: add microwave and appliances to houses

### DIFF
--- a/data/json/itemgroups/SUS/domestic.json
+++ b/data/json/itemgroups/SUS/domestic.json
@@ -130,7 +130,15 @@
     "subtype": "collection",
     "entries": [
       { "item": "microwave", "prob": 90 },
-	  {  "distribution": [ { "item": "food_processor", "prob": 70 }, { "item": "multi_cooker", "prob": 50 },  { "item": "dehydrator", "prob": 30 }, { "item": "hotplate", "prob": 30 } ], "prob": 50 },
+      {
+        "distribution": [
+          { "item": "food_processor", "prob": 70 },
+          { "item": "multi_cooker", "prob": 50 },
+          { "item": "dehydrator", "prob": 30 },
+          { "item": "hotplate", "prob": 30 }
+        ],
+        "prob": 50
+      },
       { "item": "waffleiron", "prob": 45 },
       { "item": "pastaextruder", "prob": 10 },
       { "item": "soda_machine", "prob": 10 },

--- a/data/json/mapgen_palettes/house_general_palette.json
+++ b/data/json/mapgen_palettes/house_general_palette.json
@@ -191,7 +191,11 @@
       "4": { "item": "SUS_junk_drawer", "chance": 100 },
       "5": { "item": "SUS_kitchen_sink", "chance": 100 },
       "6": [ { "item": "SUS_pantry", "chance": 25 }, { "item": "cannedfood", "chance": 20, "repeat": [ 1, 2 ] } ],
-      "7": [ { "item": "SUS_breakfast_cupboard", "chance": 40 }, { "item": "SUS_coffee_cupboard", "chance": 50 }, { "item": "SUS_appliances_cupboard", "chance": 50 } ],
+      "7": [
+        { "item": "SUS_breakfast_cupboard", "chance": 40 },
+        { "item": "SUS_coffee_cupboard", "chance": 50 },
+        { "item": "SUS_appliances_cupboard", "chance": 50 }
+      ],
       "8": [
         { "item": "SUS_hair_drawer", "chance": 50 },
         { "item": "SUS_bathroom_cabinet", "chance": 50 },


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

It always puzzled me why I could never find a microwave in any house. Talking to the scrapyard vendor, you're given a mission to get microwaves for their magnetotrons. The advice the vendor gives you is basically "Check houses, almost everyone had a microwave prior to the cataclysm." 

I found out the reason why this wasn't the case. Only one house was actually assigned to the item group that spawns microwaves or any other appliances. It was literally impossible to find ordinary commonplace kitchen appliances other than coffeemakers at any house's kitchen for this reason.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

I decided to, rather than modify every single house in the game, modify the mapgen palette to include one itemgroup into one specific cupboard's symbol that is populated in nearly every house reliably.

The cupboard I chose was the one normally assigned both breakfast items such as toaster and cereal, and coffee items.

The itemgroup in question, SUS_appliances_cupboard, also got a touch-up to make it balanced and not overly generous.



## Describe alternatives you've considered

I considered dropping this itemgroup into a different map palette symbol's furniture - but honestly, having looked through several different distinct types of houses including bungalows, fenced houses, and three story houses, it just made more sense to go with the coffee cupboard's symbol instead. 

The other symbols weren't consistently present in every house design.

Granted, in my testing I found that even the coffee cupboard wasn't consistently present - but it was populating in enough house designs that it could be considered "universal."

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

I tested this again and again with numerous different weights assigned to see spawn rates.

Initial testing showed that higher weights are needed to spawn any of the item groups at all - with breakfast and coffee both set to 30, and appliances set to 40, there were times when nothing appeared in the cupboard.

Final number is set at 40/50/50. This reliably spawns any of the three groups - you will never have an empty cupboard. Sometimes you will have both coffee and breakfast plus microwave. Other times you will have just microwave and some coffee powder. But never bare tile.

Later testing showed that the itemgroup itself was not balanced very well - you could get a microwave _and_ multiple high-value appliances in addition such as a food processor and a multi-cooker. 

I addressed this by putting all the powered appliances except the soda machine and can sealer into a distribution - forcing the game to pick just one of them to spawn if at all. I gave it a weight of 50.

Testing with over 20 houses proved this was a solid solution overall  - you could still, if you had godly rng, get a soda machine in addition to one of the appliances and a microwave - but primarily you're getting a microwave and _maybe_ a food processor. 



## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

Primarily, I made these changes just to align a mission giver's advice with player expectations - if you're told to check houses for microwaves, then you should expect to find microwaves in houses. 

Obviously, once this content is mainlined, it can very easily be rebalanced as desired. 

At least now, most houses in the game have _a chance at all_ of having kitchen appliances in them.

 It's not simply a race to collect the most coffeemakers anymore.

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
