### PR TITLE
fix: add `UNIQUE` flag to hunting lodge variant to not spam 10-100 of them per overmap chunk

### DIFF
--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -24,9 +24,9 @@
     "connections": [ { "point": [ -1, 0, 0 ], "connection": "local_road", "existing": true, "from": [ 0, 0, 0 ] } ],
     "locations": [ "forest" ],
     "city_distance": [ 30, -1 ],
-    "city_sizes": [ 0, 12 ],
+    "city_sizes": [ 1, 20 ],
     "occurrences": [ 10, 100 ],
-    "flags": [ "CLASSIC", "WILDERNESS", "MAN_MADE", "UNIQUE", "ELECTRIC_GRID", "FLUID_GRID" ]
+    "flags": [ "CLASSIC", "MAN_MADE", "UNIQUE", "ELECTRIC_GRID", "FLUID_GRID" ]
   },
   {
     "type": "overmap_special",
@@ -44,9 +44,9 @@
     "connections": [ { "point": [ -1, 0, 0 ], "connection": "local_road", "existing": true, "from": [ 0, 0, 0 ] } ],
     "locations": [ "forest" ],
     "city_distance": [ 30, -1 ],
-    "city_sizes": [ 0, 12 ],
+    "city_sizes": [ 1, 20 ],
     "occurrences": [ 0, 1 ],
-    "flags": [ "CLASSIC", "WILDERNESS", "MAN_MADE", "ELECTRIC_GRID", "FLUID_GRID" ]
+    "flags": [ "CLASSIC", "MAN_MADE", "ELECTRIC_GRID", "FLUID_GRID" ]
   },
   {
     "type": "overmap_special",


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

DDA ports gonna DDA, https://github.com/cataclysmbn/Cataclysm-BN/pull/8174 forgot a fairly important flag presumably because the DDA version would've uses a different name for its local-unique flag so it probably got removed during testing but without getting the BN version of the flag put in its place.

Fixes https://github.com/cataclysmbn/Cataclysm-BN/issues/8280

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. Added `UNIQUE` flag to the version of hunting lodges that had 10-100 occurrences, as that's very obviously meant to be a 10% chance per overmap chunk.
2. Also fixed some inexplicable regressions made to regular movie theaters in that PR.
3. Fixed hunting lodges being allowed to spawn in zero city size worlds despite needing an EXISTING road connection, which is asking for trouble since roads are much more rare in those worlds. In exchange bumped max city size up to 20.
4. Misc: Also added `ELECTRIC_GRID` and `FLUID_GRID` to both variants of hunting lodges.

## Describe alternatives you've considered

Adding `GLOBALLY_UNIQUE` instead, dunno if there's really enough special about it to warrant that though.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected file for syntax and lint errors.
2. Load-tested in compiled test build.
3. Used my eyes to confirm that the only overmap special added by the PR that has a fuckload of mininum ocurrences now has the `UNIQUE` flag.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
