### PR TITLE
fix: Unicode names in folded vehicle names no longer cause game crashes

### DIFF
--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -980,7 +980,7 @@ bool vehicle::fold_up()
         folding_veh_item->set_var( "weight", to_milligram( total_mass() ) );
         folding_veh_item->set_var( "volume", total_folded_volume() / units::legacy_volume_factor );
         // remove "folded" from name to allow for more flexibility with folded vehicle names. also lowers first character
-        folding_veh_item->set_var( "name", string_format( _( "%s" ), to_lower_case( name ) ) );
+        folding_veh_item->set_var( "name", to_lower_case( name ) );
         folding_veh_item->set_var( "vehicle_name", name );
         // TODO: a better description?
         folding_veh_item->set_var( "description", string_format( _( "A folded %s." ), name ) );


### PR DESCRIPTION
## Purpose of change (The Why)
I believe this should resolve the following:
actually unsure here: #8277 
closes: #7499 
closes: #6293 
closes: #7546 
closes: #7697 

## Describe the solution (The How)
Instead of using std::tolower
Instead use string_utils::to_lower_case

## Describe alternatives you've considered
None

## Testing
Do note: I had difficulty replicating the issues in main; This should work though for a solution

Copied some Unicode characters into the field
Folded
Save didn't blow up
Used other chars
Name was lowercased

## Additional Context
This will not fix any already existing cases of the issue

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.