### PR TITLE
feat: bone plating & ram vehicle part

### DIFF
--- a/data/json/vehicleparts/plating.json
+++ b/data/json/vehicleparts/plating.json
@@ -33,7 +33,7 @@
     "requirements": {
       "install": { "skills": [ [ "mechanics", 2 ] ], "time": "10 m", "using": [ [ "rope_natural", 1 ] ] },
       "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "5 m", "using": [ [ "vehicle_weld_removal", 1 ] ] },
-      "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "5 m", "using": [ [ "armor_chitin", 3 ] ] }
+      "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "5 m", "using": [ [ "bone_sturdy", 3 ] ] }
     },
     "flags": [ "ARMOR" ],
     "breaks_into": [ { "item": "bone", "count": [ 5, 15 ] } ],

--- a/data/json/vehicleparts/rams.json
+++ b/data/json/vehicleparts/rams.json
@@ -163,7 +163,7 @@
     "breaks_into": [ { "item": "bone", "count": [ 5, 15 ] } ],
     "requirements": {
       "install": { "skills": [ [ "mechanics", 2 ] ], "time": "60 m", "using": [ [ "rope_natural", 1 ] ] },
-      "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "60 m", "using": [ [ "adhesive", 1 ], [ "armor_chitin", 3 ] ] }
+      "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "60 m", "using": [ [ "adhesive", 1 ], [ "bone_sturdy", 3 ] ] }
     },
     "damage_reduction": { "all": 75 }
   },


### PR DESCRIPTION
## Note
Balancing consideration required. Please advise. Skills, components, durability etc.

## Purpose of change (The Why)
bone plating exists as a craftable item, however it lacks a vehicle part. So, while the player can craft the bone plating item, they can not apply it to the vehicle. This PR adds a vehicle part, so that the bone plating item can be applied to vehicles.

## Describe the solution (The How)
Create a vehicle part entry for `bone_plating`

## Describe alternatives you've considered
Removing the recipes to create a bone plating item, since it can not be used in any meaningful way without a corresponding vehicle part.

## Testing
Created a new character, used debug to spawn a vehicle and confirmed that the bone plating item exists in the ui. Spawned the pre-existing `bone armor kit` item, and applied it to the spawned vehicle.

## Additional context
<img width="1283" height="292" alt="image" src="https://github.com/user-attachments/assets/998a1375-4ee6-4262-8374-0ed65b748500" />


## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
