### PR TITLE
test: prevent vehicle tests from exploding on changing vehicle prototypes

### DIFF
--- a/data/mods/TEST_DATA/vehicles.json
+++ b/data/mods/TEST_DATA/vehicles.json
@@ -1,0 +1,4791 @@
+[
+  {
+    "id": "bicycle_test",
+    "type": "vehicle",
+    "name": "Bicycle",
+    "blueprint": [ "o#o" ],
+    "parts": [
+      { "x": 1, "y": 0, "parts": [ "xlframe_vertical", "wheel_mount_light_steerable", "wheel_bicycle" ] },
+      { "x": 0, "y": 0, "parts": [ "xlframe_vertical_2", "saddle_pedal", "horn_bicycle", "foot_pedals" ] },
+      {
+        "x": -1,
+        "y": 0,
+        "parts": [ "xlframe_vertical", "wheel_mount_light", "wheel_bicycle_rear", "basketsm_bike_rear" ]
+      }
+    ],
+    "items": [  ]
+  },
+  {
+    "id": "bicycle_electric_test",
+    "type": "vehicle",
+    "name": "Electric Bicycle",
+    "blueprint": [ "o#o" ],
+    "parts": [
+      { "x": 1, "y": 0, "parts": [ "xlframe_vertical", "wheel_mount_light_steerable", "wheel_bicycle", "headlight" ] },
+      {
+        "x": 0,
+        "y": 0,
+        "parts": [
+          "xlframe_vertical_2",
+          "saddle_pedal",
+          "horn_bicycle",
+          "foot_pedals",
+          "controls",
+          "controls_electronic",
+          "alternator_bicycle"
+        ]
+      },
+      {
+        "x": -1,
+        "y": 0,
+        "parts": [
+          "xlframe_vertical",
+          "wheel_mount_light",
+          "wheel_bicycle_rear",
+          "basketsm_bike_rear",
+          "small_storage_battery",
+          "engine_electric_tiny"
+        ]
+      }
+    ],
+    "items": [  ]
+  },
+  {
+    "id": "motorcycle_test",
+    "type": "vehicle",
+    "name": "Motorcycle",
+    "blueprint": [ "o#>o" ],
+    "parts": [
+      {
+        "x": 1,
+        "y": 0,
+        "parts": [ "frame_handle", { "part": "tank_small", "fuel": "gasoline" }, "headlight", "battery_motorbike" ]
+      },
+      {
+        "x": 0,
+        "y": 0,
+        "parts": [
+          "frame_vertical_2",
+          "saddle_motor",
+          "motorcycle_kickstand",
+          "controls",
+          "controls_electronic",
+          "vehicle_alarm",
+          "horn_car",
+          "engine_vtwin",
+          "alternator_motorbike"
+        ]
+      },
+      { "x": 2, "y": 0, "parts": [ "frame_vertical", "wheel_mount_light_steerable", "wheel_motorbike" ] },
+      {
+        "x": -1,
+        "y": 0,
+        "parts": [ "frame_vertical", "wheel_mount_light", "wheel_motorbike_rear", "muffler", "box" ]
+      }
+    ],
+    "items": [  ]
+  },
+  {
+    "id": "motorcycle_sidecart_test",
+    "type": "vehicle",
+    "name": "Motorcycle",
+    "blueprint": [
+      [ "o#>o" ],
+      [ " #> " ]
+    ],
+    "parts": [
+      {
+        "x": 1,
+        "y": 0,
+        "parts": [ "frame_handle", { "part": "tank_small", "fuel": "gasoline" }, "headlight", "battery_motorbike" ]
+      },
+      { "x": 1, "y": 1, "parts": [ "frame_handle", "box" ] },
+      {
+        "x": 0,
+        "y": 0,
+        "parts": [
+          "frame_vertical_2",
+          "saddle_motor",
+          "controls",
+          "controls_electronic",
+          "vehicle_alarm",
+          "horn_car",
+          "engine_vtwin",
+          "alternator_motorbike"
+        ]
+      },
+      { "x": 2, "y": 0, "parts": [ "frame_vertical", "wheel_mount_light_steerable", "wheel_motorbike" ] },
+      {
+        "x": -1,
+        "y": 0,
+        "parts": [ "frame_vertical", "wheel_mount_light", "wheel_motorbike_rear", "muffler", "box" ]
+      },
+      { "x": 0, "y": 1, "parts": [ "frame_cross", "wheel_mount_light", "wheel_motorbike", "seat" ] }
+    ],
+    "items": [
+      { "x": -1, "y": 0, "chance": 2, "items": [ "joint" ] },
+      { "x": -1, "y": 0, "chance": 8, "items": [ "helmet_motor" ] },
+      { "x": 0, "y": 1, "chance": 33, "items": [ "helmet_motor" ] }
+    ]
+  },
+  {
+    "id": "quad_bike_test",
+    "type": "vehicle",
+    "name": "Quad Bike",
+    "blueprint": [
+      [ "O O" ],
+      [ "=#>" ],
+      [ "O O" ]
+    ],
+    "parts": [
+      { "x": -1, "y": 1, "parts": [ "frame_horizontal", "wheel_mount_light", "wheel_motorbike_or_rear" ] },
+      { "x": -1, "y": -1, "parts": [ "frame_horizontal", "wheel_mount_light", "wheel_motorbike_or_rear" ] },
+      {
+        "x": 1,
+        "y": 0,
+        "parts": [
+          "frame_cover",
+          "engine_vtwin",
+          "alternator_motorbike",
+          "battery_motorbike",
+          "headlight",
+          { "part": "tank_small", "fuel": "gasoline" },
+          "plating_steel"
+        ]
+      },
+      { "x": 1, "y": 1, "parts": [ "frame_horizontal", "wheel_mount_light_steerable", "wheel_motorbike_or" ] },
+      {
+        "x": 0,
+        "y": 0,
+        "parts": [ "frame_vertical_2", "saddle_motor", "controls", "controls_electronic", "horn_car" ]
+      },
+      { "x": -1, "y": 0, "parts": [ "frame_horizontal", "muffler", "trunk" ] },
+      { "x": 1, "y": -1, "parts": [ "frame_horizontal", "wheel_mount_light_steerable", "wheel_motorbike_or" ] }
+    ],
+    "items": [ { "x": -1, "y": 0, "chance": 10, "items": [ "helmet_motor" ] } ]
+  },
+  {
+    "id": "scooter_test",
+    "type": "vehicle",
+    "name": "Scooter",
+    "blueprint": [ "o>o" ],
+    "parts": [
+      { "x": 1, "y": 0, "parts": [ "xlframe_vertical", "wheel_mount_light_steerable", "wheel_small" ] },
+      {
+        "x": 0,
+        "y": 0,
+        "parts": [
+          "frame_handle",
+          "headlight",
+          "saddle_motor",
+          "controls",
+          "controls_electronic",
+          "horn_car",
+          "motorcycle_kickstand",
+          "engine_1cyl",
+          "alternator_motorbike",
+          "battery_motorbike",
+          { "part": "tank_small", "fuel": "gasoline" }
+        ]
+      },
+      { "x": -1, "y": 0, "parts": [ "xlframe_vertical", "wheel_mount_light", "wheel_small", "muffler" ] }
+    ],
+    "items": [  ]
+  },
+  {
+    "id": "scooter_electric_test",
+    "type": "vehicle",
+    "name": "Electric Scooter",
+    "blueprint": [ "o>o" ],
+    "parts": [
+      { "x": 1, "y": 0, "parts": [ "xlframe_vertical", "wheel_mount_light_steerable", "wheel_small" ] },
+      {
+        "x": 0,
+        "y": 0,
+        "parts": [
+          "frame_handle",
+          "headlight",
+          "saddle_motor",
+          "controls",
+          "controls_electronic",
+          "horn_car",
+          "motorcycle_kickstand",
+          "medium_storage_battery",
+          "engine_electric_small"
+        ]
+      },
+      { "x": -1, "y": 0, "parts": [ "xlframe_vertical", "wheel_mount_light", "wheel_small", "foldable_solar_panel" ] }
+    ],
+    "items": [  ]
+  },
+  {
+    "id": "superbike_test",
+    "type": "vehicle",
+    "name": "Superbike",
+    "blueprint": [ "o#>o" ],
+    "parts": [
+      {
+        "x": 1,
+        "y": 0,
+        "parts": [ "frame_handle", { "part": "tank_small", "fuel": "gasoline" }, "headlight", "battery_car" ]
+      },
+      {
+        "x": 0,
+        "y": 0,
+        "parts": [
+          "frame_vertical_2",
+          "saddle_motor",
+          "motorcycle_kickstand",
+          "controls",
+          "controls_electronic",
+          "vehicle_alarm",
+          "horn_car",
+          "engine_inline4",
+          "alternator_motorbike"
+        ]
+      },
+      { "x": 2, "y": 0, "parts": [ "frame_vertical", "wheel_mount_light_steerable", "wheel_motorbike" ] },
+      { "x": -1, "y": 0, "parts": [ "frame_vertical", "wheel_mount_light", "wheel_motorbike_rear", "muffler" ] }
+    ],
+    "items": [  ]
+  },
+  {
+    "id": "tandem_test",
+    "type": "vehicle",
+    "name": "Tandem",
+    "blueprint": [ "o##o" ],
+    "parts": [
+      { "x": 1, "y": 0, "parts": [ "xlframe_vertical", "wheel_mount_light_steerable", "wheel_bicycle" ] },
+      {
+        "x": -2,
+        "y": 0,
+        "parts": [ "xlframe_vertical", "wheel_mount_light", "wheel_bicycle_rear", "basketsm_bike_rear" ]
+      },
+      { "x": 0, "y": 0, "parts": [ "xlframe_vertical_2", "saddle_motor", "horn_bicycle", "foot_pedals" ] },
+      { "x": -1, "y": 0, "parts": [ "xlframe_vertical_2", "saddle_pedal", "foot_pedals" ] }
+    ],
+    "items": [  ]
+  },
+  {
+    "id": "unicycle_test",
+    "type": "vehicle",
+    "name": "Unicycle",
+    "blueprint": [ "#" ],
+    "parts": [ { "x": 0, "y": 0, "parts": [ "frame_handle", "saddle", "foot_pedals", "wheel_mount_light", "wheel_unicycle" ] } ],
+    "items": [  ]
+  },
+  {
+    "id": "beetle_test",
+    "type": "vehicle",
+    "name": "Beetle",
+    "blueprint": [
+      [ "o+-o" ],
+      [ "|=|=" ],
+      [ "|=|=" ],
+      [ "o+-o" ]
+    ],
+    "parts": [
+      { "x": -1, "y": 1, "parts": [ "frame_nw", "halfboard_horizontal" ] },
+      {
+        "x": 2,
+        "y": 2,
+        "parts": [ "frame_ne", "halfboard_ne", "headlight", "wheel_mount_medium_steerable", "wheel" ]
+      },
+      { "x": 0, "y": 2, "parts": [ "frame_vertical", "door_front_right" ] },
+      {
+        "x": 2,
+        "y": -1,
+        "parts": [ "frame_nw", "halfboard_nw", "headlight", "wheel_mount_medium_steerable", "wheel" ]
+      },
+      { "x": -1, "y": -1, "parts": [ "frame_horizontal", "halfboard_sw", "wheel_mount_medium", "wheel" ] },
+      { "x": 1, "y": 0, "parts": [ "frame_horizontal", "windshield_horizontal_front" ] },
+      { "x": 1, "y": 1, "parts": [ "frame_horizontal", "windshield_horizontal_front" ] },
+      {
+        "x": 0,
+        "y": 0,
+        "parts": [ "frame_vertical_2", "seat", "seatbelt", "roof", "controls", "dashboard", "vehicle_alarm", "horn_car" ]
+      },
+      { "x": 2, "y": 0, "parts": [ "frame_vertical_2", "trunk" ] },
+      {
+        "x": -1,
+        "y": 0,
+        "parts": [ "frame_ne", "halfboard_horizontal", "engine_inline4", "alternator_car", "battery_car" ]
+      },
+      { "x": 0, "y": 1, "parts": [ "frame_vertical_2", "seat", "seatbelt", "roof" ] },
+      { "x": 0, "y": -1, "parts": [ "frame_vertical", "door_front_left" ] },
+      { "x": 1, "y": 2, "parts": [ "frame_vertical", "windshield_ne" ] },
+      { "x": -1, "y": 2, "parts": [ "frame_horizontal", "halfboard_se", "wheel_mount_medium", "wheel" ] },
+      { "x": 2, "y": 1, "parts": [ "frame_vertical_2", "trunk", { "part": "tank", "fuel": "gasoline" } ] },
+      { "x": 1, "y": -1, "parts": [ "frame_vertical", "windshield_nw" ] }
+    ],
+    "items": [
+      { "x": 0, "y": 0, "chance": 8, "item_groups": [ "car_misc" ] },
+      { "x": 2, "y": 0, "chance": 6, "item_groups": [ "car_kit" ] },
+      { "x": 2, "y": 1, "chance": 8, "item_groups": [ "car_kit" ] },
+      { "x": 2, "y": 1, "chance": 8, "items": [ "jack_small", "wheel" ] }
+    ]
+  },
+  {
+    "id": "bubble_car_test",
+    "type": "vehicle",
+    "name": "Bubble Car",
+    "blueprint": [
+      [ " --- " ],
+      [ "+o#o-" ],
+      [ "|=##|" ],
+      [ "+o#o-" ],
+      [ " --- " ]
+    ],
+    "parts": [
+      { "x": -3, "y": 1, "parts": [ "xlframe_se", "windshield" ] },
+      { "x": -1, "y": 1, "parts": [ "xlframe_vertical_2", "engine_electric", "seat", "seatbelt", "roof" ] },
+      { "x": 0, "y": 2, "parts": [ "xlframe_ne", "windshield" ] },
+      { "x": -1, "y": -1, "parts": [ "xlframe_vertical_2", "engine_electric", "seat", "seatbelt", "roof" ] },
+      { "x": -2, "y": 2, "parts": [ "xlframe_sw", "door" ] },
+      { "x": 1, "y": 0, "parts": [ "xlframe_horizontal", "windshield" ] },
+      { "x": 0, "y": -2, "parts": [ "xlframe_nw", "windshield" ] },
+      { "x": -1, "y": -2, "parts": [ "xlframe_vertical", "windshield" ] },
+      { "x": 1, "y": 1, "parts": [ "xlframe_ne", "windshield" ] },
+      { "x": -3, "y": 0, "parts": [ "xlframe_horizontal", "windshield" ] },
+      { "x": -2, "y": 0, "parts": [ "xlframe_horizontal", "medium_storage_battery", "trunk", "roof" ] },
+      {
+        "x": 0,
+        "y": 0,
+        "parts": [ "xlframe_horizontal", "seat", "seatbelt", "roof", "drive_by_wire_controls", "dashboard", "vehicle_alarm", "horn_car" ]
+      },
+      { "x": -2, "y": -2, "parts": [ "xlframe_se", "door" ] },
+      {
+        "x": -1,
+        "y": 0,
+        "parts": [ "xlframe_vertical_2", "seat", "engine_electric", "minireactor", "seatbelt", "roof", "headlight" ]
+      },
+      { "x": -2, "y": 1, "parts": [ "xlframe_cross", "wheel_mount_medium_steerable", "wheel", "windshield" ] },
+      { "x": 0, "y": 1, "parts": [ "xlframe_cross", "wheel_mount_medium_steerable", "wheel", "windshield" ] },
+      { "x": 0, "y": -1, "parts": [ "xlframe_cross", "wheel_mount_medium_steerable", "wheel", "windshield" ] },
+      { "x": -1, "y": 2, "parts": [ "xlframe_vertical", "windshield" ] },
+      { "x": 1, "y": -1, "parts": [ "xlframe_nw", "windshield" ] },
+      { "x": -2, "y": -1, "parts": [ "xlframe_cross", "wheel_mount_medium_steerable", "wheel", "windshield" ] },
+      { "x": -3, "y": -1, "parts": [ "xlframe_sw", "windshield" ] }
+    ],
+    "items": [
+      { "x": -2, "y": 0, "chance": 3, "item_groups": [ "car_kit" ] },
+      { "x": -2, "y": 0, "chance": 3, "items": [ "jack_small", "wheel" ] }
+    ]
+  },
+  {
+    "id": "car_test",
+    "type": "vehicle",
+    "name": "Car",
+    "blueprint": [
+      [ "o-++-o" ],
+      [ "+=##'|" ],
+      [ "+=##'|" ],
+      [ "o-++-o" ]
+    ],
+    "parts": [
+      { "x": -3, "y": 1, "parts": [ "frame_horizontal", "door_trunk" ] },
+      { "x": -1, "y": 1, "parts": [ "frame_vertical_2", "seat", "seatbelt", "roof" ] },
+      {
+        "x": 2,
+        "y": 2,
+        "parts": [ "frame_ne", "halfboard_ne", "wheel_mount_medium_steerable", "wheel", "headlight" ]
+      },
+      { "x": 0, "y": 2, "parts": [ "frame_vertical", "door_front_right" ] },
+      {
+        "x": 2,
+        "y": -1,
+        "parts": [ "frame_nw", "halfboard_nw", "wheel_mount_medium_steerable", "wheel", "headlight" ]
+      },
+      { "x": -1, "y": -1, "parts": [ "frame_vertical", "door_rear_left" ] },
+      { "x": -2, "y": 2, "parts": [ "frame_vertical", "halfboard_vertical_right" ] },
+      { "x": 1, "y": 0, "parts": [ "frame_horizontal", "windshield_horizontal_front" ] },
+      { "x": -3, "y": 2, "parts": [ "frame_horizontal", "halfboard_se", "wheel_mount_medium", "wheel" ] },
+      { "x": 1, "y": 1, "parts": [ "frame_horizontal", "windshield_horizontal_front" ] },
+      { "x": -3, "y": 0, "parts": [ "frame_horizontal", "door_trunk" ] },
+      { "x": -2, "y": 0, "parts": [ "frame_vertical", "trunk", "muffler", "roof" ] },
+      {
+        "x": 0,
+        "y": 0,
+        "parts": [
+          "frame_vertical_2",
+          "reclining_seat",
+          "seatbelt",
+          "controls",
+          "dashboard",
+          "vehicle_clock",
+          "vehicle_alarm",
+          "stereo",
+          "horn_car",
+          "roof"
+        ]
+      },
+      {
+        "x": 2,
+        "y": 0,
+        "parts": [ "frame_horizontal", "halfboard_horizontal_front", "engine_inline4", "alternator_car", "battery_car" ]
+      },
+      { "x": -1, "y": 0, "parts": [ "frame_vertical_2", "seat", "seatbelt", "roof" ] },
+      { "x": -2, "y": 1, "parts": [ "frame_vertical", "trunk", "roof" ] },
+      { "x": 0, "y": 1, "parts": [ "frame_vertical_2", "reclining_seat", "seatbelt", "roof" ] },
+      { "x": 0, "y": -1, "parts": [ "frame_vertical", "door_front_left" ] },
+      { "x": -1, "y": 2, "parts": [ "frame_vertical", "door_rear_right" ] },
+      { "x": 1, "y": 2, "parts": [ "frame_vertical", "windshield_ne" ] },
+      { "x": 2, "y": 1, "parts": [ "frame_horizontal", "halfboard_horizontal_front" ] },
+      { "x": 1, "y": -1, "parts": [ "frame_vertical", "windshield_nw" ] },
+      {
+        "x": -2,
+        "y": -1,
+        "parts": [ "frame_vertical", "halfboard_vertical_left", { "part": "tank", "fuel": "gasoline" } ]
+      },
+      { "x": -3, "y": -1, "parts": [ "frame_horizontal", "halfboard_sw", "wheel_mount_medium", "wheel" ] }
+    ],
+    "items": [
+      { "x": 0, "y": 0, "chance": 14, "item_groups": [ "car_misc" ] },
+      { "x": 0, "y": 0, "chance": 5, "item_groups": [ "snacks" ] },
+      { "x": 0, "y": 1, "chance": 8, "item_groups": [ "car_misc" ] },
+      { "x": 0, "y": 1, "chance": 2, "item_groups": [ "fast_food" ] },
+      { "x": -2, "y": 0, "chance": 11, "item_groups": [ "car_kit" ] },
+      { "x": -2, "y": 1, "chance": 15, "item_groups": [ "car_kit" ] },
+      { "x": -2, "y": 1, "chance": 15, "items": [ "jack_small", "wheel" ] }
+    ]
+  },
+  {
+    "id": "car_mini_test",
+    "type": "vehicle",
+    "name": "City Car",
+    "blueprint": [
+      [ "o+-o" ],
+      [ "+#'|" ],
+      [ "+#'|" ],
+      [ "o+-o" ]
+    ],
+    "parts": [
+      { "x": 2, "y": 2, "parts": [ "frame_ne", "halfboard_ne", "wheel_mount_medium_steerable", "wheel", "headlight" ] },
+      { "x": -1, "y": 1, "parts": [ "frame_horizontal", "hatch" ] },
+      { "x": 0, "y": 2, "parts": [ "frame_vertical", "door_rear_right" ] },
+      {
+        "x": 2,
+        "y": -1,
+        "parts": [ "frame_nw", "halfboard_nw", "wheel_mount_medium_steerable", "wheel", "headlight" ]
+      },
+      {
+        "x": -1,
+        "y": -1,
+        "parts": [ "frame_horizontal", { "part": "tank_small", "fuel": "gasoline" }, "halfboard_sw", "wheel_mount_medium", "wheel" ]
+      },
+      { "x": 1, "y": 0, "parts": [ "frame_horizontal", "windshield_horizontal_front" ] },
+      { "x": 1, "y": 1, "parts": [ "frame_horizontal", "windshield_horizontal_front" ] },
+      {
+        "x": 0,
+        "y": 0,
+        "parts": [
+          "frame_vertical_2",
+          "seat",
+          "seatbelt",
+          "controls",
+          "dashboard",
+          "vehicle_clock",
+          "vehicle_alarm",
+          "horn_car",
+          "roof"
+        ]
+      },
+      {
+        "x": 2,
+        "y": 0,
+        "parts": [ "frame_horizontal", "halfboard_horizontal_front", "engine_inline4", "alternator_car", "battery_car" ]
+      },
+      { "x": -1, "y": 0, "parts": [ "frame_horizontal", "hatch", "muffler" ] },
+      { "x": 0, "y": 1, "parts": [ "frame_vertical_2", "seat", "seatbelt", "roof" ] },
+      { "x": 0, "y": -1, "parts": [ "frame_vertical", "door_rear_left" ] },
+      { "x": 1, "y": 2, "parts": [ "frame_vertical", "windshield_ne" ] },
+      {
+        "x": -1,
+        "y": 2,
+        "parts": [ "frame_horizontal", { "part": "tank_small", "fuel": "gasoline" }, "halfboard_se", "wheel_mount_medium", "wheel" ]
+      },
+      { "x": 2, "y": 1, "parts": [ "frame_horizontal", "halfboard_horizontal_front" ] },
+      { "x": 1, "y": -1, "parts": [ "frame_vertical", "windshield_nw" ] }
+    ],
+    "items": [
+      { "x": 0, "y": 0, "chance": 5, "item_groups": [ "car_misc" ] },
+      { "x": -1, "y": 0, "chance": 5, "items": [ "mag_glam" ] }
+    ]
+  },
+  {
+    "id": "car_sports_test",
+    "type": "vehicle",
+    "name": "Sports Car",
+    "blueprint": [
+      [ "o-+-o" ],
+      [ "+=#'|" ],
+      [ "+=#'|" ],
+      [ "o-+-o" ]
+    ],
+    "parts": [
+      { "x": 2, "y": 2, "parts": [ "frame_ne", "halfboard_ne", "wheel_mount_medium_steerable", "wheel_slick", "headlight" ] },
+      { "x": -1, "y": 1, "parts": [ "frame_vertical", "trunk", "roof" ] },
+      { "x": 0, "y": 2, "parts": [ "frame_vertical", "door_front_right" ] },
+      {
+        "x": 2,
+        "y": -1,
+        "parts": [ "frame_nw", "halfboard_nw", "wheel_mount_medium_steerable", "wheel_slick", "headlight" ]
+      },
+      {
+        "x": -1,
+        "y": -1,
+        "parts": [ "frame_vertical", "halfboard_vertical_left", { "part": "tank", "fuel": "gasoline" } ]
+      },
+      { "x": -2, "y": 2, "parts": [ "frame_horizontal", "halfboard_se", "wheel_mount_medium", "wheel_slick" ] },
+      { "x": 1, "y": 0, "parts": [ "frame_horizontal", "windshield_horizontal_front" ] },
+      { "x": 1, "y": 1, "parts": [ "frame_horizontal", "windshield_horizontal_front" ] },
+      { "x": -2, "y": 0, "parts": [ "frame_horizontal", "door_trunk" ] },
+      {
+        "x": 0,
+        "y": 0,
+        "parts": [ "frame_vertical_2", "seat_leather", "seatbelt", "controls", "dashboard", "vehicle_alarm", "horn_car", "roof" ]
+      },
+      {
+        "x": 2,
+        "y": 0,
+        "parts": [ "frame_horizontal", "halfboard_horizontal_front", "engine_v12", "alternator_car", "battery_car" ]
+      },
+      { "x": -1, "y": 0, "parts": [ "frame_vertical", "trunk", "muffler", "roof" ] },
+      { "x": -2, "y": 1, "parts": [ "frame_horizontal", "door_trunk" ] },
+      { "x": 0, "y": 1, "parts": [ "frame_vertical_2", "seat_leather", "seatbelt", "roof" ] },
+      { "x": 0, "y": -1, "parts": [ "frame_vertical", "door_front_left" ] },
+      { "x": 1, "y": 2, "parts": [ "frame_vertical", "windshield_ne" ] },
+      { "x": -1, "y": 2, "parts": [ "frame_vertical", "halfboard_vertical_right" ] },
+      { "x": 2, "y": 1, "parts": [ "frame_horizontal", "halfboard_horizontal_front" ] },
+      { "x": 1, "y": -1, "parts": [ "frame_vertical", "windshield_nw" ] },
+      { "x": -2, "y": -1, "parts": [ "frame_horizontal", "halfboard_sw", "wheel_mount_medium", "wheel_slick" ] }
+    ],
+    "items": [
+      { "x": 0, "y": 0, "chance": 10, "item_groups": [ "snacks_fancy" ] },
+      { "x": 0, "y": 1, "chance": 10, "item_groups": [ "snacks_fancy" ] }
+    ]
+  },
+  {
+    "id": "car_sports_atomic_test",
+    "type": "vehicle",
+    "name": "Atomic Sports Car",
+    "blueprint": [
+      [ "o--+-o" ],
+      [ "=>'#'|" ],
+      [ "=>'#'|" ],
+      [ "o--+-o" ]
+    ],
+    "parts": [
+      {
+        "x": -3,
+        "y": 1,
+        "parts": [ "hdframe_horizontal", "halfboard_horizontal", "engine_electric_enhanced", "plating_steel" ]
+      },
+      { "x": -1, "y": 1, "parts": [ "frame_vertical_2", "windshield", "roof" ] },
+      {
+        "x": 2,
+        "y": 2,
+        "parts": [ "frame_ne", "halfboard_ne", "wheel_mount_medium_steerable", "wheel_slick", "headlight" ]
+      },
+      { "x": 0, "y": 2, "parts": [ "frame_vertical", "door_rear_right" ] },
+      {
+        "x": 2,
+        "y": -1,
+        "parts": [ "frame_nw", "halfboard_nw", "wheel_mount_medium_steerable", "wheel_slick", "headlight" ]
+      },
+      { "x": -1, "y": -1, "parts": [ "frame_vertical", "halfboard_vertical_left" ] },
+      { "x": -2, "y": 2, "parts": [ "frame_vertical", "halfboard_vertical_right" ] },
+      { "x": 1, "y": 0, "parts": [ "frame_horizontal", "windshield_horizontal_front" ] },
+      { "x": -3, "y": 2, "parts": [ "frame_horizontal", "halfboard_se", "wheel_mount_medium", "wheel_slick" ] },
+      { "x": 1, "y": 1, "parts": [ "frame_horizontal", "windshield_horizontal_front" ] },
+      {
+        "x": -3,
+        "y": 0,
+        "parts": [ "hdframe_horizontal", "halfboard_horizontal_rear", "engine_electric_enhanced", "plating_steel" ]
+      },
+      { "x": -2, "y": 0, "parts": [ "hdframe_vertical", "minireactor", "halfboard_cover", "plating_steel" ] },
+      {
+        "x": 0,
+        "y": 0,
+        "parts": [
+          "frame_vertical_2",
+          "seat_leather",
+          "seatbelt",
+          "controls",
+          "dashboard",
+          "vehicle_alarm",
+          "stereo",
+          "horn_car",
+          "roof"
+        ]
+      },
+      { "x": 2, "y": 0, "parts": [ "frame_horizontal", "halfboard_horizontal_front" ] },
+      { "x": -1, "y": 0, "parts": [ "frame_vertical_2", "windshield", "roof" ] },
+      {
+        "x": -2,
+        "y": 1,
+        "parts": [ "hdframe_vertical", "storage_battery_mount", "storage_battery_removable", "halfboard_cover", "plating_steel" ]
+      },
+      { "x": 0, "y": 1, "parts": [ "frame_vertical_2", "seat_leather", "seatbelt", "roof" ] },
+      { "x": 0, "y": -1, "parts": [ "frame_vertical", "door_rear_left" ] },
+      { "x": -1, "y": 2, "parts": [ "frame_vertical", "halfboard_vertical_right" ] },
+      { "x": 1, "y": 2, "parts": [ "frame_vertical", "windshield_ne" ] },
+      { "x": 2, "y": 1, "parts": [ "frame_horizontal", "halfboard_horizontal_front" ] },
+      { "x": 1, "y": -1, "parts": [ "frame_vertical", "windshield_nw" ] },
+      { "x": -2, "y": -1, "parts": [ "frame_vertical", "halfboard_vertical_left" ] },
+      { "x": -3, "y": -1, "parts": [ "frame_horizontal", "halfboard_sw", "wheel_mount_medium", "wheel_slick" ] }
+    ],
+    "items": [
+      { "x": 0, "y": 0, "chance": 16, "items": [ "coke" ] },
+      { "x": 0, "y": 0, "chance": 8, "item_groups": [ "snacks_fancy" ] },
+      { "x": 0, "y": 1, "chance": 10, "item_groups": [ "snacks_fancy" ] },
+      { "x": 0, "y": 1, "chance": 5, "item_groups": [ "female_underwear" ] }
+    ]
+  },
+  {
+    "id": "car_sports_electric_test",
+    "type": "vehicle",
+    "name": "Electric Sports Car",
+    "blueprint": [
+      [ "o-+-o" ],
+      [ "+=#'|" ],
+      [ "+=#'|" ],
+      [ "o-+-o" ]
+    ],
+    "parts": [
+      {
+        "x": 2,
+        "y": 2,
+        "parts": [ "xlframe_ne", "xlhalfboard_ne", "wheel_mount_medium_steerable", "wheel_slick", "headlight" ]
+      },
+      { "x": -1, "y": 1, "parts": [ "frame_vertical", "storage_battery", "trunk", "roof" ] },
+      { "x": 0, "y": 2, "parts": [ "xlframe_vertical", "door_rear_right" ] },
+      {
+        "x": 2,
+        "y": -1,
+        "parts": [ "xlframe_nw", "xlhalfboard_nw", "wheel_mount_medium_steerable", "wheel_slick", "headlight" ]
+      },
+      { "x": -1, "y": -1, "parts": [ "xlframe_vertical", "xlhalfboard_vertical_left" ] },
+      { "x": -2, "y": 2, "parts": [ "xlframe_horizontal", "xlhalfboard_se", "wheel_mount_medium", "wheel_slick" ] },
+      { "x": 1, "y": 0, "parts": [ "xlframe_horizontal", "windshield_horizontal_front" ] },
+      { "x": 1, "y": 1, "parts": [ "xlframe_horizontal", "windshield_horizontal_front" ] },
+      { "x": -2, "y": 0, "parts": [ "xlframe_horizontal", "door_trunk" ] },
+      {
+        "x": 0,
+        "y": 0,
+        "parts": [ "frame_vertical_2", "seat_leather", "seatbelt", "controls", "dashboard", "vehicle_alarm", "horn_car", "roof" ]
+      },
+      {
+        "x": 2,
+        "y": 0,
+        "parts": [ "xlframe_horizontal", "xlhalfboard_horizontal_front", "engine_electric_enhanced", "storage_battery" ]
+      },
+      { "x": -1, "y": 0, "parts": [ "frame_vertical", "storage_battery", "trunk", "roof" ] },
+      { "x": -2, "y": 1, "parts": [ "xlframe_horizontal", "door_trunk" ] },
+      { "x": 0, "y": 1, "parts": [ "frame_vertical_2", "seat_leather", "seatbelt", "roof" ] },
+      { "x": 0, "y": -1, "parts": [ "xlframe_vertical", "door_rear_left" ] },
+      { "x": 1, "y": 2, "parts": [ "xlframe_vertical", "windshield_ne" ] },
+      { "x": -1, "y": 2, "parts": [ "xlframe_vertical", "xlhalfboard_vertical_right" ] },
+      {
+        "x": 2,
+        "y": 1,
+        "parts": [ "xlframe_horizontal", "engine_electric_enhanced", "storage_battery", "xlhalfboard_horizontal_front" ]
+      },
+      { "x": 1, "y": -1, "parts": [ "xlframe_vertical", "windshield_nw" ] },
+      { "x": -2, "y": -1, "parts": [ "xlframe_horizontal", "xlhalfboard_sw", "wheel_mount_medium", "wheel_slick" ] }
+    ],
+    "items": [ { "x": -1, "y": 0, "chance": 8, "items": [ "sm_extinguisher" ] } ]
+  },
+  {
+    "id": "electric_car_test",
+    "type": "vehicle",
+    "name": "Electric Car",
+    "blueprint": [
+      [ "##++-o" ],
+      [ "+=##'|" ],
+      [ "+=##'|" ],
+      [ "##++-o" ]
+    ],
+    "parts": [
+      { "x": -3, "y": 1, "parts": [ "xlframe_horizontal", "door_trunk" ] },
+      { "x": -1, "y": 1, "parts": [ "xlframe_vertical_2", "seat", "seatbelt", "roof" ] },
+      {
+        "x": 2,
+        "y": 2,
+        "parts": [ "xlframe_ne", "halfboard_ne", "headlight", "wheel_mount_medium_steerable", "wheel" ]
+      },
+      { "x": 0, "y": 2, "parts": [ "xlframe_vertical", "door_front_right" ] },
+      {
+        "x": 2,
+        "y": -1,
+        "parts": [ "xlframe_nw", "halfboard_nw", "headlight", "wheel_mount_medium_steerable", "wheel" ]
+      },
+      { "x": -1, "y": -1, "parts": [ "xlframe_vertical", "door_rear_left" ] },
+      {
+        "x": -2,
+        "y": 2,
+        "parts": [ "xlframe_vertical", "halfboard_vertical_right", "storage_battery_mount", "storage_battery_removable", "solar_panel" ]
+      },
+      { "x": 1, "y": 0, "parts": [ "xlframe_horizontal", "windshield_horizontal_front" ] },
+      { "x": -3, "y": 2, "parts": [ "xlframe_se", "halfboard_se", "wheel_mount_medium", "wheel", "solar_panel" ] },
+      { "x": 1, "y": 1, "parts": [ "xlframe_horizontal", "windshield_horizontal_front" ] },
+      { "x": -3, "y": 0, "parts": [ "xlframe_horizontal", "door_trunk" ] },
+      { "x": -2, "y": 0, "parts": [ "xlframe_vertical", "trunk", "roof" ] },
+      {
+        "x": 0,
+        "y": 0,
+        "parts": [
+          "xlframe_vertical_2",
+          "seat",
+          "seatbelt",
+          "controls",
+          "dashboard",
+          "vehicle_clock",
+          "vehicle_alarm",
+          "horn_car",
+          "roof"
+        ]
+      },
+      { "x": 2, "y": 0, "parts": [ "xlframe_horizontal", "halfboard_horizontal_front", "engine_electric_large" ] },
+      { "x": -1, "y": 0, "parts": [ "xlframe_vertical_2", "seat", "seatbelt", "roof" ] },
+      { "x": -2, "y": 1, "parts": [ "xlframe_vertical", "trunk", "roof" ] },
+      { "x": 0, "y": 1, "parts": [ "xlframe_vertical_2", "seat", "seatbelt", "roof" ] },
+      { "x": 0, "y": -1, "parts": [ "xlframe_vertical", "door_front_left" ] },
+      { "x": -1, "y": 2, "parts": [ "xlframe_vertical", "door_rear_right" ] },
+      { "x": 1, "y": 2, "parts": [ "xlframe_vertical", "windshield_ne" ] },
+      { "x": 2, "y": 1, "parts": [ "xlframe_horizontal", "halfboard_horizontal_front" ] },
+      { "x": 1, "y": -1, "parts": [ "xlframe_vertical", "windshield_nw" ] },
+      {
+        "x": -2,
+        "y": -1,
+        "parts": [ "xlframe_vertical", "halfboard_vertical_left", "storage_battery_mount", "storage_battery_removable", "solar_panel" ]
+      },
+      { "x": -3, "y": -1, "parts": [ "xlframe_sw", "halfboard_sw", "wheel_mount_medium", "wheel", "solar_panel" ] }
+    ],
+    "items": [  ]
+  },
+  {
+    "id": "rara_x_test",
+    "type": "vehicle",
+    "name": "Solar Car",
+    "blueprint": [
+      [ "   ###o " ],
+      [ " ###--+-" ],
+      [ " ###|B#|" ],
+      [ " ###--+-" ],
+      [ "   ###o " ]
+    ],
+    "parts": [
+      { "x": -3, "y": 1, "parts": [ "xlframe_se", "solar_panel_v2" ] },
+      { "x": -1, "y": 1, "parts": [ "xlframe_vertical_2", "windshield_horizontal_front", "roof" ] },
+      { "x": 0, "y": 2, "parts": [ "xlframe_ne" ] },
+      { "x": -5, "y": -1, "parts": [ "xlframe_sw", "solar_panel_v2" ] },
+      { "x": -1, "y": -1, "parts": [ "xlframe_vertical_2", "windshield_horizontal_front", "roof" ] },
+      { "x": -2, "y": 2, "parts": [ "xlframe_sw", "solar_panel_v2" ] },
+      { "x": 1, "y": 0, "parts": [ "xlframe_horizontal", "windshield" ] },
+      { "x": -3, "y": 2, "parts": [ "xlframe_sw", "solar_panel_v2" ] },
+      { "x": 0, "y": -2, "parts": [ "xlframe_nw" ] },
+      { "x": -1, "y": -2, "parts": [ "xlframe_vertical", "windshield_nw" ] },
+      { "x": -4, "y": 0, "parts": [ "xlframe_horizontal", "solar_panel_v2" ] },
+      { "x": 1, "y": 1, "parts": [ "xlframe_ne", "windshield" ] },
+      { "x": -3, "y": 0, "parts": [ "xlframe_horizontal", "solar_panel_v2" ] },
+      { "x": -4, "y": -1, "parts": [ "xlframe_sw", "solar_panel_v2" ] },
+      {
+        "x": -2,
+        "y": 0,
+        "parts": [ "xlframe_horizontal", "storage_battery", "engine_electric", "windshield_horizontal_rear", "roof" ]
+      },
+      {
+        "x": 0,
+        "y": 0,
+        "parts": [ "xlframe_horizontal", "seat", "seatbelt", "roof", "drive_by_wire_controls", "dashboard", "vehicle_alarm", "horn_car" ]
+      },
+      { "x": -2, "y": -2, "parts": [ "xlframe_se", "solar_panel_v2" ] },
+      { "x": -1, "y": 0, "parts": [ "xlframe_vertical_2", "box", "engine_electric", "roof", "headlight" ] },
+      { "x": -2, "y": 1, "parts": [ "xlframe_cross", "windshield" ] },
+      { "x": -4, "y": 1, "parts": [ "xlframe_se", "solar_panel_v2" ] },
+      { "x": -3, "y": -2, "parts": [ "xlframe_se", "solar_panel_v2" ] },
+      { "x": 0, "y": 1, "parts": [ "xlframe_cross", "wheel_mount_medium_steerable", "wheel", "door_front_left" ] },
+      { "x": 0, "y": -1, "parts": [ "xlframe_cross", "wheel_mount_medium_steerable", "wheel", "door_front_right" ] },
+      { "x": -1, "y": 2, "parts": [ "xlframe_vertical", "windshield_ne" ] },
+      { "x": -5, "y": 1, "parts": [ "xlframe_se", "solar_panel_v2" ] },
+      { "x": 1, "y": -1, "parts": [ "xlframe_nw", "windshield" ] },
+      { "x": -2, "y": -1, "parts": [ "xlframe_cross", "windshield" ] },
+      { "x": -3, "y": -1, "parts": [ "xlframe_sw", "solar_panel_v2" ] },
+      {
+        "x": -5,
+        "y": 0,
+        "parts": [ "xlframe_horizontal", "solar_panel_v2", "wheel_mount_medium_steerable", "wheel" ]
+      }
+    ],
+    "items": [  ]
+  },
+  {
+    "id": "suv_test",
+    "type": "vehicle",
+    "name": "SUV",
+    "blueprint": [
+      [ "-o-++-o" ],
+      [ "+==##'|" ],
+      [ "+==##'|" ],
+      [ "-o-++-o" ]
+    ],
+    "parts": [
+      { "x": -3, "y": 1, "parts": [ "frame_vertical", "trunk", "roof" ] },
+      { "x": -1, "y": 1, "parts": [ "frame_vertical_2", "seat", "seatbelt", "roof" ] },
+      {
+        "x": 2,
+        "y": 2,
+        "parts": [ "frame_ne", "halfboard_ne", "wheel_mount_medium_steerable", "wheel", "headlight" ]
+      },
+      { "x": 0, "y": 2, "parts": [ "frame_vertical", "door_front_right" ] },
+      {
+        "x": 2,
+        "y": -1,
+        "parts": [ "frame_nw", "halfboard_nw", "wheel_mount_medium_steerable", "wheel", "headlight" ]
+      },
+      { "x": -1, "y": -1, "parts": [ "frame_vertical", "door_rear_left" ] },
+      { "x": -2, "y": 2, "parts": [ "frame_vertical", "halfboard_vertical_right" ] },
+      { "x": 1, "y": 0, "parts": [ "frame_horizontal", "windshield_horizontal_front" ] },
+      { "x": -3, "y": 2, "parts": [ "frame_vertical", "halfboard_vertical_right", "wheel_mount_medium", "wheel" ] },
+      { "x": -4, "y": 0, "parts": [ "frame_horizontal", "door_trunk" ] },
+      { "x": 1, "y": 1, "parts": [ "frame_horizontal", "windshield_horizontal_front" ] },
+      { "x": -4, "y": 2, "parts": [ "frame_horizontal", "halfboard_se" ] },
+      { "x": -3, "y": 0, "parts": [ "frame_vertical", "trunk", "muffler", "roof" ] },
+      { "x": -4, "y": -1, "parts": [ "frame_horizontal", "halfboard_sw" ] },
+      { "x": -2, "y": 0, "parts": [ "frame_vertical", "trunk", "roof" ] },
+      {
+        "x": 0,
+        "y": 0,
+        "parts": [
+          "frame_vertical_2",
+          "reclining_seat",
+          "seatbelt",
+          "controls",
+          "dashboard",
+          "vehicle_clock",
+          "vehicle_alarm",
+          "stereo",
+          "horn_car",
+          "roof"
+        ]
+      },
+      {
+        "x": 2,
+        "y": 0,
+        "parts": [ "frame_horizontal", "halfboard_horizontal_front", "engine_v6", "alternator_car", "battery_car" ]
+      },
+      { "x": -1, "y": 0, "parts": [ "frame_vertical_2", "seat", "seatbelt", "roof" ] },
+      { "x": -2, "y": 1, "parts": [ "frame_vertical", "trunk", "roof" ] },
+      { "x": -4, "y": 1, "parts": [ "frame_horizontal", "door_trunk" ] },
+      { "x": 0, "y": 1, "parts": [ "frame_vertical_2", "reclining_seat", "seatbelt", "roof" ] },
+      { "x": 0, "y": -1, "parts": [ "frame_vertical", "door_front_left" ] },
+      { "x": -1, "y": 2, "parts": [ "frame_vertical", "door_rear_right" ] },
+      { "x": 1, "y": 2, "parts": [ "frame_vertical", "windshield_ne" ] },
+      { "x": 2, "y": 1, "parts": [ "frame_horizontal", "halfboard_horizontal_front" ] },
+      { "x": 1, "y": -1, "parts": [ "frame_vertical", "windshield_nw" ] },
+      {
+        "x": -2,
+        "y": -1,
+        "parts": [ "frame_vertical", "halfboard_vertical_left", { "part": "tank", "fuel": "gasoline" } ]
+      },
+      {
+        "x": -3,
+        "y": -1,
+        "parts": [ "frame_vertical", "halfboard_vertical_left", { "part": "tank", "fuel": "gasoline" }, "wheel_mount_medium", "wheel" ]
+      }
+    ],
+    "items": [
+      { "x": 0, "y": 0, "chance": 16, "items": [ "cig" ] },
+      { "x": 0, "y": 0, "chance": 16, "items": [ "lighter" ] },
+      { "x": 0, "y": 1, "chance": 1, "items": [ "roadmap" ] },
+      { "x": 0, "y": 1, "chance": 10, "items": [ "flashlight" ] },
+      { "x": 0, "y": 1, "chance": 5, "items": [ "1st_aid" ] },
+      { "x": -1, "y": 0, "chance": 5, "item_groups": [ "snacks" ] },
+      { "x": -1, "y": 0, "chance": 5, "item_groups": [ "fast_food" ] },
+      { "x": -1, "y": 1, "chance": 5, "item_groups": [ "snacks" ] },
+      { "x": -1, "y": 1, "chance": 5, "item_groups": [ "fast_food" ] },
+      { "x": -2, "y": 1, "chance": 5, "items": [ "screwdriver" ] },
+      { "x": -2, "y": 1, "chance": 5, "items": [ "scissors" ] },
+      { "x": -2, "y": 1, "chance": 5, "items": [ "crowbar" ] },
+      { "x": -2, "y": 1, "chance": 5, "items": [ "jumper_cable" ] },
+      { "x": -2, "y": 1, "chance": 15, "items": [ "jack_small", "wheel" ] }
+    ]
+  },
+  {
+    "id": "suv_electric_test",
+    "type": "vehicle",
+    "name": "Electric SUV",
+    "blueprint": [
+      [ "-o-++-o" ],
+      [ "+==##'|" ],
+      [ "+==##'|" ],
+      [ "-o-++-o" ]
+    ],
+    "parts": [
+      { "x": -3, "y": 1, "parts": [ "xlframe_vertical", "trunk", "roof", "solar_panel" ] },
+      { "x": -1, "y": 1, "parts": [ "xlframe_vertical_2", "roof", "seat", "seatbelt" ] },
+      {
+        "x": 2,
+        "y": 2,
+        "parts": [ "xlframe_ne", "halfboard_ne", "wheel_mount_medium_steerable", "wheel", "headlight" ]
+      },
+      { "x": 0, "y": 2, "parts": [ "xlframe_vertical", "door_front_right" ] },
+      {
+        "x": 2,
+        "y": -1,
+        "parts": [ "xlframe_nw", "halfboard_nw", "wheel_mount_medium_steerable", "wheel", "headlight" ]
+      },
+      { "x": -1, "y": -1, "parts": [ "xlframe_vertical", "door_rear_left" ] },
+      { "x": -2, "y": 2, "parts": [ "xlframe_vertical", "halfboard_vertical_right" ] },
+      { "x": 1, "y": 0, "parts": [ "xlframe_horizontal", "windshield_horizontal_front" ] },
+      { "x": -3, "y": 2, "parts": [ "xlframe_vertical", "halfboard_vertical_right", "wheel_mount_medium", "wheel" ] },
+      { "x": -4, "y": 0, "parts": [ "xlframe_horizontal", "door_trunk" ] },
+      { "x": 1, "y": 1, "parts": [ "xlframe_horizontal", "windshield_horizontal_front" ] },
+      { "x": -4, "y": 2, "parts": [ "xlframe_horizontal", "halfboard_se" ] },
+      { "x": -3, "y": 0, "parts": [ "xlframe_vertical", "trunk", "roof", "solar_panel" ] },
+      { "x": -4, "y": -1, "parts": [ "xlframe_horizontal", "halfboard_sw" ] },
+      { "x": -2, "y": 0, "parts": [ "xlframe_vertical", "trunk", "roof", "solar_panel" ] },
+      {
+        "x": 0,
+        "y": 0,
+        "parts": [
+          "xlframe_vertical_2",
+          "roof",
+          "reclining_seat",
+          "seatbelt",
+          "controls",
+          "dashboard",
+          "vehicle_clock",
+          "vehicle_alarm",
+          "stereo",
+          "horn_car",
+          "storage_battery"
+        ]
+      },
+      { "x": 2, "y": 0, "parts": [ "xlframe_horizontal", "halfboard_horizontal_front", "engine_electric_large" ] },
+      { "x": -1, "y": 0, "parts": [ "xlframe_vertical_2", "roof", "seat", "seatbelt" ] },
+      { "x": -2, "y": 1, "parts": [ "xlframe_vertical", "trunk", "roof", "solar_panel" ] },
+      { "x": -4, "y": 1, "parts": [ "xlframe_horizontal", "door_trunk" ] },
+      { "x": 0, "y": 1, "parts": [ "xlframe_vertical_2", "roof", "reclining_seat", "seatbelt", "storage_battery" ] },
+      { "x": 0, "y": -1, "parts": [ "xlframe_vertical", "door_front_left" ] },
+      { "x": -1, "y": 2, "parts": [ "xlframe_vertical", "door_rear_right" ] },
+      { "x": 1, "y": 2, "parts": [ "xlframe_horizontal", "windshield_ne" ] },
+      { "x": 2, "y": 1, "parts": [ "xlframe_horizontal", "halfboard_horizontal_front" ] },
+      { "x": 1, "y": -1, "parts": [ "xlframe_horizontal", "windshield_nw" ] },
+      { "x": -2, "y": -1, "parts": [ "xlframe_vertical", "halfboard_vertical_left" ] },
+      { "x": -3, "y": -1, "parts": [ "xlframe_vertical", "halfboard_vertical_left", "wheel_mount_medium", "wheel" ] }
+    ],
+    "items": [
+      { "x": 0, "y": 0, "chance": 16, "items": [ "cig" ] },
+      { "x": 0, "y": 0, "chance": 16, "items": [ "lighter" ] },
+      { "x": 0, "y": 1, "chance": 1, "items": [ "roadmap" ] },
+      { "x": 0, "y": 1, "chance": 10, "items": [ "flashlight" ] },
+      { "x": 0, "y": 1, "chance": 5, "items": [ "1st_aid" ] },
+      { "x": -1, "y": 0, "chance": 5, "item_groups": [ "snacks" ] },
+      { "x": -1, "y": 0, "chance": 5, "item_groups": [ "fast_food" ] },
+      { "x": -1, "y": 1, "chance": 5, "item_groups": [ "snacks" ] },
+      { "x": -1, "y": 1, "chance": 5, "item_groups": [ "fast_food" ] },
+      { "x": -2, "y": 1, "chance": 5, "items": [ "screwdriver" ] },
+      { "x": -2, "y": 1, "chance": 5, "items": [ "scissors" ] },
+      { "x": -2, "y": 1, "chance": 5, "items": [ "crowbar" ] },
+      { "x": -2, "y": 1, "chance": 5, "items": [ "jumper_cable" ] },
+      { "x": -2, "y": 1, "chance": 15, "items": [ "jack_small", "wheel" ] }
+    ]
+  },
+  {
+    "id": "golf_cart_test",
+    "type": "vehicle",
+    "name": "Golf Cart",
+    "blueprint": [
+      [ "o|o" ],
+      [ "o|o" ]
+    ],
+    "parts": [
+      { "x": -1, "y": 1, "parts": [ "frame_se", "box", "wheel_mount_light", "wheel_small" ] },
+      { "x": 1, "y": 0, "parts": [ "frame_nw", "halfboard_nw", "wheel_mount_light_steerable", "wheel_small" ] },
+      { "x": 1, "y": 1, "parts": [ "frame_ne", "halfboard_ne", "wheel_mount_light_steerable", "wheel_small" ] },
+      { "x": 0, "y": 0, "parts": [ "frame_horizontal", "seat", "roof", "engine_electric", "controls" ] },
+      { "x": -1, "y": 0, "parts": [ "frame_sw", "box", "wheel_mount_light", "wheel_small" ] },
+      { "x": 0, "y": 1, "parts": [ "frame_horizontal", "seat", "roof", "storage_battery" ] }
+    ],
+    "items": [
+      { "x": -1, "y": 0, "chance": 25, "//repeat": 2, "item_groups": [ "golf_cart" ] },
+      { "x": -1, "y": 1, "chance": 25, "//repeat": 2, "item_groups": [ "golf_cart" ] }
+    ]
+  },
+  {
+    "id": "golf_cart_4seat_test",
+    "type": "vehicle",
+    "name": "Golf Cart",
+    "blueprint": [
+      [ "o|o" ],
+      [ "o|o" ]
+    ],
+    "parts": [
+      { "x": 0, "y": 0, "part": "frame_horizontal" },
+      { "x": 0, "y": 0, "part": "seat" },
+      { "x": 0, "y": 0, "part": "roof" },
+      { "x": 0, "y": 0, "part": "engine_electric" },
+      { "x": 0, "y": 0, "part": "controls" },
+      { "x": 0, "y": 1, "part": "frame_horizontal" },
+      { "x": 0, "y": 1, "part": "seat" },
+      { "x": 0, "y": 1, "part": "roof" },
+      { "x": 0, "y": 1, "part": "storage_battery" },
+      { "x": 1, "y": 0, "part": "frame_nw" },
+      { "x": 1, "y": 0, "part": "halfboard_nw" },
+      { "x": 1, "y": 0, "parts": [ "wheel_mount_light_steerable", "wheel_small" ] },
+      { "x": 1, "y": 1, "part": "frame_ne" },
+      { "x": 1, "y": 1, "part": "halfboard_ne" },
+      { "x": 1, "y": 1, "parts": [ "wheel_mount_light_steerable", "wheel_small" ] },
+      { "x": -1, "y": 0, "part": "frame_sw" },
+      { "x": -1, "y": 0, "part": "roof" },
+      { "x": -1, "y": 0, "part": "seat" },
+      { "x": -1, "y": 0, "parts": [ "wheel_mount_light", "wheel_small" ] },
+      { "x": -1, "y": 1, "part": "frame_se" },
+      { "x": -1, "y": 1, "part": "roof" },
+      { "x": -1, "y": 1, "part": "seat" },
+      { "x": -1, "y": 1, "parts": [ "wheel_mount_light", "wheel_small" ] }
+    ],
+    "items": [
+      { "x": -1, "y": 0, "chance": 20, "//repeat": 2, "item_groups": [ "golf_cart" ] },
+      { "x": -1, "y": 1, "chance": 20, "//repeat": 2, "item_groups": [ "golf_cart" ] },
+      { "x": 0, "y": 0, "chance": 20, "item_groups": [ "golf_cart" ] },
+      { "x": 0, "y": 1, "chance": 20, "item_groups": [ "golf_cart" ] }
+    ]
+  },
+  {
+    "id": "hearse_test",
+    "type": "vehicle",
+    "name": "Hearse",
+    "blueprint": [
+      [ "o''-+-o" ],
+      [ "+==|#'|" ],
+      [ "+==|#'|" ],
+      [ "o''-+-o" ]
+    ],
+    "parts": [
+      { "x": -3, "y": 1, "parts": [ "frame_vertical", "trunk", "roof" ] },
+      { "x": -1, "y": 1, "parts": [ "frame_vertical_2", "windshield", "roof" ] },
+      {
+        "x": 2,
+        "y": 2,
+        "parts": [ "frame_ne", "halfboard_ne", "headlight", "wheel_mount_medium_steerable", "wheel" ]
+      },
+      { "x": 0, "y": 2, "parts": [ "frame_vertical", "door_front_right", "roof" ] },
+      {
+        "x": 2,
+        "y": -1,
+        "parts": [ "frame_nw", "halfboard_nw", "headlight", "wheel_mount_medium_steerable", "wheel" ]
+      },
+      { "x": -1, "y": -1, "parts": [ "frame_vertical", "board_vertical_left", "roof" ] },
+      { "x": -2, "y": 2, "parts": [ "frame_vertical", "windshield_vertical_right", "v_curtain", "roof" ] },
+      { "x": 1, "y": 0, "parts": [ "frame_horizontal", "windshield_horizontal_front" ] },
+      { "x": -3, "y": 2, "parts": [ "frame_vertical", "windshield_vertical_right", "v_curtain", "roof" ] },
+      { "x": -4, "y": 0, "parts": [ "frame_horizontal", "door", "v_curtain", "roof" ] },
+      { "x": 1, "y": 1, "parts": [ "frame_horizontal", "windshield_horizontal_front" ] },
+      { "x": -4, "y": 2, "parts": [ "frame_se", "board_se", "wheel_mount_medium", "wheel", "roof" ] },
+      { "x": -3, "y": 0, "parts": [ "frame_vertical", "trunk", "muffler", "roof" ] },
+      { "x": -4, "y": -1, "parts": [ "frame_sw", "board_sw", "wheel_mount_medium", "wheel", "roof" ] },
+      { "x": -2, "y": 0, "parts": [ "frame_vertical_2", "trunk", "roof" ] },
+      {
+        "x": 0,
+        "y": 0,
+        "parts": [
+          "frame_vertical_2",
+          "reclining_seat",
+          "seatbelt",
+          "controls",
+          "dashboard",
+          "vehicle_clock",
+          "vehicle_alarm",
+          "horn_car",
+          "roof"
+        ]
+      },
+      {
+        "x": 2,
+        "y": 0,
+        "parts": [ "frame_horizontal", "halfboard_horizontal", "engine_inline4", "alternator_car", "battery_car" ]
+      },
+      { "x": -1, "y": 0, "parts": [ "frame_vertical_2", "windshield", "roof" ] },
+      { "x": -2, "y": 1, "parts": [ "frame_vertical_2", "trunk", "roof" ] },
+      { "x": -4, "y": 1, "parts": [ "frame_horizontal", "door", "v_curtain", "roof" ] },
+      { "x": 0, "y": 1, "parts": [ "frame_vertical_2", "reclining_seat", "seatbelt", "roof" ] },
+      { "x": 0, "y": -1, "parts": [ "frame_vertical", "door_front_left", "roof" ] },
+      { "x": -1, "y": 2, "parts": [ "frame_vertical", "board_vertical_right", "roof" ] },
+      { "x": 1, "y": 2, "parts": [ "frame_vertical", "windshield_ne" ] },
+      { "x": 2, "y": 1, "parts": [ "frame_horizontal", "halfboard_horizontal" ] },
+      { "x": 1, "y": -1, "parts": [ "frame_vertical", "windshield_nw" ] },
+      { "x": -2, "y": -1, "parts": [ "frame_vertical", "windshield_vertical_left", "v_curtain", "roof" ] },
+      {
+        "x": -3,
+        "y": -1,
+        "parts": [ "frame_vertical", "windshield_vertical_left", "v_curtain", { "part": "tank", "fuel": "gasoline" }, "roof" ]
+      }
+    ],
+    "items": [  ]
+  },
+  {
+    "id": "pickup_technical_test",
+    "type": "vehicle",
+    "name": "Technical",
+    "blueprint": [
+      [ "o--+-ox" ],
+      [ "=='#'|x" ],
+      [ ".#'#'|x" ],
+      [ "o--+-ox" ]
+    ],
+    "parts": [
+      { "x": -3, "y": 1, "parts": [ "frame_horizontal", "aisle_vertical" ] },
+      { "x": -1, "y": 1, "parts": [ "frame_vertical_2", "windshield_horizontal_front", "rebar_plate", "roof" ] },
+      {
+        "x": 2,
+        "y": 2,
+        "parts": [ "frame_ne", "halfboard_ne", "wheel_mount_medium_steerable", "wheel", "spring_plate", "headlight" ]
+      },
+      { "x": 0, "y": 2, "parts": [ "frame_vertical", "door_front_right" ] },
+      {
+        "x": 2,
+        "y": -1,
+        "parts": [ "frame_nw", "halfboard_nw", "wheel_mount_medium_steerable", "wheel", "spring_plate", "headlight" ]
+      },
+      { "x": -1, "y": -1, "parts": [ "frame_vertical", "halfboard_vertical_left" ] },
+      { "x": 3, "y": 1, "parts": [ "ram_spiked" ] },
+      {
+        "x": -2,
+        "y": 2,
+        "parts": [ "frame_vertical", "halfboard_vertical_right", { "part": "tank", "fuel": "gasoline" } ]
+      },
+      { "x": 1, "y": 0, "parts": [ "frame_horizontal", "windshield_horizontal_front", "rebar_plate" ] },
+      { "x": 3, "y": 0, "parts": [ "ram_spiked" ] },
+      {
+        "x": -3,
+        "y": 2,
+        "parts": [ "frame_horizontal", "halfboard_se", "wheel_mount_medium", "wheel", "spring_plate" ]
+      },
+      { "x": 1, "y": 1, "parts": [ "frame_horizontal", "windshield_horizontal_front", "rebar_plate" ] },
+      { "x": 3, "y": -1, "parts": [ "ram_spiked" ] },
+      { "x": -3, "y": 0, "parts": [ "frame_horizontal", "trunk" ] },
+      { "x": -2, "y": 0, "parts": [ "frame_vertical", "trunk", "muffler", "roof" ] },
+      {
+        "x": 0,
+        "y": 0,
+        "parts": [ "frame_vertical_2", "seat", "seatbelt", "controls", "dashboard", "stereo", "horn_car", "roof" ]
+      },
+      {
+        "x": 2,
+        "y": 0,
+        "parts": [ "frame_horizontal", "halfboard_horizontal", "engine_v6", "alternator_car", "battery_car" ]
+      },
+      { "x": -1, "y": 0, "parts": [ "frame_vertical_2", "windshield_horizontal_front", "rebar_plate", "roof" ] },
+      {
+        "x": -2,
+        "y": 1,
+        "parts": [
+          "frame_vertical",
+          "seat",
+          "turret_mount_manual_steel",
+          { "part": "mounted_m60", "ammo": 80, "ammo_qty": [ 10, 100 ] },
+          "roof"
+        ]
+      },
+      { "x": 0, "y": 1, "parts": [ "frame_vertical_2", "seat", "seatbelt", "roof" ] },
+      { "x": 0, "y": -1, "parts": [ "frame_vertical", "door_front_left" ] },
+      { "x": -1, "y": 2, "parts": [ "frame_vertical", "halfboard_vertical_right" ] },
+      { "x": 1, "y": 2, "parts": [ "frame_vertical", "windshield_ne", "rebar_plate" ] },
+      { "x": 2, "y": 1, "parts": [ "frame_horizontal", "halfboard_horizontal" ] },
+      { "x": 3, "y": 2, "parts": [ "ram_spiked" ] },
+      { "x": 1, "y": -1, "parts": [ "frame_vertical", "windshield_nw", "rebar_plate" ] },
+      {
+        "x": -2,
+        "y": -1,
+        "parts": [ "frame_vertical", "halfboard_vertical_left", { "part": "tank", "fuel": "gasoline" } ]
+      },
+      {
+        "x": -3,
+        "y": -1,
+        "parts": [ "frame_horizontal", "halfboard_sw", "wheel_mount_medium", "wheel", "spring_plate" ]
+      }
+    ],
+    "items": [
+      { "x": 0, "y": 0, "chance": 15, "item_groups": "car_misc" },
+      { "x": 0, "y": 0, "chance": 10, "item_groups": "car_misc" },
+      { "x": 0, "y": 1, "chance": 10, "item_groups": "car_misc" },
+      { "x": -3, "y": 0, "chance": 10, "item_groups": "car_kit" },
+      { "x": -3, "y": 0, "chance": 8, "item_groups": "fuel_gasoline" },
+      { "x": -2, "y": 0, "chance": 40, "items": [ "308" ] },
+      { "x": -2, "y": 0, "chance": 20, "items": [ "308", "308" ] },
+      { "x": -2, "y": 0, "chance": 10, "items": [ "308", "308" ] },
+      { "x": -2, "y": 0, "chance": 5, "items": [ "308", "308" ] }
+    ]
+  },
+  {
+    "id": "ambulance_test",
+    "type": "vehicle",
+    "name": "Ambulance",
+    "blueprint": [
+      [ "      o " ],
+      [ "O----+-O" ],
+      [ "|===|#'|" ],
+      [ "+=#=|o'>" ],
+      [ "|===|#'|" ],
+      [ "O--+-+-O" ],
+      [ "      o " ]
+    ],
+    "parts": [
+      { "x": -3, "y": 1, "parts": [ "frame_vertical", "bed", "roof" ] },
+      { "x": 2, "y": 2, "parts": [ "frame_horizontal", "halfboard_horizontal" ] },
+      { "x": -1, "y": 1, "parts": [ "frame_horizontal", "board_horizontal", "light_blue" ] },
+      { "x": 0, "y": 2, "parts": [ "frame_vertical_2", "seat", "seatbelt", "roof" ] },
+      { "x": 1, "y": 3, "parts": [ "frame_vertical", "windshield" ] },
+      {
+        "x": 2,
+        "y": -1,
+        "parts": [ "frame_nw", "halfboard_nw", "headlight", "wheel_mount_medium_steerable", "wheel_wide" ]
+      },
+      { "x": -1, "y": -1, "parts": [ "frame_sw", "board_sw", { "part": "tank", "fuel": "gasoline" } ] },
+      { "x": -3, "y": 3, "parts": [ "frame_vertical", "board_vertical", "roof" ] },
+      { "x": -2, "y": 2, "parts": [ "frame_vertical", "lit_aisle_vertical", "roof" ] },
+      { "x": -1, "y": 3, "parts": [ "frame_se", "board_se", { "part": "tank", "fuel": "gasoline" } ] },
+      { "x": 1, "y": 0, "parts": [ "frame_horizontal", "windshield" ] },
+      { "x": -5, "y": -1, "parts": [ "frame_sw", "board_sw", "wheel_mount_medium", "wheel_wide", "roof" ] },
+      { "x": -3, "y": 2, "parts": [ "frame_vertical", "aisle_vertical", "roof" ] },
+      { "x": 1, "y": 4, "parts": [ "wing_mirror_right" ] },
+      { "x": 1, "y": -2, "parts": [ "wing_mirror_left" ] },
+      { "x": -2, "y": 3, "parts": [ "frame_vertical", "door_opaque", "roof" ] },
+      {
+        "x": 2,
+        "y": 3,
+        "parts": [ "frame_ne", "halfboard_ne", "headlight", "wheel_mount_medium_steerable", "wheel_wide" ]
+      },
+      { "x": -5, "y": 3, "parts": [ "frame_se", "board_se", "wheel_mount_medium", "wheel_wide", "roof" ] },
+      { "x": -4, "y": 0, "parts": [ "frame_vertical", "box", "roof" ] },
+      { "x": 1, "y": 1, "parts": [ "frame_horizontal", "windshield" ] },
+      { "x": -4, "y": 2, "parts": [ "frame_vertical", "aisle_vertical", "roof" ] },
+      { "x": -3, "y": 0, "parts": [ "frame_vertical", "box", "roof" ] },
+      { "x": -4, "y": -1, "parts": [ "frame_vertical", "board_vertical", "roof" ] },
+      { "x": -2, "y": 0, "parts": [ "frame_vertical", "box", "roof" ] },
+      {
+        "x": 0,
+        "y": 0,
+        "parts": [
+          "frame_vertical_2",
+          "seat",
+          "seatbelt",
+          "controls",
+          "dashboard",
+          "vehicle_clock",
+          "vehicle_alarm",
+          "horn_big",
+          "roof"
+        ]
+      },
+      { "x": 2, "y": 0, "parts": [ "frame_horizontal", "halfboard_horizontal" ] },
+      { "x": -1, "y": 0, "parts": [ "frame_horizontal", "board_horizontal", "light_red" ] },
+      { "x": -2, "y": 1, "parts": [ "frame_vertical", "reclining_seat", "roof" ] },
+      { "x": -4, "y": 1, "parts": [ "frame_vertical", "aisle_vertical", "roof" ] },
+      { "x": 0, "y": 3, "parts": [ "frame_vertical", "door" ] },
+      { "x": 0, "y": 1, "parts": [ "frame_vertical", "box", "roof" ] },
+      { "x": 0, "y": -1, "parts": [ "frame_vertical", "door" ] },
+      { "x": 1, "y": 2, "parts": [ "frame_horizontal", "windshield" ] },
+      { "x": -1, "y": 2, "parts": [ "frame_horizontal", "board_horizontal", "light_red" ] },
+      { "x": -4, "y": 3, "parts": [ "frame_vertical", "board_vertical", "roof" ] },
+      { "x": -5, "y": 1, "parts": [ "frame_horizontal", "door", "roof" ] },
+      {
+        "x": 2,
+        "y": 1,
+        "parts": [ "frame_cover", "halfboard_cover", "engine_v8", "alternator_truck", "battery_car" ]
+      },
+      { "x": 1, "y": -1, "parts": [ "frame_vertical", "windshield" ] },
+      { "x": -5, "y": 2, "parts": [ "frame_horizontal", "board_horizontal", "beeper", "roof", "light_blue" ] },
+      { "x": -2, "y": -1, "parts": [ "frame_vertical", "board_vertical", "roof" ] },
+      { "x": -3, "y": -1, "parts": [ "frame_vertical", "board_vertical", "roof" ] },
+      { "x": -5, "y": 0, "parts": [ "frame_horizontal", "board_horizontal", "roof", "light_red" ] }
+    ],
+    "items": [
+      { "x": -2, "y": 0, "chance": 20, "items": [ "bandages" ] },
+      { "x": -2, "y": 0, "chance": 15, "items": [ "aspirin" ] },
+      { "x": -2, "y": 0, "chance": 15, "items": [ "disinfectant" ] },
+      { "x": -2, "y": 0, "chance": 5, "items": [ "codeine" ] },
+      { "x": -2, "y": 0, "chance": 25, "item_groups": [ "ambulance_equipment" ] },
+      { "x": -3, "y": 0, "chance": 15, "items": [ "bandages" ] },
+      { "x": -3, "y": 0, "chance": 15, "items": [ "1st_aid" ] },
+      { "x": -3, "y": 0, "chance": 5, "items": [ "adrenaline_injector" ] },
+      { "x": -3, "y": 0, "chance": 5, "items": [ "oxycodone" ] },
+      { "x": -3, "y": 0, "chance": 5, "items": [ "tramadol" ] },
+      { "x": -3, "y": 0, "chance": 25, "item_groups": [ "ambulance_equipment" ] },
+      { "x": -4, "y": 0, "chance": 5, "items": [ "morphine" ] },
+      { "x": -4, "y": 0, "chance": 12, "items": [ "antibiotics" ] },
+      { "x": -4, "y": 0, "chance": 5, "items": [ "thorazine" ] },
+      { "x": -4, "y": 0, "chance": 15, "items": [ "disinfectant" ] },
+      { "x": -4, "y": 0, "chance": 5, "items": [ "tramadol" ] },
+      { "x": -4, "y": 0, "chance": 8, "items": [ "quikclot" ] },
+      { "x": -4, "y": 0, "chance": 25, "item_groups": [ "ambulance_equipment" ] }
+    ]
+  },
+  {
+    "id": "car_fbi_test",
+    "type": "vehicle",
+    "name": "FBI, Emergency",
+    "blueprint": [
+      [ "o-++-o" ],
+      [ "+=##'|" ],
+      [ "+=##'|" ],
+      [ "o-++-o" ]
+    ],
+    "parts": [
+      { "x": -3, "y": 1, "parts": [ "frame_horizontal", "door_trunk" ] },
+      { "x": -1, "y": 1, "parts": [ "frame_vertical_2", "seat", "seatbelt", "roof" ] },
+      {
+        "x": 2,
+        "y": 2,
+        "parts": [ "frame_ne", "halfboard_ne", "wheel_mount_medium_steerable", "wheel", "headlight" ]
+      },
+      { "x": 0, "y": 2, "parts": [ "frame_vertical", "door" ] },
+      {
+        "x": 2,
+        "y": -1,
+        "parts": [ "frame_nw", "halfboard_nw", "wheel_mount_medium_steerable", "wheel", "headlight" ]
+      },
+      { "x": -1, "y": -1, "parts": [ "frame_vertical", "door" ] },
+      { "x": -2, "y": 2, "parts": [ "frame_vertical", "halfboard_vertical" ] },
+      { "x": 1, "y": 0, "parts": [ "frame_horizontal", "windshield" ] },
+      { "x": -3, "y": 2, "parts": [ "frame_horizontal", "halfboard_se", "wheel_mount_medium", "wheel" ] },
+      { "x": 1, "y": 1, "parts": [ "frame_horizontal", "windshield" ] },
+      { "x": -3, "y": 0, "parts": [ "frame_horizontal", "door_trunk" ] },
+      { "x": -2, "y": 0, "parts": [ "frame_vertical", "trunk", "muffler", "roof" ] },
+      {
+        "x": 0,
+        "y": 0,
+        "parts": [
+          "frame_vertical_2",
+          "seat",
+          "seatbelt",
+          "controls",
+          "dashboard",
+          "vehicle_clock",
+          "vehicle_alarm",
+          "horn_car",
+          "roof"
+        ]
+      },
+      {
+        "x": 2,
+        "y": 0,
+        "parts": [ "frame_horizontal", "engine_v8", "alternator_truck", "battery_car", "halfboard_horizontal" ]
+      },
+      { "x": -1, "y": 0, "parts": [ "frame_vertical_2", "seat", "seatbelt", "roof" ] },
+      { "x": -2, "y": 1, "parts": [ "frame_vertical", "trunk", "roof" ] },
+      { "x": 0, "y": 1, "parts": [ "frame_vertical_2", "seat", "seatbelt", "roof", "light_blue" ] },
+      { "x": 0, "y": -1, "parts": [ "frame_vertical", "door" ] },
+      { "x": -1, "y": 2, "parts": [ "frame_vertical", "door" ] },
+      { "x": 1, "y": 2, "parts": [ "frame_vertical", "windshield" ] },
+      { "x": 2, "y": 1, "parts": [ "frame_horizontal", "halfboard_horizontal" ] },
+      { "x": 1, "y": -1, "parts": [ "frame_vertical", "windshield" ] },
+      {
+        "x": -2,
+        "y": -1,
+        "parts": [ "frame_vertical", "halfboard_vertical", { "part": "tank", "fuel": "gasoline" } ]
+      },
+      { "x": -3, "y": -1, "parts": [ "frame_horizontal", "halfboard_sw", "wheel_mount_medium", "wheel" ] }
+    ],
+    "items": [ { "x": -2, "y": 1, "chance": 75, "magazine": 100, "ammo": 50, "item_groups": [ "guns_cop" ] } ]
+  },
+  {
+    "id": "fire_engine_test",
+    "type": "vehicle",
+    "name": "Fire Engine",
+    "blueprint": [
+      [ "OO---+'" ],
+      [ "|T|#|#'" ],
+      [ "+T|#+H'" ],
+      [ "|T|#|#'" ],
+      [ "OO---+'" ]
+    ],
+    "parts": [
+      { "x": -3, "y": 1, "parts": [ "frame_horizontal", "roof", "board_horizontal", { "part": "tank", "fuel": "water" } ] },
+      { "x": -1, "y": 1, "parts": [ "frame_horizontal", "roof", "seat", "seatbelt" ] },
+      {
+        "x": 0,
+        "y": 2,
+        "parts": [ "frame_horizontal", "roof", "wheel_mount_medium_steerable", "wheel_wide", "door" ]
+      },
+      { "x": -5, "y": -1, "parts": [ "frame_horizontal", "roof", "door_trunk", "storage_battery" ] },
+      { "x": -1, "y": -1, "parts": [ "frame_horizontal", "roof", "seat", "seatbelt" ] },
+      { "x": -2, "y": 2, "parts": [ "frame_horizontal", "roof", "floodlight", "board_vertical" ] },
+      {
+        "x": -4,
+        "y": -2,
+        "parts": [ "frame_horizontal", "roof", "wheel_mount_medium", "wheel_wide", "board_vertical" ]
+      },
+      {
+        "x": 1,
+        "y": 0,
+        "parts": [ "frame_horizontal", "roof", "windshield", "engine_v8", "alternator_truck", "horn_big" ]
+      },
+      { "x": -3, "y": 2, "parts": [ "frame_horizontal", "roof", "board_vertical", "beeper" ] },
+      {
+        "x": 0,
+        "y": -2,
+        "parts": [ "frame_horizontal", "roof", "wheel_mount_medium_steerable", "wheel_wide", "door" ]
+      },
+      { "x": 1, "y": -2, "parts": [ "frame_horizontal", "roof", "windshield", "turret_mount", "watercannon" ] },
+      { "x": -1, "y": -2, "parts": [ "frame_horizontal", "roof", "door", { "part": "tank", "fuel": "gasoline" } ] },
+      { "x": -4, "y": 0, "parts": [ "frame_horizontal", "roof", { "part": "tank", "fuel": "water" }, "trunk" ] },
+      { "x": 1, "y": 1, "parts": [ "frame_horizontal", "roof", "windshield", "headlight", "floodlight" ] },
+      {
+        "x": -4,
+        "y": 2,
+        "parts": [ "frame_horizontal", "roof", "wheel_mount_medium", "wheel_wide", "board_vertical" ]
+      },
+      {
+        "x": -3,
+        "y": 0,
+        "parts": [ "frame_horizontal", "roof", "board_horizontal", { "part": "tank", "fuel": "water" } ]
+      },
+      {
+        "x": -4,
+        "y": -1,
+        "parts": [ "frame_horizontal", "roof", "light_red", { "part": "tank", "fuel": "water" }, "trunk" ]
+      },
+      { "x": -2, "y": 0, "parts": [ "frame_horizontal", "roof", { "part": "tank", "fuel": "water" }, "trunk" ] },
+      {
+        "x": 0,
+        "y": 0,
+        "parts": [ "frame_horizontal", "roof", "light_red", "seat", "seatbelt", "controls", "dashboard" ]
+      },
+      { "x": -2, "y": -2, "parts": [ "frame_horizontal", "roof", "floodlight", "board_vertical" ] },
+      {
+        "x": -5,
+        "y": -2,
+        "parts": [ "frame_horizontal", "roof", "floodlight", "wheel_mount_medium", "wheel_wide", "board_vertical" ]
+      },
+      { "x": -1, "y": 0, "parts": [ "frame_horizontal", "roof", "seat", "seatbelt" ] },
+      { "x": -2, "y": 1, "parts": [ "frame_horizontal", "roof", { "part": "tank", "fuel": "water" }, "trunk" ] },
+      {
+        "x": -4,
+        "y": 1,
+        "parts": [ "frame_horizontal", "roof", "light_red", { "part": "tank", "fuel": "water" }, "trunk" ]
+      },
+      { "x": -3, "y": -2, "parts": [ "frame_horizontal", "roof", "board_vertical" ] },
+      { "x": 0, "y": 1, "parts": [ "frame_horizontal", "roof", "seat", "seatbelt" ] },
+      { "x": 0, "y": -1, "parts": [ "frame_horizontal", "roof", "seat", "seatbelt" ] },
+      { "x": -1, "y": 2, "parts": [ "frame_horizontal", "roof", "door", { "part": "tank", "fuel": "gasoline" } ] },
+      { "x": 1, "y": 2, "parts": [ "frame_horizontal", "roof", "windshield", "turret_mount", "watercannon" ] },
+      { "x": -5, "y": 1, "parts": [ "frame_horizontal", "roof", "door_trunk", "storage_battery" ] },
+      { "x": 1, "y": -1, "parts": [ "frame_horizontal", "roof", "windshield", "headlight", "floodlight" ] },
+      {
+        "x": -5,
+        "y": 2,
+        "parts": [ "frame_horizontal", "roof", "floodlight", "wheel_mount_medium", "wheel_wide", "board_vertical" ]
+      },
+      {
+        "x": -3,
+        "y": -1,
+        "parts": [ "frame_horizontal", "roof", "board_horizontal", { "part": "tank", "fuel": "water" } ]
+      },
+      { "x": -2, "y": -1, "parts": [ "frame_horizontal", "roof", { "part": "tank", "fuel": "water" }, "trunk" ] },
+      { "x": -5, "y": 0, "parts": [ "frame_horizontal", "roof", "door_trunk", "storage_battery" ] }
+    ],
+    "items": [
+      { "x": -4, "y": -1, "chance": 40, "items": [ "firehelmet" ] },
+      { "x": -4, "y": -1, "chance": 20, "item_groups": [ "fireman_mask" ] },
+      { "x": -4, "y": -1, "chance": 40, "items": [ "bunker_coat" ] },
+      { "x": -4, "y": -1, "chance": 40, "items": [ "bunker_pants" ] },
+      { "x": -4, "y": -1, "chance": 40, "items": [ "boots_bunker" ] },
+      { "x": -4, "y": -1, "chance": 40, "items": [ "fireman_belt" ] },
+      { "x": -4, "y": -1, "chance": 20, "items": [ "nomex_suit" ] },
+      { "x": -4, "y": -1, "chance": 20, "items": [ "nomex_hood" ] },
+      { "x": -4, "y": -1, "chance": 40, "items": [ "nomex_gloves" ] },
+      { "x": -4, "y": 0, "chance": 40, "items": [ "firehelmet" ] },
+      { "x": -4, "y": 0, "chance": 40, "items": [ "bunker_coat" ] },
+      { "x": -4, "y": 0, "chance": 40, "items": [ "bunker_pants" ] },
+      { "x": -4, "y": 0, "chance": 40, "items": [ "boots_bunker" ] },
+      { "x": -4, "y": 0, "chance": 40, "items": [ "fireman_belt" ] },
+      { "x": -4, "y": 0, "chance": 20, "items": [ "nomex_suit" ] },
+      { "x": -4, "y": 0, "chance": 20, "items": [ "nomex_hood" ] },
+      { "x": -4, "y": 0, "chance": 40, "items": [ "nomex_gloves" ] },
+      { "x": -4, "y": 1, "chance": 40, "items": [ "firehelmet" ] },
+      { "x": -4, "y": 1, "chance": 20, "item_groups": [ "fireman_mask" ] },
+      { "x": -4, "y": 1, "chance": 40, "items": [ "bunker_coat" ] },
+      { "x": -4, "y": 1, "chance": 40, "items": [ "bunker_pants" ] },
+      { "x": -4, "y": 1, "chance": 40, "items": [ "boots_bunker" ] },
+      { "x": -4, "y": 1, "chance": 40, "items": [ "fireman_belt" ] },
+      { "x": -4, "y": 1, "chance": 20, "items": [ "nomex_suit" ] },
+      { "x": -4, "y": 1, "chance": 20, "items": [ "nomex_hood" ] },
+      { "x": -4, "y": 1, "chance": 40, "items": [ "nomex_gloves" ] },
+      { "x": -2, "y": -1, "chance": 40, "items": [ "firehelmet" ] },
+      { "x": -2, "y": -1, "chance": 20, "item_groups": [ "fireman_gear" ] },
+      { "x": -2, "y": -1, "chance": 40, "items": [ "bunker_coat" ] },
+      { "x": -2, "y": -1, "chance": 40, "items": [ "bunker_pants" ] },
+      { "x": -2, "y": -1, "chance": 40, "items": [ "boots_bunker" ] },
+      { "x": -2, "y": -1, "chance": 40, "items": [ "fireman_belt" ] },
+      { "x": -2, "y": -1, "chance": 20, "items": [ "nomex_suit" ] },
+      { "x": -2, "y": -1, "chance": 20, "items": [ "nomex_hood" ] },
+      { "x": -2, "y": -1, "chance": 40, "item_groups": [ "fireman_gloves" ] },
+      { "x": -2, "y": 0, "chance": 40, "items": [ "firehelmet" ] },
+      { "x": -2, "y": 0, "chance": 40, "items": [ "bunker_coat" ] },
+      { "x": -2, "y": 0, "chance": 40, "items": [ "bunker_pants" ] },
+      { "x": -2, "y": 0, "chance": 40, "items": [ "boots_bunker" ] },
+      { "x": -2, "y": 0, "chance": 40, "items": [ "fireman_belt" ] },
+      { "x": -2, "y": 0, "chance": 20, "items": [ "nomex_suit" ] },
+      { "x": -2, "y": 0, "chance": 20, "items": [ "nomex_hood" ] },
+      { "x": -2, "y": 0, "chance": 40, "items": [ "nomex_gloves" ] },
+      { "x": -2, "y": 1, "chance": 40, "items": [ "firehelmet" ] },
+      { "x": -2, "y": 1, "chance": 40, "items": [ "bunker_coat" ] },
+      { "x": -2, "y": 1, "chance": 40, "items": [ "boots_bunker" ] },
+      { "x": -2, "y": 1, "chance": 40, "items": [ "fireman_belt" ] },
+      { "x": -2, "y": 1, "chance": 40, "item_groups": [ "fireman_pants" ] },
+      { "x": -2, "y": 1, "chance": 20, "item_groups": [ "fireman_torso" ] },
+      { "x": -2, "y": 1, "chance": 20, "item_groups": [ "fireman_head" ] },
+      { "x": -2, "y": 1, "chance": 40, "item_groups": [ "fireman_gloves" ] }
+    ]
+  },
+  {
+    "id": "fire_truck_test",
+    "type": "vehicle",
+    "name": "Fire Truck",
+    "blueprint": [
+      [ "        o" ],
+      [ "|+++-+-+-" ],
+      [ "|===|#*#*" ],
+      [ "+===|=*H|" ],
+      [ "|===|#*#*" ],
+      [ "|+++-+-+-" ],
+      [ "        o" ]
+    ],
+    "parts": [
+      { "x": -3, "y": 1, "parts": [ "hdframe_horizontal", "board_horizontal", "roof" ] },
+      { "x": 2, "y": 2, "parts": [ "hdframe_horizontal", "halfboard_horizontal", "horn_big" ] },
+      { "x": -1, "y": 1, "parts": [ "hdframe_horizontal", "trunk", "roof", "light_red" ] },
+      { "x": 1, "y": 3, "parts": [ "hdframe_vertical", "headlight", "windshield", "roof" ] },
+      { "x": 2, "y": -1, "parts": [ "hdframe_nw", "halfboard_nw" ] },
+      { "x": -6, "y": 3, "parts": [ "hdframe_vertical", "stowboard_vertical", "roof" ] },
+      { "x": 1, "y": 0, "parts": [ "hdframe_horizontal", "windshield", "roof" ] },
+      { "x": -3, "y": 2, "parts": [ "hdframe_horizontal", "board_horizontal", "roof" ] },
+      { "x": 1, "y": -2, "parts": [ "wing_mirror_left" ] },
+      { "x": -7, "y": 2, "parts": [ "hdframe_horizontal", "board_horizontal", "beeper", "roof" ] },
+      { "x": -4, "y": 0, "parts": [ "hdframe_horizontal", "trunk", "roof" ] },
+      { "x": 1, "y": 1, "parts": [ "hdframe_horizontal", "windshield", "roof" ] },
+      { "x": -4, "y": 2, "parts": [ "hdframe_horizontal", "trunk", "roof" ] },
+      { "x": -4, "y": -1, "parts": [ "hdframe_vertical", "stowboard_vertical", "roof" ] },
+      { "x": -2, "y": 0, "parts": [ "hdframe_horizontal", "aisle_horizontal", "roof" ] },
+      {
+        "x": 0,
+        "y": 0,
+        "parts": [ "hdframe_horizontal", "seat", "seatbelt", "controls", "dashboard", "vehicle_alarm", "roof" ]
+      },
+      { "x": 2, "y": 0, "parts": [ "hdframe_horizontal", "halfboard_horizontal", "horn_big" ] },
+      { "x": -7, "y": 1, "parts": [ "hdframe_horizontal", "door_opaque", "roof" ] },
+      { "x": -1, "y": 0, "parts": [ "hdframe_horizontal", "seat", "seatbelt", "roof", "light_red" ] },
+      { "x": -2, "y": 1, "parts": [ "hdframe_horizontal", "seat", "seatbelt", "roof" ] },
+      { "x": -7, "y": -1, "parts": [ "hdframe_sw", "board_sw", "roof" ] },
+      { "x": -7, "y": 3, "parts": [ "hdframe_se", "board_se", "roof" ] },
+      {
+        "x": 0,
+        "y": 3,
+        "parts": [ "hdframe_vertical", "door", "roof", "wheel_mount_medium_steerable", "wheel_wide" ]
+      },
+      {
+        "x": 0,
+        "y": 1,
+        "parts": [ "hdframe_horizontal", "engine_v8", "alternator_truck", "battery_car", "trunk", "roof" ]
+      },
+      {
+        "x": 0,
+        "y": -1,
+        "parts": [ "hdframe_vertical", "door", "roof", "wheel_mount_medium_steerable", "wheel_wide" ]
+      },
+      { "x": 1, "y": 2, "parts": [ "hdframe_horizontal", "windshield", "roof" ] },
+      { "x": -6, "y": 2, "parts": [ "hdframe_horizontal", "trunk", "roof" ] },
+      { "x": -7, "y": 0, "parts": [ "hdframe_horizontal", "board_horizontal", "roof" ] },
+      { "x": -6, "y": -1, "parts": [ "hdframe_vertical", "stowboard_vertical", "roof" ] },
+      { "x": -5, "y": 0, "parts": [ "hdframe_horizontal", "trunk", "roof" ] },
+      { "x": 0, "y": 2, "parts": [ "hdframe_horizontal", "seat", "seatbelt", "roof" ] },
+      {
+        "x": -5,
+        "y": -1,
+        "parts": [
+          "hdframe_vertical",
+          "wheel_mount_medium",
+          "wheel_wide",
+          { "part": "tank", "fuel": "gasoline" },
+          "stowboard_vertical",
+          "roof"
+        ]
+      },
+      { "x": -1, "y": -1, "parts": [ "hdframe_vertical", "board_vertical", "roof" ] },
+      { "x": -3, "y": 3, "parts": [ "hdframe_se", "board_se", "roof" ] },
+      { "x": -2, "y": 2, "parts": [ "hdframe_horizontal", "aisle_horizontal", "roof" ] },
+      { "x": -1, "y": 3, "parts": [ "hdframe_vertical", "board_vertical", "roof" ] },
+      { "x": 1, "y": 4, "parts": [ "wing_mirror_right" ] },
+      { "x": -2, "y": 3, "parts": [ "hdframe_vertical", "door", "roof" ] },
+      { "x": 2, "y": 3, "parts": [ "hdframe_ne", "halfboard_ne" ] },
+      {
+        "x": -5,
+        "y": 3,
+        "parts": [
+          "hdframe_vertical",
+          "wheel_mount_medium",
+          "wheel_wide",
+          { "part": "tank", "fuel": "gasoline" },
+          "stowboard_vertical",
+          "roof"
+        ]
+      },
+      { "x": -3, "y": 0, "parts": [ "hdframe_horizontal", "board_horizontal", "roof" ] },
+      { "x": -6, "y": 1, "parts": [ "hdframe_horizontal", "muffler", "aisle_vertical", "roof" ] },
+      { "x": -4, "y": 1, "parts": [ "hdframe_horizontal", "aisle_vertical", "roof" ] },
+      { "x": -6, "y": 0, "parts": [ "hdframe_horizontal", "trunk", "roof" ] },
+      { "x": -4, "y": 3, "parts": [ "hdframe_vertical", "stowboard_vertical", "roof" ] },
+      { "x": -1, "y": 2, "parts": [ "hdframe_horizontal", "seat", "seatbelt", "roof", "light_red" ] },
+      { "x": -5, "y": 1, "parts": [ "hdframe_horizontal", "aisle_vertical", "roof" ] },
+      { "x": 2, "y": 1, "parts": [ "hdframe_horizontal", "halfboard_horizontal", "headlight" ] },
+      { "x": 1, "y": -1, "parts": [ "hdframe_vertical", "headlight", "windshield", "roof" ] },
+      { "x": -5, "y": 2, "parts": [ "hdframe_horizontal", "trunk", "roof" ] },
+      { "x": -2, "y": -1, "parts": [ "hdframe_vertical", "door", "roof" ] },
+      { "x": -3, "y": -1, "parts": [ "hdframe_sw", "board_sw", "roof" ] }
+    ],
+    "items": [
+      { "x": 0, "y": 1, "chance": 1, "items": [ "roadmap" ] },
+      { "x": -1, "y": 1, "chance": 8, "items": [ "smoxygen_tank", "1st_aid" ] },
+      { "x": -1, "y": 1, "chance": 12, "items": [ "extinguisher" ] },
+      { "x": -4, "y": 2, "chance": 4, "item_groups": [ "fireman_gear" ] },
+      { "x": -4, "y": 0, "chance": 8, "items": [ "flashlight", "oxygen_tank", "smoxygen_tank", "1st_aid" ] },
+      { "x": -4, "y": -1, "chance": 4, "item_groups": [ "fireman_gear" ] },
+      {
+        "x": -5,
+        "y": 0,
+        "chance": 1,
+        "items": [ "bunker_coat", "bunker_pants", "boots_bunker", "fire_gauntlets", "firehelmet", "mask_bunker" ]
+      },
+      {
+        "x": -5,
+        "y": -1,
+        "chance": 7,
+        "items": [ "fire_ax", "hammer_sledge", "hammer_sledge_short", "shovel", "throw_extinguisher", "ny_hook", "pike_pole" ]
+      },
+      {
+        "x": -5,
+        "y": 3,
+        "chance": 1,
+        "items": [ "fire_ax", "chainsaw_off", "halligan", "throw_extinguisher", "ny_hook", "pike_pole" ]
+      },
+      { "x": -6, "y": 0, "chance": 1, "items": [ "nomex_suit", "nomex_hood", "nomex_gloves", "nomex_socks" ] },
+      {
+        "x": -6,
+        "y": -1,
+        "chance": 5,
+        "items": [ "halligan", "crowbar", "hammer_sledge", "hammer_sledge_short", "ny_hook", "pike_pole" ]
+      },
+      { "x": -6, "y": 2, "chance": 1, "items": [ "entry_suit", "mask_gas", "smoxygen_tank" ] },
+      {
+        "x": -6,
+        "y": 3,
+        "chance": 5,
+        "items": [ "halligan", "crowbar", "shovel", "rope_30", "throw_extinguisher", "ny_hook", "pike_pole" ]
+      }
+    ]
+  },
+  {
+    "id": "policecar_test",
+    "type": "vehicle",
+    "name": "Police Car",
+    "blueprint": [
+      [ "o-++-o" ],
+      [ "+=##'|" ],
+      [ "+=##'|" ],
+      [ "o-++-o" ]
+    ],
+    "parts": [
+      { "x": -3, "y": 1, "parts": [ "frame_horizontal", "door_trunk" ] },
+      { "x": -1, "y": 1, "parts": [ "frame_vertical_2", "seat", "seatbelt", "roof", "light_blue" ] },
+      {
+        "x": 2,
+        "y": 2,
+        "parts": [ "frame_ne", "halfboard_ne", "wheel_mount_medium_steerable", "wheel", "headlight" ]
+      },
+      { "x": 0, "y": 2, "parts": [ "frame_vertical", "door" ] },
+      {
+        "x": 2,
+        "y": -1,
+        "parts": [ "frame_nw", "halfboard_nw", "wheel_mount_medium_steerable", "wheel", "headlight" ]
+      },
+      { "x": -1, "y": -1, "parts": [ "frame_vertical", "door" ] },
+      { "x": -2, "y": 2, "parts": [ "frame_vertical", "halfboard_vertical" ] },
+      { "x": 1, "y": 0, "parts": [ "frame_horizontal", "windshield" ] },
+      { "x": -3, "y": 2, "parts": [ "frame_horizontal", "halfboard_se", "wheel_mount_medium", "wheel" ] },
+      { "x": 1, "y": 1, "parts": [ "frame_horizontal", "windshield" ] },
+      { "x": -3, "y": 0, "parts": [ "frame_horizontal", "door_trunk" ] },
+      { "x": -2, "y": 0, "parts": [ "frame_vertical", "trunk", "muffler", "roof" ] },
+      {
+        "x": 0,
+        "y": 0,
+        "parts": [
+          "frame_vertical_2",
+          "seat",
+          "seatbelt",
+          "controls",
+          "dashboard",
+          "vehicle_clock",
+          "vehicle_alarm",
+          "horn_car",
+          "roof"
+        ]
+      },
+      {
+        "x": 2,
+        "y": 0,
+        "parts": [ "frame_horizontal", "engine_v8", "alternator_truck", "battery_car", "halfboard_horizontal" ]
+      },
+      { "x": -1, "y": 0, "parts": [ "frame_vertical_2", "seat", "seatbelt", "roof", "light_red" ] },
+      { "x": -2, "y": 1, "parts": [ "frame_vertical", "trunk", "roof" ] },
+      { "x": 0, "y": 1, "parts": [ "frame_vertical_2", "seat", "seatbelt", "roof" ] },
+      { "x": 0, "y": -1, "parts": [ "frame_vertical", "door" ] },
+      { "x": -1, "y": 2, "parts": [ "frame_vertical", "door" ] },
+      { "x": 1, "y": 2, "parts": [ "frame_vertical", "windshield" ] },
+      { "x": 2, "y": 1, "parts": [ "frame_horizontal", "halfboard_horizontal" ] },
+      { "x": 1, "y": -1, "parts": [ "frame_vertical", "windshield" ] },
+      {
+        "x": -2,
+        "y": -1,
+        "parts": [ "frame_vertical", "halfboard_vertical", { "part": "tank", "fuel": "gasoline" } ]
+      },
+      { "x": -3, "y": -1, "parts": [ "frame_horizontal", "halfboard_sw", "wheel_mount_medium", "wheel" ] }
+    ],
+    "items": [
+      { "x": -2, "y": 0, "chance": 5, "item_groups": [ "tools_entry" ] },
+      { "x": -2, "y": 0, "chance": 5, "item_groups": [ "cop_gear" ] },
+      { "x": -2, "y": 1, "chance": 3, "magazine": 100, "ammo": 50, "item_groups": [ "cop_weapons" ] }
+    ]
+  },
+  {
+    "id": "policesuv_test",
+    "type": "vehicle",
+    "name": "Police SUV",
+    "blueprint": [
+      [ "-o-++-o" ],
+      [ "+==##'|" ],
+      [ "+==##'|" ],
+      [ "-o-++-o" ]
+    ],
+    "parts": [
+      { "x": -3, "y": 1, "parts": [ "frame_vertical", "trunk", "roof" ] },
+      { "x": -1, "y": 1, "parts": [ "frame_vertical_2", "seat", "seatbelt", "roof", "light_blue" ] },
+      {
+        "x": 2,
+        "y": 2,
+        "parts": [ "frame_ne", "halfboard_ne", "wheel_mount_medium_steerable", "wheel", "headlight_reinforced" ]
+      },
+      { "x": 0, "y": 2, "parts": [ "frame_vertical", "door" ] },
+      {
+        "x": 2,
+        "y": -1,
+        "parts": [ "frame_nw", "halfboard_nw", "wheel_mount_medium_steerable", "wheel", "headlight_reinforced" ]
+      },
+      { "x": -1, "y": -1, "parts": [ "frame_vertical", "door" ] },
+      { "x": -2, "y": 2, "parts": [ "frame_vertical", "halfboard_vertical" ] },
+      { "x": 1, "y": 0, "parts": [ "frame_horizontal", "windshield" ] },
+      { "x": -3, "y": 2, "parts": [ "frame_vertical", "halfboard_vertical", "wheel_mount_medium", "wheel" ] },
+      { "x": -4, "y": 0, "parts": [ "frame_horizontal", "door_trunk" ] },
+      { "x": 1, "y": 1, "parts": [ "frame_horizontal", "windshield" ] },
+      { "x": -4, "y": 2, "parts": [ "frame_horizontal", "halfboard_se" ] },
+      { "x": -3, "y": 0, "parts": [ "frame_vertical", "trunk", "muffler", "roof" ] },
+      { "x": -4, "y": -1, "parts": [ "frame_horizontal", "halfboard_sw" ] },
+      { "x": -2, "y": 0, "parts": [ "frame_vertical", "trunk", "roof" ] },
+      {
+        "x": 0,
+        "y": 0,
+        "parts": [
+          "frame_vertical_2",
+          "seat",
+          "seatbelt",
+          "controls",
+          "dashboard",
+          "vehicle_clock",
+          "vehicle_alarm",
+          "horn_car",
+          "roof"
+        ]
+      },
+      {
+        "x": 2,
+        "y": 0,
+        "parts": [ "frame_horizontal", "halfboard_horizontal", "engine_v8", "alternator_truck", "battery_car" ]
+      },
+      { "x": -1, "y": 0, "parts": [ "frame_vertical_2", "seat", "seatbelt", "roof", "light_red" ] },
+      { "x": -2, "y": 1, "parts": [ "frame_vertical", "trunk", "roof" ] },
+      { "x": -4, "y": 1, "parts": [ "frame_horizontal", "door_trunk" ] },
+      { "x": 0, "y": 1, "parts": [ "frame_vertical_2", "seat", "seatbelt", "roof" ] },
+      { "x": 0, "y": -1, "parts": [ "frame_vertical", "door" ] },
+      { "x": -1, "y": 2, "parts": [ "frame_vertical", "door" ] },
+      { "x": 1, "y": 2, "parts": [ "frame_vertical", "windshield" ] },
+      { "x": 2, "y": 1, "parts": [ "frame_horizontal", "halfboard_horizontal" ] },
+      { "x": 1, "y": -1, "parts": [ "frame_vertical", "windshield" ] },
+      {
+        "x": -2,
+        "y": -1,
+        "parts": [ "frame_vertical", "halfboard_vertical", { "part": "tank", "fuel": "gasoline" } ]
+      },
+      {
+        "x": -3,
+        "y": -1,
+        "parts": [ "frame_vertical", "halfboard_vertical", { "part": "tank", "fuel": "gasoline" }, "wheel_mount_medium", "wheel" ]
+      }
+    ],
+    "items": [
+      { "x": -2, "y": 0, "chance": 5, "item_groups": [ "cop_gear" ] },
+      { "x": -2, "y": 1, "chance": 3, "magazine": 100, "ammo": 50, "item_groups": [ "cop_weapons" ] },
+      { "x": -3, "y": 0, "chance": 5, "item_groups": [ "tools_entry" ] },
+      { "x": -3, "y": 1, "chance": 4, "items": [ "jumper_cable" ] },
+      { "x": -3, "y": 1, "chance": 7, "items": [ "jack_small", "wheel" ] }
+    ]
+  },
+  {
+    "id": "truck_swat_test",
+    "type": "vehicle",
+    "name": "SWAT Truck",
+    "blueprint": [
+      [ "     o " ],
+      [ "O----+-O" ],
+      [ "|###|#'|" ],
+      [ "+====='>" ],
+      [ "|#==|#'|" ],
+      [ "O--+-+-O" ],
+      [ "     o " ]
+    ],
+    "parts": [
+      { "x": -3, "y": 1, "parts": [ "hdframe_horizontal", "aisle_horizontal", "hdroof" ] },
+      { "x": 2, "y": 2, "parts": [ "hdframe_horizontal", "halfboard_horizontal_2", "plating_steel" ] },
+      { "x": -1, "y": 1, "parts": [ "hdframe_horizontal", "aisle_horizontal", "hdroof" ] },
+      { "x": 0, "y": 2, "parts": [ "hdframe_vertical_2", "seat", "seatbelt", "light_red", "hdroof" ] },
+      { "x": 1, "y": 3, "parts": [ "hdframe_vertical", "reinforced_windshield", "plating_steel" ] },
+      {
+        "x": 2,
+        "y": -1,
+        "parts": [ "hdframe_nw", "halfboard_nw", "headlight_reinforced", "wheel_mount_medium_steerable", "wheel_wide", "plating_steel" ]
+      },
+      {
+        "x": -1,
+        "y": -1,
+        "parts": [ "hdframe_sw", "hdboard_sw", { "part": "tank", "fuel": "diesel" }, "hdroof", "plating_steel" ]
+      },
+      { "x": -3, "y": 3, "parts": [ "hdframe_vertical", "hdboard_vertical", "hdroof", "plating_steel" ] },
+      { "x": -2, "y": 2, "parts": [ "hdframe_vertical", "seat", "seatbelt", "hdroof" ] },
+      {
+        "x": -1,
+        "y": 3,
+        "parts": [ "hdframe_se", "hdboard_se", { "part": "tank", "fuel": "diesel" }, "hdroof", "plating_steel" ]
+      },
+      { "x": 1, "y": 0, "parts": [ "hdframe_horizontal", "reinforced_windshield", "plating_steel" ] },
+      {
+        "x": -5,
+        "y": -1,
+        "parts": [ "hdframe_sw", "hdboard_sw", "wheel_mount_medium", "wheel_wide", "hdroof", "plating_steel" ]
+      },
+      { "x": -3, "y": 2, "parts": [ "hdframe_horizontal", "seat", "seatbelt", "hdroof" ] },
+      { "x": 1, "y": 4, "parts": [ "wing_mirror_right" ] },
+      { "x": 1, "y": -2, "parts": [ "wing_mirror_left" ] },
+      { "x": -2, "y": 3, "parts": [ "hdframe_vertical", "hddoor_opaque_right", "hdroof", "plating_steel" ] },
+      {
+        "x": 2,
+        "y": 3,
+        "parts": [ "hdframe_ne", "halfboard_ne", "headlight_reinforced", "wheel_mount_medium_steerable", "wheel_wide", "plating_steel" ]
+      },
+      {
+        "x": -5,
+        "y": 3,
+        "parts": [ "hdframe_se", "hdboard_se", "wheel_mount_medium", "wheel_wide", "hdroof", "plating_steel" ]
+      },
+      { "x": -4, "y": 0, "parts": [ "hdframe_horizontal", "seat", "seatbelt", "hdroof" ] },
+      {
+        "x": 1,
+        "y": 1,
+        "parts": [
+          "hdframe_horizontal",
+          "reinforced_windshield",
+          "plating_steel",
+          "diesel_engine_v6",
+          "alternator_truck",
+          "battery_car"
+        ]
+      },
+      { "x": -4, "y": 2, "parts": [ "hdframe_horizontal", "seat", "seatbelt", "hdroof" ] },
+      { "x": -3, "y": 0, "parts": [ "hdframe_horizontal", "seat", "seatbelt", "hdroof" ] },
+      { "x": -4, "y": -1, "parts": [ "hdframe_vertical", "hdboard_vertical", "hdroof", "plating_steel" ] },
+      { "x": -2, "y": 0, "parts": [ "hdframe_vertical", "seat", "seatbelt", "hdroof" ] },
+      {
+        "x": 0,
+        "y": 0,
+        "parts": [
+          "hdframe_vertical_2",
+          "seat",
+          "seatbelt",
+          "controls",
+          "dashboard",
+          "light_blue",
+          "vehicle_alarm",
+          "horn_car",
+          "hdroof"
+        ]
+      },
+      { "x": 2, "y": 0, "parts": [ "hdframe_horizontal", "halfboard_horizontal_2", "plating_steel" ] },
+      { "x": -1, "y": 0, "parts": [ "hdframe_horizontal", "hdboard_horizontal", "hdroof", "plating_steel" ] },
+      { "x": -2, "y": 1, "parts": [ "hdframe_vertical", "aisle_horizontal", "hdroof" ] },
+      { "x": -4, "y": 1, "parts": [ "hdframe_horizontal", "aisle_horizontal", "hdroof" ] },
+      { "x": 0, "y": 3, "parts": [ "hdframe_vertical", "hddoor_right", "plating_steel" ] },
+      { "x": 0, "y": 1, "parts": [ "hdframe_vertical", "aisle_horizontal", "hdroof" ] },
+      { "x": 0, "y": -1, "parts": [ "hdframe_vertical", "hddoor_left", "plating_steel" ] },
+      { "x": 1, "y": 2, "parts": [ "hdframe_horizontal", "reinforced_windshield", "plating_steel" ] },
+      { "x": -1, "y": 2, "parts": [ "hdframe_horizontal", "hdboard_horizontal", "hdroof", "plating_steel" ] },
+      { "x": -4, "y": 3, "parts": [ "hdframe_vertical", "hdboard_vertical", "hdroof", "plating_steel" ] },
+      { "x": -5, "y": 1, "parts": [ "hdframe_horizontal", "hddoor_opaque", "hdroof", "plating_steel" ] },
+      { "x": 2, "y": 1, "parts": [ "hdframe_cover", "halfboard_horizontal_2", "plating_steel" ] },
+      { "x": 1, "y": -1, "parts": [ "hdframe_vertical", "reinforced_windshield", "plating_steel" ] },
+      { "x": -5, "y": 2, "parts": [ "hdframe_horizontal", "hdboard_horizontal", "hdroof", "plating_steel" ] },
+      { "x": -2, "y": -1, "parts": [ "hdframe_vertical", "hdboard_vertical", "hdroof", "plating_steel" ] },
+      { "x": -3, "y": -1, "parts": [ "hdframe_vertical", "hdboard_vertical", "hdroof", "plating_steel" ] },
+      { "x": -5, "y": 0, "parts": [ "hdframe_horizontal", "hdboard_horizontal", "hdroof", "plating_steel" ] }
+    ],
+    "items": [
+      { "x": -2, "y": 0, "chance": 50, "item_groups": [ "swat_gear" ] },
+      { "x": -2, "y": 2, "chance": 50, "magazine": 100, "ammo": 50, "item_groups": [ "guns_swat" ] },
+      { "x": -2, "y": 2, "chance": 50, "item_groups": [ "ammo_swat" ] },
+      { "x": -3, "y": 0, "chance": 50, "magazine": 100, "ammo": 50, "item_groups": [ "guns_swat" ] },
+      { "x": -3, "y": 0, "chance": 50, "item_groups": [ "mags_swat" ] },
+      { "x": -3, "y": 2, "chance": 50, "item_groups": [ "swat_gear" ] },
+      { "x": -4, "y": 0, "chance": 50, "magazine": 100, "ammo": 50, "item_groups": [ "guns_swat" ] },
+      { "x": -4, "y": 0, "chance": 50, "item_groups": [ "ammo_swat" ] },
+      { "x": -4, "y": 2, "chance": 50, "item_groups": [ "swat_gear" ] }
+    ]
+  },
+  {
+    "id": "oldtractor_test",
+    "type": "vehicle",
+    "name": "Primitive Tractor",
+    "blueprint": [
+      [ " O  O " ],
+      [ "&&#==&" ],
+      [ " O  O " ]
+    ],
+    "parts": [
+      { "x": -1, "y": 1, "parts": [ "frame_cross", "wheel_mount_medium", "wheel_wide_or" ] },
+      { "x": 2, "y": -1, "parts": [ "frame_cross", "wheel_mount_medium_steerable", "wheel_wide_or" ] },
+      { "x": -1, "y": -1, "parts": [ "frame_cross", "wheel_mount_medium", "wheel_wide_or" ] },
+      {
+        "x": 1,
+        "y": 0,
+        "parts": [ "frame_vertical", "halfboard_vertical", "engine_steam_medium", "alternator_truck", "battery_car" ]
+      },
+      { "x": 3, "y": 0, "parts": [ "reaper" ] },
+      { "x": -2, "y": 0, "parts": [ "seed_drill" ] },
+      { "x": 0, "y": 0, "parts": [ "frame_vertical", "seat", "controls", "dashboard" ] },
+      {
+        "x": 2,
+        "y": 0,
+        "parts": [ "frame_cross", "halfboard_vertical", { "part": "fuel_bunker", "fuel": "coal_lump" } ]
+      },
+      { "x": -1, "y": 0, "parts": [ "frame_cross", "plow" ] },
+      { "x": 2, "y": 1, "parts": [ "frame_cross", "wheel_mount_medium_steerable", "wheel_wide_or" ] }
+    ],
+    "items": [  ]
+  },
+  {
+    "id": "autotractor_test",
+    "type": "vehicle",
+    "name": "Automatic Tractor",
+    "blueprint": [
+      [ "O---O" ],
+      [ "8|=x|" ],
+      [ "O-+-O" ]
+    ],
+    "parts": [
+      { "x": -1, "y": 1, "parts": [ "frame_cross", "storage_battery_mount", "storage_battery_removable", "board_se" ] },
+      { "x": 2, "y": -1, "parts": [ "frame_nw", "wheel_mount_medium_steerable", "wheel_wide_or", "board_nw" ] },
+      {
+        "x": -1,
+        "y": -1,
+        "parts": [ "frame_cross", "storage_battery_mount", "storage_battery_removable", "board_sw" ]
+      },
+      { "x": 1, "y": 0, "parts": [ "frame_vertical_2", "robot_controls", "roof" ] },
+      { "x": 1, "y": 1, "parts": [ "frame_vertical", "board_vertical" ] },
+      { "x": -2, "y": 0, "parts": [ "seed_drill_advanced" ] },
+      { "x": 0, "y": 0, "parts": [ "frame_vertical_2", "reaper_advanced", "roof" ] },
+      { "x": 2, "y": 0, "parts": [ "frame_horizontal", "board_horizontal", "headlight", "omnicam" ] },
+      { "x": -1, "y": 0, "parts": [ "frame_horizontal", "plow", "board_horizontal" ] },
+      {
+        "x": -2,
+        "y": 1,
+        "parts": [
+          "frame_se",
+          "engine_electric",
+          "storage_battery_mount",
+          "storage_battery_removable",
+          "cargo_space",
+          "wheel_mount_medium_steerable",
+          "wheel_wide_or"
+        ]
+      },
+      { "x": 0, "y": 1, "parts": [ "frame_vertical", "door_opaque" ] },
+      { "x": 0, "y": -1, "parts": [ "frame_vertical", "board_vertical" ] },
+      { "x": 2, "y": 1, "parts": [ "frame_ne", "wheel_mount_medium_steerable", "wheel_wide_or", "board_ne" ] },
+      { "x": 1, "y": -1, "parts": [ "frame_vertical", "board_vertical" ] },
+      {
+        "x": -2,
+        "y": -1,
+        "parts": [
+          "frame_sw",
+          "engine_electric",
+          "storage_battery_mount",
+          "storage_battery_removable",
+          "cargo_space",
+          "wheel_mount_medium_steerable",
+          "wheel_wide_or"
+        ]
+      }
+    ],
+    "items": [  ]
+  },
+  {
+    "id": "tractor_plow_test",
+    "type": "vehicle",
+    "name": "Plow Tractor",
+    "blueprint": [
+      [ "&    " ],
+      [ "+O  O" ],
+      [ "&=#==" ],
+      [ "+O  O" ],
+      [ "&    " ]
+    ],
+    "parts": [
+      { "x": -1, "y": 1, "parts": [ "frame_horizontal", "wheel_mount_medium", "wheel_wide_or" ] },
+      { "x": 2, "y": -1, "parts": [ "frame_horizontal", "wheel_mount_medium_steerable", "wheel_wide_or" ] },
+      { "x": -1, "y": -1, "parts": [ "frame_horizontal", "wheel_mount_medium", "wheel_wide_or" ] },
+      { "x": -2, "y": 2, "parts": [ "frame_cross", "plow" ] },
+      {
+        "x": 1,
+        "y": 0,
+        "parts": [ "frame_horizontal", "halfboard_vertical", "battery_car", "diesel_engine_v6", "alternator_truck" ]
+      },
+      { "x": -2, "y": 0, "parts": [ "frame_cross", "plow" ] },
+      { "x": 0, "y": 0, "parts": [ "frame_vertical", "seat", "controls", "dashboard" ] },
+      { "x": 2, "y": 0, "parts": [ "frame_horizontal", "halfboard_vertical" ] },
+      { "x": -2, "y": -2, "parts": [ "frame_cross", "plow" ] },
+      { "x": -1, "y": 0, "parts": [ "frame_cross", { "part": "tank", "fuel": "diesel" }, "halfboard_vertical" ] },
+      { "x": -2, "y": 1, "parts": [ "frame_cross" ] },
+      { "x": 2, "y": 1, "parts": [ "frame_horizontal", "wheel_mount_medium_steerable", "wheel_wide_or" ] },
+      { "x": -2, "y": -1, "parts": [ "frame_cross" ] }
+    ],
+    "items": [  ]
+  },
+  {
+    "id": "tractor_reaper_test",
+    "type": "vehicle",
+    "name": "Reaper Tractor",
+    "blueprint": [
+      [ "&    " ],
+      [ "+O  O" ],
+      [ "&=#==" ],
+      [ "+O  O" ],
+      [ "&    " ]
+    ],
+    "parts": [
+      { "x": -1, "y": 1, "parts": [ "frame_horizontal", "wheel_mount_medium", "wheel_wide_or" ] },
+      { "x": 2, "y": -1, "parts": [ "frame_horizontal", "wheel_mount_medium_steerable", "wheel_wide_or" ] },
+      { "x": -1, "y": -1, "parts": [ "frame_horizontal", "wheel_mount_medium", "wheel_wide_or" ] },
+      { "x": -2, "y": 2, "parts": [ "reaper" ] },
+      {
+        "x": 1,
+        "y": 0,
+        "parts": [ "frame_horizontal", "halfboard_vertical", "battery_car", "diesel_engine_v6", "alternator_truck" ]
+      },
+      { "x": -2, "y": 0, "parts": [ "reaper" ] },
+      { "x": 0, "y": 0, "parts": [ "frame_vertical", "seat", "controls", "dashboard" ] },
+      { "x": 2, "y": 0, "parts": [ "frame_horizontal", "halfboard_vertical" ] },
+      { "x": -2, "y": -2, "parts": [ "reaper" ] },
+      { "x": -1, "y": 0, "parts": [ "frame_cross", { "part": "tank", "fuel": "diesel" }, "halfboard_vertical" ] },
+      { "x": -2, "y": 1, "parts": [ "frame_cross" ] },
+      { "x": 2, "y": 1, "parts": [ "frame_horizontal", "wheel_mount_medium_steerable", "wheel_wide_or" ] },
+      { "x": -2, "y": -1, "parts": [ "frame_cross" ] }
+    ],
+    "items": [  ]
+  },
+  {
+    "id": "tractor_seed_test",
+    "type": "vehicle",
+    "name": "Planter Tractor",
+    "blueprint": [
+      [ "&    " ],
+      [ "+O  O" ],
+      [ "&=#==" ],
+      [ "+O  O" ],
+      [ "&    " ]
+    ],
+    "parts": [
+      { "x": -1, "y": 1, "parts": [ "frame_horizontal", "wheel_mount_medium", "wheel_wide_or" ] },
+      { "x": 2, "y": -1, "parts": [ "frame_horizontal", "wheel_mount_medium_steerable", "wheel_wide_or" ] },
+      { "x": -1, "y": -1, "parts": [ "frame_horizontal", "wheel_mount_medium", "wheel_wide_or" ] },
+      { "x": -2, "y": 2, "parts": [ "seed_drill" ] },
+      {
+        "x": 1,
+        "y": 0,
+        "parts": [ "frame_horizontal", "halfboard_vertical", "battery_car", "diesel_engine_v6", "alternator_truck" ]
+      },
+      { "x": -2, "y": 0, "parts": [ "seed_drill" ] },
+      { "x": 0, "y": 0, "parts": [ "frame_vertical", "seat", "controls", "dashboard" ] },
+      { "x": 2, "y": 0, "parts": [ "frame_horizontal", "halfboard_vertical" ] },
+      { "x": -2, "y": -2, "parts": [ "seed_drill" ] },
+      { "x": -1, "y": 0, "parts": [ "frame_cross", { "part": "tank", "fuel": "diesel" }, "halfboard_vertical" ] },
+      { "x": -2, "y": 1, "parts": [ "frame_cross" ] },
+      { "x": 2, "y": 1, "parts": [ "frame_horizontal", "wheel_mount_medium_steerable", "wheel_wide_or" ] },
+      { "x": -2, "y": -1, "parts": [ "frame_cross" ] }
+    ],
+    "items": [  ]
+  },
+  {
+    "id": "aapc-mg_test",
+    "type": "vehicle",
+    "name": "Mechanized Infantry Carrier",
+    "blueprint": [  ],
+    "parts": [
+      {
+        "x": 2,
+        "y": 2,
+        "parts": [ "hdframe_vertical", "hdboard_vertical", "plating_military", "wheel_mount_heavy", "wheel_armor" ]
+      },
+      { "x": 5, "y": 2, "parts": [ "hdframe_ne", "hdhalfboard_ne", "plating_military" ] },
+      {
+        "x": 0,
+        "y": 2,
+        "parts": [ "hdframe_vertical", "hdboard_vertical", "plating_military", "wheel_mount_heavy", "wheel_armor" ]
+      },
+      { "x": 4, "y": 0, "parts": [ "hdframe_horizontal", "hdboard_ne", "plating_military" ] },
+      { "x": 2, "y": -1, "parts": [ "hdframe_vertical_2", "seat", "hdroof" ] },
+      { "x": -1, "y": 1, "parts": [ "hdframe_vertical_2", "box", "recharge_station", "hdroof" ] },
+      {
+        "x": 3,
+        "y": 1,
+        "parts": [
+          "hdframe_vertical_2",
+          "hdroof",
+          "plating_military",
+          { "fuel": "jp8", "part": "tank_small" },
+          "cam_control",
+          "turret_mount",
+          { "part": "mounted_browning", "ammo": 60, "ammo_qty": [ 10, 100 ] },
+          "turret_autoloader",
+          "seat",
+          "seatbelt_heavyduty"
+        ]
+      },
+      { "x": 5, "y": 0, "parts": [ "hdframe_horizontal", "hdhalfboard_horizontal", "plating_military", "horn_big" ] },
+      { "x": -1, "y": -1, "parts": [ "hdframe_vertical_2", "box", "recharge_station", "hdroof" ] },
+      { "x": 1, "y": 0, "parts": [ "hdframe_vertical_2", "aisle_horizontal", "hdroof" ] },
+      {
+        "x": 3,
+        "y": 0,
+        "parts": [
+          "hdframe_vertical_2",
+          "stowboard_vertical",
+          "hdroof",
+          "diesel_engine_v6",
+          "battery_car",
+          "alternator_truck",
+          "plating_military"
+        ]
+      },
+      { "x": -2, "y": 2, "parts": [ "hdframe_se", "hdboard_se", "muffler", "plating_military" ] },
+      { "x": 4, "y": -2, "parts": [ "hdframe_nw", "hdboard_nw", "plating_military", "omnicam" ] },
+      { "x": -3, "y": 2, "parts": [ { "fuel": "jp8", "part": "external_tank" } ] },
+      { "x": 5, "y": 1, "parts": [ "hdframe_horizontal", "hdhalfboard_horizontal", "plating_military" ] },
+      {
+        "x": 1,
+        "y": -2,
+        "parts": [ "hdframe_vertical", "hdboard_vertical", "plating_military", "wheel_mount_heavy", "wheel_armor" ]
+      },
+      {
+        "x": 0,
+        "y": -2,
+        "parts": [ "hdframe_vertical", "hdboard_vertical", "plating_military", "wheel_mount_heavy", "wheel_armor" ]
+      },
+      { "x": -1, "y": -2, "parts": [ "hdframe_vertical", "hdboard_vertical", "plating_military" ] },
+      {
+        "x": 4,
+        "y": 1,
+        "parts": [ "hdframe_horizontal", "hdboard_horizontal", "plating_military", "headlight_reinforced" ]
+      },
+      { "x": 1, "y": 1, "parts": [ "hdframe_vertical_2", "box", "recharge_station", "hdroof" ] },
+      {
+        "x": 3,
+        "y": -1,
+        "parts": [
+          "hdframe_vertical_2",
+          "hdroof",
+          "controls",
+          "dashboard",
+          "cam_control",
+          "vehicle_clock",
+          "seat",
+          "seatbelt_heavyduty"
+        ]
+      },
+      { "x": -2, "y": 0, "parts": [ "hdframe_horizontal", "hddoor_opaque", "omnicam", "plating_military" ] },
+      { "x": 5, "y": -1, "parts": [ "hdframe_horizontal", "hdhalfboard_horizontal", "plating_military" ] },
+      { "x": 2, "y": 0, "parts": [ "hdframe_vertical_2", "aisle_horizontal", "hdroof" ] },
+      { "x": 0, "y": 0, "parts": [ "hdframe_vertical_2", "aisle_horizontal", "hdroof" ] },
+      { "x": -1, "y": 0, "parts": [ "hdframe_vertical_2", "aisle_horizontal", "hdroof" ] },
+      { "x": -2, "y": 1, "parts": [ "hdframe_horizontal", "hdboard_horizontal", "plating_military" ] },
+      { "x": -2, "y": -2, "parts": [ "hdframe_sw", "hdboard_sw", "muffler", "plating_military" ] },
+      { "x": -3, "y": -2, "parts": [ { "fuel": "jp8", "part": "external_tank" } ] },
+      { "x": 4, "y": 2, "parts": [ "hdframe_ne", "hdboard_ne", "plating_military", "omnicam" ] },
+      {
+        "x": 2,
+        "y": -2,
+        "parts": [ "hdframe_vertical", "hdboard_vertical", "plating_military", "wheel_mount_heavy", "wheel_armor" ]
+      },
+      { "x": 0, "y": 1, "parts": [ "hdframe_vertical_2", "seat", "hdroof" ] },
+      {
+        "x": 4,
+        "y": -1,
+        "parts": [ "hdframe_horizontal", "plating_military", "headlight_reinforced", "reinforced_windshield", "v_hdshutter" ]
+      },
+      { "x": 0, "y": -1, "parts": [ "hdframe_vertical_2", "seat", "hdroof" ] },
+      {
+        "x": 1,
+        "y": 2,
+        "parts": [ "hdframe_vertical", "hdboard_vertical", "plating_military", "wheel_mount_heavy", "wheel_armor" ]
+      },
+      { "x": -1, "y": 2, "parts": [ "hdframe_vertical", "hdboard_vertical", "plating_military" ] },
+      { "x": 5, "y": -2, "parts": [ "hdframe_nw", "hdhalfboard_nw", "plating_military" ] },
+      {
+        "x": 3,
+        "y": 2,
+        "parts": [ "hdframe_vertical", "hdboard_vertical", "plating_military", "wheel_mount_heavy_steerable", "wheel_armor" ]
+      },
+      {
+        "x": 3,
+        "y": -2,
+        "parts": [ "hdframe_vertical", "hdboard_vertical", "plating_military", "wheel_mount_heavy_steerable", "wheel_armor" ]
+      },
+      { "x": 2, "y": 1, "parts": [ "hdframe_vertical_2", "seat", "hdroof" ] },
+      { "x": 1, "y": -1, "parts": [ "hdframe_vertical_2", "box", "recharge_station", "hdroof" ] },
+      { "x": -2, "y": -1, "parts": [ "hdframe_horizontal", "hdboard_horizontal", "plating_military" ] }
+    ],
+    "items": [
+      { "x": 3, "y": -1, "chance": 2, "items": [ "id_military" ] },
+      { "x": 3, "y": -1, "chance": 2, "items": [ "mil_gps_device" ] },
+      { "x": 3, "y": -1, "chance": 20, "item_groups": [ "tools_survival" ] },
+      { "x": 3, "y": 1, "chance": 50, "items": [ "ear_plugs" ] },
+      { "x": -1, "y": -1, "chance": 20, "item_groups": [ "ammo_milspec" ] },
+      { "x": -1, "y": 1, "chance": 20, "item_groups": [ "ammo_milspec" ] },
+      { "x": 1, "y": -1, "chance": 20, "item_groups": [ "ammo_milspec" ] },
+      { "x": 1, "y": 1, "chance": 20, "item_groups": [ "ammo_milspec" ] },
+      { "x": -1, "y": -1, "chance": 10, "item_groups": [ "mags_milspec" ] },
+      { "x": -1, "y": 1, "chance": 10, "item_groups": [ "mags_milspec" ] },
+      { "x": 1, "y": -1, "chance": 10, "item_groups": [ "mags_milspec" ] },
+      { "x": 1, "y": 1, "chance": 10, "item_groups": [ "mags_milspec" ] },
+      { "x": -1, "y": -1, "chance": 5, "item_groups": [ "guns_milspec" ] },
+      { "x": -1, "y": 1, "chance": 5, "item_groups": [ "guns_milspec" ] },
+      { "x": 1, "y": -1, "chance": 5, "item_groups": [ "guns_milspec" ] },
+      { "x": 1, "y": 1, "chance": 5, "item_groups": [ "guns_milspec" ] }
+    ]
+  },
+  {
+    "id": "apc_test",
+    "type": "vehicle",
+    "name": "Armored Personnel Carrier",
+    "blueprint": [  ],
+    "parts": [
+      {
+        "x": 2,
+        "y": 2,
+        "parts": [ "hdframe_vertical", "hdboard_vertical", "plating_military", "wheel_mount_heavy", "wheel_armor" ]
+      },
+      { "x": 5, "y": 2, "parts": [ "hdframe_ne", "hdhalfboard_ne", "plating_military" ] },
+      {
+        "x": 0,
+        "y": 2,
+        "parts": [ "hdframe_vertical", "hdboard_vertical", "plating_military", "wheel_mount_heavy", "wheel_armor" ]
+      },
+      { "x": 4, "y": 0, "parts": [ "hdframe_horizontal", "hdboard_ne", "plating_military" ] },
+      { "x": 2, "y": -1, "parts": [ "hdframe_vertical_2", "seat", "hdroof" ] },
+      { "x": -1, "y": 1, "parts": [ "hdframe_vertical_2", "seat", "hdroof" ] },
+      {
+        "x": 3,
+        "y": 1,
+        "parts": [
+          "hdframe_vertical_2",
+          "hdroof",
+          "plating_military",
+          { "fuel": "jp8", "part": "tank_small" },
+          "cam_control",
+          "turret_mount",
+          { "part": "mounted_browning", "ammo": 60, "ammo_qty": [ 10, 100 ] },
+          "turret_autoloader",
+          "seat",
+          "seatbelt_heavyduty"
+        ]
+      },
+      { "x": 5, "y": 0, "parts": [ "hdframe_horizontal", "hdhalfboard_horizontal", "plating_military", "horn_big" ] },
+      { "x": -1, "y": -1, "parts": [ "hdframe_vertical_2", "seat", "hdroof" ] },
+      { "x": 1, "y": 0, "parts": [ "hdframe_vertical_2", "aisle_horizontal", "hdroof" ] },
+      {
+        "x": 3,
+        "y": 0,
+        "parts": [
+          "hdframe_vertical_2",
+          "stowboard_vertical",
+          "hdroof",
+          "diesel_engine_v6",
+          "battery_car",
+          "alternator_truck",
+          "plating_military"
+        ]
+      },
+      { "x": -2, "y": 2, "parts": [ "hdframe_se", "hdboard_se", "muffler", "plating_military" ] },
+      { "x": 4, "y": -2, "parts": [ "hdframe_nw", "hdboard_nw", "plating_military", "omnicam" ] },
+      { "x": -3, "y": 2, "parts": [ { "fuel": "jp8", "part": "external_tank" } ] },
+      { "x": 5, "y": 1, "parts": [ "hdframe_horizontal", "hdhalfboard_horizontal", "plating_military" ] },
+      {
+        "x": 1,
+        "y": -2,
+        "parts": [ "hdframe_vertical", "hdboard_vertical", "plating_military", "wheel_mount_heavy", "wheel_armor" ]
+      },
+      {
+        "x": 0,
+        "y": -2,
+        "parts": [ "hdframe_vertical", "hdboard_vertical", "plating_military", "wheel_mount_heavy", "wheel_armor" ]
+      },
+      { "x": -1, "y": -2, "parts": [ "hdframe_vertical", "hdboard_vertical", "plating_military" ] },
+      {
+        "x": 4,
+        "y": 1,
+        "parts": [ "hdframe_horizontal", "hdboard_horizontal", "plating_military", "headlight_reinforced" ]
+      },
+      { "x": 1, "y": 1, "parts": [ "hdframe_vertical_2", "seat", "hdroof" ] },
+      {
+        "x": 3,
+        "y": -1,
+        "parts": [
+          "hdframe_vertical_2",
+          "hdroof",
+          "controls",
+          "dashboard",
+          "cam_control",
+          "vehicle_clock",
+          "seat",
+          "seatbelt_heavyduty"
+        ]
+      },
+      { "x": -2, "y": 0, "parts": [ "hdframe_horizontal", "hddoor_opaque", "omnicam", "plating_military" ] },
+      { "x": 5, "y": -1, "parts": [ "hdframe_horizontal", "hdhalfboard_horizontal", "plating_military" ] },
+      { "x": 2, "y": 0, "parts": [ "hdframe_vertical_2", "aisle_horizontal", "hdroof" ] },
+      { "x": 0, "y": 0, "parts": [ "hdframe_vertical_2", "aisle_horizontal", "hdroof" ] },
+      { "x": -1, "y": 0, "parts": [ "hdframe_vertical_2", "aisle_horizontal", "hdroof" ] },
+      { "x": -2, "y": 1, "parts": [ "hdframe_horizontal", "hdboard_horizontal", "plating_military" ] },
+      { "x": -2, "y": -2, "parts": [ "hdframe_sw", "hdboard_sw", "muffler", "plating_military" ] },
+      { "x": -3, "y": -2, "parts": [ { "fuel": "jp8", "part": "external_tank" } ] },
+      { "x": 4, "y": 2, "parts": [ "hdframe_ne", "hdboard_ne", "plating_military", "omnicam" ] },
+      {
+        "x": 2,
+        "y": -2,
+        "parts": [ "hdframe_vertical", "hdboard_vertical", "plating_military", "wheel_mount_heavy", "wheel_armor" ]
+      },
+      { "x": 0, "y": 1, "parts": [ "hdframe_vertical_2", "seat", "hdroof" ] },
+      {
+        "x": 4,
+        "y": -1,
+        "parts": [ "hdframe_horizontal", "plating_military", "headlight_reinforced", "reinforced_windshield" ]
+      },
+      { "x": 0, "y": -1, "parts": [ "hdframe_vertical_2", "seat", "hdroof" ] },
+      {
+        "x": 1,
+        "y": 2,
+        "parts": [ "hdframe_vertical", "hdboard_vertical", "plating_military", "wheel_mount_heavy", "wheel_armor" ]
+      },
+      { "x": -1, "y": 2, "parts": [ "hdframe_vertical", "hdboard_vertical", "plating_military" ] },
+      { "x": 5, "y": -2, "parts": [ "hdframe_nw", "hdhalfboard_nw", "plating_military" ] },
+      {
+        "x": 3,
+        "y": 2,
+        "parts": [ "hdframe_vertical", "hdboard_vertical", "plating_military", "wheel_mount_heavy_steerable", "wheel_armor" ]
+      },
+      {
+        "x": 3,
+        "y": -2,
+        "parts": [ "hdframe_vertical", "hdboard_vertical", "plating_military", "wheel_mount_heavy_steerable", "wheel_armor" ]
+      },
+      { "x": 2, "y": 1, "parts": [ "hdframe_vertical_2", "seat", "hdroof" ] },
+      { "x": 1, "y": -1, "parts": [ "hdframe_vertical_2", "seat", "hdroof" ] },
+      { "x": -2, "y": -1, "parts": [ "hdframe_horizontal", "hdboard_horizontal", "plating_military" ] }
+    ],
+    "items": [ { "y": -1, "x": 3, "chance": 2, "items": [ "id_military" ] } ]
+  },
+  {
+    "id": "humvee_test",
+    "type": "vehicle",
+    "name": "Humvee",
+    "blueprint": [
+      [ "O-++-OH" ],
+      [ "|H##'|H" ],
+      [ "t###'|H" ],
+      [ "|H##'|H" ],
+      [ "O-++-OH" ]
+    ],
+    "parts": [
+      { "x": -3, "y": 1, "parts": [ "hdframe_horizontal", "hddoor_trunk", "plating_military" ] },
+      {
+        "x": 2,
+        "y": 2,
+        "parts": [ "hdframe_horizontal", "hdhalfboard_horizontal", "plating_military", "headlight_reinforced" ]
+      },
+      {
+        "x": -1,
+        "y": 1,
+        "parts": [
+          "hdframe_horizontal_2",
+          "aisle_horizontal",
+          "hdroof",
+          "turret_mount",
+          { "ammo_types": [ "762_51" ], "part": "mounted_m240", "ammo": 60, "ammo_qty": [ 10, 100 ] },
+          "turret_autoloader"
+        ]
+      },
+      { "x": 1, "y": 3, "parts": [ "hdframe_vertical", "reinforced_windshield" ] },
+      {
+        "x": 2,
+        "y": -1,
+        "parts": [ "hdframe_nw", "hdhalfboard_nw", "plating_military", "wheel_mount_heavy_steerable", "wheel_armor" ]
+      },
+      {
+        "x": 0,
+        "y": 2,
+        "parts": [ "hdframe_vertical_2", "hdroof", { "fuel": "jp8", "part": "tank" }, "seat", "seatbelt" ]
+      },
+      { "x": -1, "y": -1, "parts": [ "hdframe_vertical", "hddoor_left" ] },
+      { "x": 3, "y": 1, "parts": [ "hdframe_horizontal_2", "plating_military" ] },
+      { "x": -2, "y": 2, "parts": [ "hdframe_horizontal_2", "trunk", "hdroof" ] },
+      { "x": -1, "y": 3, "parts": [ "hdframe_vertical", "hddoor_right" ] },
+      { "x": 1, "y": 0, "parts": [ "hdframe_horizontal", "reinforced_windshield" ] },
+      { "x": 3, "y": 0, "parts": [ "hdframe_horizontal_2", "plating_military" ] },
+      {
+        "x": -3,
+        "y": 3,
+        "parts": [ "hdframe_se", "hdboard_se", "plating_military", "wheel_mount_heavy", "wheel_armor" ]
+      },
+      { "x": -3, "y": 2, "parts": [ "hdframe_horizontal", "hddoor_trunk", "plating_military" ] },
+      { "x": -2, "y": 3, "parts": [ "hdframe_vertical", "hdboard_vertical", "plating_military" ] },
+      {
+        "x": 2,
+        "y": 3,
+        "parts": [ "hdframe_ne", "hdhalfboard_ne", "plating_military", "wheel_mount_heavy_steerable", "wheel_armor" ]
+      },
+      { "x": 1, "y": 1, "parts": [ "hdframe_horizontal", "reinforced_windshield" ] },
+      { "x": 3, "y": -1, "parts": [ "hdframe_horizontal", "plating_military" ] },
+      { "x": -3, "y": 0, "parts": [ "hdframe_horizontal", "hddoor_trunk", "muffler", "plating_military" ] },
+      { "x": -2, "y": 0, "parts": [ "hdframe_horizontal_2", "trunk", "hdroof" ] },
+      {
+        "x": 0,
+        "y": 0,
+        "parts": [
+          "hdframe_vertical_2",
+          "hdroof",
+          { "fuel": "jp8", "part": "tank" },
+          "controls",
+          "dashboard",
+          "vehicle_clock",
+          "horn_big",
+          "seat",
+          "seatbelt"
+        ]
+      },
+      {
+        "x": 2,
+        "y": 0,
+        "parts": [ "hdframe_horizontal", "hdhalfboard_horizontal", "plating_military", "headlight_reinforced" ]
+      },
+      { "x": -1, "y": 0, "parts": [ "hdframe_horizontal_2", "seat", "seatbelt", "hdroof" ] },
+      { "x": -2, "y": 1, "parts": [ "hdframe_horizontal_2", "trunk", "hdroof" ] },
+      { "x": 0, "y": 3, "parts": [ "hdframe_vertical", "hddoor_right" ] },
+      { "x": 0, "y": 1, "parts": [ "hdframe_vertical_2", "box", "recharge_station", "hdroof" ] },
+      { "x": 3, "y": 3, "parts": [ "hdframe_horizontal", "plating_military" ] },
+      { "x": 0, "y": -1, "parts": [ "hdframe_vertical", "hddoor_left" ] },
+      { "x": 1, "y": 2, "parts": [ "hdframe_horizontal", "reinforced_windshield" ] },
+      { "x": -1, "y": 2, "parts": [ "hdframe_horizontal_2", "seat", "seatbelt", "hdroof" ] },
+      {
+        "x": 2,
+        "y": 1,
+        "parts": [
+          "hdframe_horizontal",
+          "hdhalfboard_horizontal",
+          "plating_military",
+          "diesel_engine_v8",
+          "alternator_truck",
+          "battery_car"
+        ]
+      },
+      { "x": 3, "y": 2, "parts": [ "hdframe_horizontal_2", "plating_military" ] },
+      { "x": 1, "y": -1, "parts": [ "hdframe_vertical", "reinforced_windshield" ] },
+      { "x": -2, "y": -1, "parts": [ "hdframe_vertical", "hdboard_vertical", "plating_military" ] },
+      {
+        "x": -3,
+        "y": -1,
+        "parts": [ "hdframe_sw", "hdboard_sw", "plating_military", "wheel_mount_heavy", "wheel_armor" ]
+      }
+    ],
+    "items": [
+      { "x": 0, "y": 0, "chance": 5, "items": [ "id_military" ] },
+      { "x": 0, "y": 0, "chance": 3, "items": [ "mil_gps_device" ] },
+      { "x": -2, "y": 2, "chance": 15, "item_groups": [ "fuel_diesel" ] }
+    ]
+  },
+  {
+    "id": "military_cargo_truck_test",
+    "type": "vehicle",
+    "name": "Military Cargo Truck",
+    "blueprint": [
+      [ "-OO--+-O-" ],
+      [ "#OO#'#'|>" ],
+      [ "||||'#'=>" ],
+      [ "#OO#'#'|>" ],
+      [ "-OO--+-O-" ]
+    ],
+    "parts": [
+      { "x": -3, "y": 1, "parts": [ "hdframe_horizontal", "aisle_vertical" ] },
+      {
+        "x": 2,
+        "y": 2,
+        "parts": [ "hdframe_horizontal", "hdhalfboard_horizontal", "plating_military", "headlight_reinforced" ]
+      },
+      { "x": -1, "y": 1, "parts": [ "hdframe_vertical_2", "reinforced_windshield" ] },
+      { "x": 1, "y": 3, "parts": [ "hdframe_vertical", "reinforced_windshield" ] },
+      {
+        "x": 2,
+        "y": -1,
+        "parts": [ "hdframe_horizontal", "hdhalfboard_nw", "plating_military", "wheel_mount_heavy_steerable", "wheel_armor" ]
+      },
+      { "x": 3, "y": 1, "parts": [ "hdframe_horizontal_2", "plating_spiked" ] },
+      { "x": 1, "y": 0, "parts": [ "hdframe_horizontal", "reinforced_windshield" ] },
+      { "x": -3, "y": 2, "parts": [ "hdframe_horizontal", "seat", "wheel_mount_heavy", "wheel_armor" ] },
+      { "x": -4, "y": 0, "parts": [ "hdframe_horizontal", "seat", "wheel_mount_heavy", "wheel_armor" ] },
+      { "x": 1, "y": 1, "parts": [ "hdframe_horizontal", "reinforced_windshield" ] },
+      { "x": 3, "y": -1, "parts": [ "hdframe_nw", "plating_spiked" ] },
+      { "x": -4, "y": 2, "parts": [ "hdframe_horizontal", "seat", "wheel_mount_heavy", "wheel_armor" ] },
+      {
+        "x": -4,
+        "y": -1,
+        "parts": [ "hdframe_horizontal", "hdhalfboard_vertical", "plating_military", "wheel_mount_heavy", "wheel_armor" ]
+      },
+      { "x": -2, "y": 0, "parts": [ "hdframe_vertical_2", "seat" ] },
+      {
+        "x": 0,
+        "y": 0,
+        "parts": [
+          "hdframe_vertical_2",
+          { "fuel": "jp8", "part": "tank" },
+          "hdroof",
+          "seat",
+          "seatbelt",
+          "controls",
+          "dashboard",
+          "vehicle_clock",
+          "horn_big"
+        ]
+      },
+      {
+        "x": 2,
+        "y": 0,
+        "parts": [ "hdframe_horizontal", "hdhalfboard_horizontal", "plating_military", "headlight_reinforced" ]
+      },
+      { "x": -1, "y": 0, "parts": [ "hdframe_horizontal", "reinforced_windshield" ] },
+      { "x": -2, "y": 1, "parts": [ "hdframe_horizontal", "aisle_vertical" ] },
+      { "x": 0, "y": 3, "parts": [ "hdframe_vertical", "hddoor_left" ] },
+      {
+        "x": 0,
+        "y": 1,
+        "parts": [ "hdframe_vertical_2", { "fuel": "jp8", "part": "tank" }, "hdroof", "seat", "seatbelt" ]
+      },
+      { "x": 3, "y": 3, "parts": [ "hdframe_ne", "plating_spiked" ] },
+      { "x": 0, "y": -1, "parts": [ "hdframe_vertical", "hddoor_right" ] },
+      { "x": 1, "y": 2, "parts": [ "hdframe_horizontal", "reinforced_windshield" ] },
+      { "x": 3, "y": 2, "parts": [ "hdframe_horizontal_2", "plating_spiked" ] },
+      { "x": -5, "y": 0, "parts": [ "hdframe_vertical_2", "seat" ] },
+      {
+        "x": 0,
+        "y": 2,
+        "parts": [ "hdframe_vertical_2", { "fuel": "jp8", "part": "tank" }, "hdroof", "seat", "seatbelt" ]
+      },
+      { "x": -5, "y": -1, "parts": [ "hdframe_vertical", "hdhalfboard_vertical", "plating_military" ] },
+      { "x": -1, "y": -1, "parts": [ "hdframe_vertical", "hdhalfboard_sw", "muffler", "plating_military" ] },
+      {
+        "x": -3,
+        "y": 3,
+        "parts": [ "hdframe_horizontal", "hdhalfboard_vertical", "plating_military", "wheel_mount_heavy", "wheel_armor" ]
+      },
+      { "x": -2, "y": 2, "parts": [ "hdframe_vertical_2", "seat" ] },
+      { "x": -1, "y": 3, "parts": [ "hdframe_vertical", "hdhalfboard_se", "muffler", "plating_military" ] },
+      { "x": 3, "y": 0, "parts": [ "hdframe_horizontal_2", "plating_spiked" ] },
+      { "x": -2, "y": 3, "parts": [ "hdframe_vertical", "hdhalfboard_vertical", "plating_military" ] },
+      {
+        "x": 2,
+        "y": 3,
+        "parts": [ "hdframe_horizontal", "hdhalfboard_ne", "plating_military", "wheel_mount_heavy_steerable", "wheel_armor" ]
+      },
+      { "x": -5, "y": 3, "parts": [ "hdframe_vertical", "hdhalfboard_vertical", "plating_military" ] },
+      { "x": -3, "y": 0, "parts": [ "hdframe_horizontal", "seat", "wheel_mount_heavy", "wheel_armor" ] },
+      { "x": -4, "y": 1, "parts": [ "hdframe_horizontal", "aisle_vertical" ] },
+      {
+        "x": -4,
+        "y": 3,
+        "parts": [ "hdframe_horizontal", "hdhalfboard_vertical", "plating_military", "wheel_mount_heavy", "wheel_armor" ]
+      },
+      { "x": -1, "y": 2, "parts": [ "hdframe_horizontal", "reinforced_windshield" ] },
+      { "x": -5, "y": 1, "parts": [ "hdframe_horizontal", "aisle_vertical" ] },
+      {
+        "x": 2,
+        "y": 1,
+        "parts": [
+          "hdframe_vertical_2",
+          "hdhalfboard_vertical_2",
+          "plating_military",
+          "diesel_engine_v8",
+          "alternator_truck",
+          "battery_car"
+        ]
+      },
+      { "x": 1, "y": -1, "parts": [ "hdframe_vertical", "reinforced_windshield" ] },
+      { "x": -5, "y": 2, "parts": [ "hdframe_vertical_2", "seat" ] },
+      { "x": -2, "y": -1, "parts": [ "hdframe_vertical", "hdhalfboard_vertical", "plating_military" ] },
+      {
+        "x": -3,
+        "y": -1,
+        "parts": [ "hdframe_horizontal", "hdhalfboard_vertical", "plating_military", "wheel_mount_heavy", "wheel_armor" ]
+      }
+    ],
+    "items": [
+      { "x": 0, "y": 0, "chance": 6, "items": [ "id_military" ] },
+      { "x": 0, "y": 0, "chance": 5, "items": [ "mil_gps_device" ] },
+      { "x": 0, "y": 1, "chance": 3, "item_groups": [ "mil_food_nodrugs" ] },
+      { "x": 0, "y": 1, "chance": 2, "item_groups": [ "mil_accessories" ] },
+      { "x": 0, "y": 2, "chance": 2, "item_groups": [ "mil_accessories" ] },
+      { "x": 0, "y": 2, "chance": 2, "item_groups": [ "gunmod_milspec" ] }
+    ]
+  },
+  {
+    "id": "flatbed_truck_test",
+    "type": "vehicle",
+    "name": "Flatbed Truck",
+    "blueprint": [
+      [ "-O------+-O" ],
+      [ "======='#'|" ],
+      [ "======='o'>" ],
+      [ "======='#'|" ],
+      [ "-O------+-O" ]
+    ],
+    "parts": [
+      { "x": -3, "y": 1, "parts": [ "frame_vertical", "cargo_space" ] },
+      { "x": 2, "y": 2, "parts": [ "frame_horizontal", "halfboard_horizontal" ] },
+      { "x": -1, "y": 1, "parts": [ "frame_horizontal", "windshield" ] },
+      { "x": 1, "y": 3, "parts": [ "frame_vertical", "windshield" ] },
+      {
+        "x": 2,
+        "y": -1,
+        "parts": [ "frame_nw", "halfboard_nw", "headlight", "wheel_mount_medium_steerable", "wheel_wide" ]
+      },
+      { "x": -6, "y": 3, "parts": [ "frame_vertical", "halfboard_vertical" ] },
+      { "x": 1, "y": 0, "parts": [ "frame_horizontal", "windshield" ] },
+      { "x": -8, "y": 2, "parts": [ "frame_horizontal", "cargo_space" ] },
+      { "x": -3, "y": 2, "parts": [ "frame_vertical", "cargo_space" ] },
+      { "x": -7, "y": 2, "parts": [ "frame_vertical", "cargo_space" ] },
+      { "x": -8, "y": 1, "parts": [ "frame_horizontal", "cargo_space", "beeper" ] },
+      { "x": -4, "y": 0, "parts": [ "frame_vertical", "cargo_space" ] },
+      { "x": 1, "y": 1, "parts": [ "frame_horizontal", "windshield" ] },
+      { "x": -4, "y": 2, "parts": [ "frame_vertical", "cargo_space" ] },
+      { "x": -4, "y": -1, "parts": [ "frame_vertical", "halfboard_vertical" ] },
+      { "x": -2, "y": 0, "parts": [ "frame_vertical", "cargo_space" ] },
+      {
+        "x": 0,
+        "y": 0,
+        "parts": [ "frame_vertical_2", "seat", "seatbelt", "roof", "controls", "dashboard", "vehicle_alarm", "horn_car" ]
+      },
+      { "x": 2, "y": 0, "parts": [ "frame_horizontal", "halfboard_horizontal" ] },
+      { "x": -7, "y": 1, "parts": [ "frame_vertical", "cargo_space" ] },
+      { "x": -1, "y": 0, "parts": [ "frame_horizontal", "windshield" ] },
+      { "x": -2, "y": 1, "parts": [ "frame_vertical", "cargo_space" ] },
+      { "x": -7, "y": -1, "parts": [ "frame_vertical", "halfboard_vertical", "wheel_mount_medium", "wheel_wide" ] },
+      { "x": -7, "y": 3, "parts": [ "frame_vertical", "halfboard_vertical", "wheel_mount_medium", "wheel_wide" ] },
+      { "x": 0, "y": 3, "parts": [ "frame_vertical", "door" ] },
+      { "x": 0, "y": 1, "parts": [ "frame_vertical", "box", "roof" ] },
+      { "x": 0, "y": -1, "parts": [ "frame_vertical", "door" ] },
+      { "x": 1, "y": 2, "parts": [ "frame_horizontal", "windshield" ] },
+      { "x": -6, "y": 2, "parts": [ "frame_vertical", "cargo_space" ] },
+      { "x": -8, "y": -1, "parts": [ "frame_vertical", "halfboard_vertical" ] },
+      { "x": -7, "y": 0, "parts": [ "frame_vertical", "cargo_space" ] },
+      { "x": -6, "y": -1, "parts": [ "frame_vertical", "halfboard_vertical" ] },
+      { "x": -5, "y": 0, "parts": [ "frame_vertical", "cargo_space" ] },
+      { "x": 0, "y": 2, "parts": [ "frame_vertical_2", "seat", "seatbelt", "roof" ] },
+      { "x": -5, "y": -1, "parts": [ "frame_vertical", "halfboard_vertical" ] },
+      { "x": -1, "y": -1, "parts": [ "frame_sw", "board_sw", { "part": "tank", "fuel": "gasoline" } ] },
+      { "x": -3, "y": 3, "parts": [ "frame_vertical", "halfboard_vertical" ] },
+      { "x": -2, "y": 2, "parts": [ "frame_vertical", "cargo_space" ] },
+      { "x": -1, "y": 3, "parts": [ "frame_se", "board_se", { "part": "tank", "fuel": "gasoline" } ] },
+      { "x": -2, "y": 3, "parts": [ "frame_vertical", "halfboard_vertical" ] },
+      {
+        "x": 2,
+        "y": 3,
+        "parts": [ "frame_ne", "halfboard_ne", "headlight", "wheel_mount_medium_steerable", "wheel_wide" ]
+      },
+      { "x": -5, "y": 3, "parts": [ "frame_vertical", "halfboard_vertical" ] },
+      { "x": -3, "y": 0, "parts": [ "frame_vertical", "cargo_space" ] },
+      { "x": -8, "y": 0, "parts": [ "frame_horizontal", "cargo_space" ] },
+      { "x": -6, "y": 1, "parts": [ "frame_vertical", "cargo_space" ] },
+      { "x": -4, "y": 1, "parts": [ "frame_vertical", "cargo_space" ] },
+      { "x": -6, "y": 0, "parts": [ "frame_vertical", "cargo_space" ] },
+      { "x": -8, "y": 3, "parts": [ "frame_vertical", "halfboard_vertical" ] },
+      { "x": -4, "y": 3, "parts": [ "frame_vertical", "halfboard_vertical" ] },
+      { "x": -1, "y": 2, "parts": [ "frame_horizontal", "windshield" ] },
+      { "x": -5, "y": 1, "parts": [ "frame_vertical", "cargo_space" ] },
+      {
+        "x": 2,
+        "y": 1,
+        "parts": [ "frame_cover", "halfboard_cover", "engine_v6", "alternator_truck", "battery_car" ]
+      },
+      { "x": 1, "y": -1, "parts": [ "frame_vertical", "windshield" ] },
+      { "x": -5, "y": 2, "parts": [ "frame_vertical", "cargo_space" ] },
+      { "x": -2, "y": -1, "parts": [ "frame_vertical", "halfboard_vertical" ] },
+      { "x": -3, "y": -1, "parts": [ "frame_vertical", "halfboard_vertical" ] }
+    ],
+    "items": [
+      { "x": 0, "y": 0, "chance": 1, "items": [ "roadmap" ] },
+      { "x": 0, "y": 0, "chance": 2, "items": [ "beer", "beer", "beer", "beer", "beer", "beer" ] },
+      { "x": -2, "y": 0, "chance": 7, "item_groups": [ "car_kit" ] },
+      { "x": -2, "y": 1, "chance": 7, "items": [ "jack", "wheel_wide" ] },
+      { "x": -2, "y": 0, "chance": 2, "item_groups": [ "hardware" ] }
+    ]
+  },
+  {
+    "id": "pickup_test",
+    "type": "vehicle",
+    "name": "Pickup Truck",
+    "blueprint": [
+      [ "o---+-o" ],
+      [ "==='#'|" ],
+      [ "==='#'|" ],
+      [ "o---+-o" ]
+    ],
+    "parts": [
+      { "x": -3, "y": 1, "parts": [ "frame_vertical", "trunk", "roof" ] },
+      { "x": -1, "y": 1, "parts": [ "frame_vertical_2", "windshield", "roof" ] },
+      {
+        "x": 2,
+        "y": 2,
+        "parts": [ "frame_ne", "halfboard_ne", "wheel_mount_medium_steerable", "wheel", "headlight" ]
+      },
+      { "x": 0, "y": 2, "parts": [ "frame_vertical", "door" ] },
+      {
+        "x": 2,
+        "y": -1,
+        "parts": [ "frame_nw", "halfboard_nw", "wheel_mount_medium_steerable", "wheel", "headlight" ]
+      },
+      { "x": -1, "y": -1, "parts": [ "frame_vertical", "halfboard_vertical" ] },
+      { "x": -2, "y": 2, "parts": [ "frame_vertical", "halfboard_vertical" ] },
+      { "x": 1, "y": 0, "parts": [ "frame_horizontal", "windshield" ] },
+      { "x": -3, "y": 2, "parts": [ "frame_vertical", "halfboard_vertical", "wheel_mount_medium", "wheel" ] },
+      { "x": -4, "y": 0, "parts": [ "frame_horizontal", "trunk" ] },
+      { "x": 1, "y": 1, "parts": [ "frame_horizontal", "windshield" ] },
+      { "x": -4, "y": 2, "parts": [ "frame_horizontal", "halfboard_se" ] },
+      { "x": -3, "y": 0, "parts": [ "frame_vertical", "trunk", "muffler", "roof" ] },
+      { "x": -4, "y": -1, "parts": [ "frame_horizontal", "halfboard_sw" ] },
+      { "x": -2, "y": 0, "parts": [ "frame_vertical", "cargo_space", "muffler", "roof" ] },
+      {
+        "x": 0,
+        "y": 0,
+        "parts": [ "frame_vertical_2", "seat", "seatbelt", "controls", "dashboard", "vehicle_alarm", "stereo", "horn_car", "roof" ]
+      },
+      {
+        "x": 2,
+        "y": 0,
+        "parts": [ "frame_horizontal", "halfboard_horizontal", "engine_v6", "alternator_truck", "battery_car" ]
+      },
+      { "x": -1, "y": 0, "parts": [ "frame_vertical_2", "windshield", "roof" ] },
+      { "x": -2, "y": 1, "parts": [ "frame_vertical", "cargo_space", "roof" ] },
+      { "x": -4, "y": 1, "parts": [ "frame_horizontal", "trunk" ] },
+      { "x": 0, "y": 1, "parts": [ "frame_vertical_2", "seat", "seatbelt", "roof" ] },
+      { "x": 0, "y": -1, "parts": [ "frame_vertical", "door" ] },
+      { "x": -1, "y": 2, "parts": [ "frame_vertical", "halfboard_vertical" ] },
+      { "x": 1, "y": 2, "parts": [ "frame_vertical", "windshield" ] },
+      { "x": 2, "y": 1, "parts": [ "frame_horizontal", "halfboard_horizontal" ] },
+      { "x": 1, "y": -1, "parts": [ "frame_vertical", "windshield" ] },
+      {
+        "x": -2,
+        "y": -1,
+        "parts": [ "frame_vertical", "halfboard_vertical", { "part": "tank", "fuel": "gasoline" } ]
+      },
+      { "x": -3, "y": -1, "parts": [ "frame_vertical", "halfboard_vertical", "wheel_mount_medium", "wheel" ] }
+    ],
+    "items": [
+      { "x": 0, "y": 0, "chance": 15, "item_groups": [ "car_misc" ] },
+      { "x": 0, "y": 0, "chance": 10, "item_groups": [ "car_misc" ] },
+      { "x": 0, "y": 1, "chance": 10, "item_groups": [ "car_misc" ] },
+      { "x": 0, "y": 1, "chance": 5, "item_groups": [ "snacks" ] },
+      { "x": 0, "y": 0, "chance": 5, "item_groups": [ "fast_food" ] },
+      { "x": -2, "y": 0, "chance": 5, "item_groups": [ "farming_tools" ] },
+      { "x": -2, "y": 1, "chance": 12, "item_groups": [ "car_kit" ] },
+      { "x": -2, "y": 1, "chance": 12, "items": [ "jack", "wheel" ] },
+      { "x": -3, "y": 1, "chance": 10, "item_groups": [ "car_kit" ] },
+      { "x": -3, "y": 0, "chance": 8, "item_groups": [ "fuel_gasoline" ] },
+      { "x": -2, "y": 1, "chance": 3, "items": [ "ax" ] }
+    ]
+  },
+  {
+    "id": "semi_truck_test",
+    "type": "vehicle",
+    "name": "Semi Truck",
+    "blueprint": [
+      [ "       o  " ],
+      [ "OO ---+-O-" ],
+      [ "OO=|#|#'|H" ],
+      [ "++-|o|o'|>" ],
+      [ "++-|o+o'|>" ],
+      [ "OO=|#|#'|H" ],
+      [ "OO ---+=O-" ],
+      [ "       o  " ]
+    ],
+    "parts": [
+      { "x": -3, "y": 1, "parts": [ "hdframe_horizontal", "board_horizontal" ] },
+      { "x": -1, "y": 1, "parts": [ "hdframe_horizontal", "board_horizontal" ] },
+      { "x": -2, "y": 4, "parts": [ "hdframe_vertical", "board_vertical", { "part": "tank", "fuel": "diesel" } ] },
+      { "x": 1, "y": 3, "parts": [ "hdframe_horizontal", "windshield" ] },
+      { "x": 2, "y": 2, "parts": [ "hdframe_vertical_2", "halfboard_vertical_2" ] },
+      {
+        "x": 2,
+        "y": -1,
+        "parts": [ "hdframe_vertical", "halfboard_vertical", "wheel_mount_medium_steerable", "wheel_wide" ]
+      },
+      { "x": 3, "y": 1, "parts": [ "hdframe_cover", "halfboard_cover" ] },
+      { "x": -6, "y": 3, "parts": [ "hdframe_horizontal", "wheel_mount_medium", "wheel_wide" ] },
+      { "x": 1, "y": 0, "parts": [ "hdframe_horizontal", "windshield" ] },
+      { "x": -3, "y": 2, "parts": [ "hdframe_horizontal", "board_horizontal", "beeper" ] },
+      { "x": 1, "y": -2, "parts": [ "wing_mirror_left" ] },
+      { "x": -4, "y": 0, "parts": [ "hdframe_vertical_2", "trunk" ] },
+      { "x": 1, "y": 1, "parts": [ "hdframe_horizontal", "windshield" ] },
+      { "x": -4, "y": 2, "parts": [ "hdframe_vertical" ] },
+      { "x": -6, "y": 4, "parts": [ "hdframe_horizontal", "wheel_mount_medium", "wheel_wide" ] },
+      { "x": 3, "y": -1, "parts": [ "hdframe_nw", "halfboard_nw" ] },
+      { "x": -2, "y": 0, "parts": [ "hdframe_vertical_2", "bed", "roof" ] },
+      {
+        "x": 0,
+        "y": 0,
+        "parts": [ "hdframe_vertical_2", "seat", "seatbelt", "roof", "controls", "dashboard", "vehicle_alarm", "horn_big" ]
+      },
+      { "x": 2, "y": 0, "parts": [ "hdframe_horizontal", "halfboard_horizontal" ] },
+      { "x": -1, "y": 0, "parts": [ "hdframe_horizontal", "board_horizontal" ] },
+      { "x": -2, "y": 1, "parts": [ "hdframe_vertical_2", "box", "roof" ] },
+      { "x": 0, "y": 4, "parts": [ "hdframe_vertical", "door" ] },
+      { "x": 0, "y": 3, "parts": [ "hdframe_vertical_2", "seat", "seatbelt", "roof" ] },
+      { "x": 0, "y": 1, "parts": [ "hdframe_horizontal", "box", "roof" ] },
+      { "x": 1, "y": 5, "parts": [ "wing_mirror_right" ] },
+      { "x": 3, "y": 3, "parts": [ "hdframe_horizontal_2", "halfboard_horizontal_2", "headlight" ] },
+      { "x": 0, "y": -1, "parts": [ "hdframe_vertical", "door" ] },
+      { "x": 1, "y": 2, "parts": [ "hdframe_horizontal", "windshield" ] },
+      { "x": -6, "y": 2, "parts": [ "hdframe_cross" ] },
+      { "x": -1, "y": 4, "parts": [ "hdframe_vertical", "board_vertical", { "part": "tank", "fuel": "diesel" } ] },
+      { "x": 3, "y": 2, "parts": [ "hdframe_cover", "halfboard_cover" ] },
+      { "x": -6, "y": -1, "parts": [ "hdframe_horizontal", "wheel_mount_medium", "wheel_wide" ] },
+      { "x": -5, "y": 0, "parts": [ "hdframe_horizontal", "wheel_mount_medium", "wheel_wide" ] },
+      { "x": 0, "y": 2, "parts": [ "hdframe_horizontal", "box", "roof" ] },
+      { "x": -3, "y": 4, "parts": [ "hdframe_se", "board_se" ] },
+      { "x": -5, "y": -1, "parts": [ "hdframe_horizontal", "wheel_mount_medium", "wheel_wide" ] },
+      { "x": -1, "y": -1, "parts": [ "hdframe_vertical", "board_vertical", { "part": "tank", "fuel": "diesel" } ] },
+      { "x": -3, "y": 3, "parts": [ "hdframe_horizontal", "board_horizontal" ] },
+      { "x": -2, "y": 2, "parts": [ "hdframe_vertical_2", "box", "roof" ] },
+      { "x": -1, "y": 3, "parts": [ "hdframe_horizontal", "board_horizontal" ] },
+      { "x": 3, "y": 4, "parts": [ "hdframe_ne", "halfboard_ne" ] },
+      { "x": 3, "y": 0, "parts": [ "hdframe_horizontal_2", "halfboard_horizontal_2", "headlight" ] },
+      { "x": 1, "y": 4, "parts": [ "hdframe_vertical", "windshield" ] },
+      { "x": -2, "y": 3, "parts": [ "hdframe_vertical_2", "bed", "roof" ] },
+      { "x": 2, "y": 3, "parts": [ "hdframe_horizontal", "halfboard_horizontal" ] },
+      { "x": -5, "y": 3, "parts": [ "hdframe_horizontal", "wheel_mount_medium", "wheel_wide" ] },
+      { "x": -3, "y": 0, "parts": [ "hdframe_horizontal", "board_horizontal" ] },
+      { "x": -5, "y": 4, "parts": [ "hdframe_horizontal", "wheel_mount_medium", "wheel_wide" ] },
+      { "x": -6, "y": 1, "parts": [ "hdframe_cross" ] },
+      { "x": -4, "y": 1, "parts": [ "hdframe_vertical" ] },
+      {
+        "x": 2,
+        "y": 4,
+        "parts": [ "hdframe_vertical", "halfboard_vertical", "wheel_mount_medium_steerable", "wheel_wide" ]
+      },
+      { "x": -6, "y": 0, "parts": [ "hdframe_horizontal", "wheel_mount_medium", "wheel_wide" ] },
+      { "x": -4, "y": 3, "parts": [ "hdframe_vertical_2", "trunk" ] },
+      { "x": -1, "y": 2, "parts": [ "hdframe_horizontal", "door_internal" ] },
+      { "x": -5, "y": 1, "parts": [ "hdframe_cross" ] },
+      {
+        "x": 2,
+        "y": 1,
+        "parts": [ "hdframe_vertical_2", "halfboard_vertical_2", "diesel_engine_v8", "alternator_truck", "battery_car" ]
+      },
+      { "x": 1, "y": -1, "parts": [ "hdframe_vertical", "windshield" ] },
+      { "x": -5, "y": 2, "parts": [ "hdframe_cross" ] },
+      { "x": -2, "y": -1, "parts": [ "hdframe_vertical", "board_vertical", { "part": "tank", "fuel": "diesel" } ] },
+      { "x": -3, "y": -1, "parts": [ "hdframe_sw", "board_sw" ] }
+    ],
+    "items": [
+      { "x": 0, "y": 0, "chance": 20, "items": [ "hat_ball" ] },
+      { "x": 0, "y": 0, "chance": 10, "items": [ "cig" ] },
+      { "x": 0, "y": 0, "chance": 5, "items": [ "choco_coffee_beans" ] },
+      { "x": 0, "y": 1, "chance": 5, "items": [ "colamdew" ] },
+      { "x": -4, "y": 0, "chance": 12, "item_groups": [ "car_kit" ] },
+      { "x": -4, "y": 0, "chance": 5, "item_groups": [ "fuel_diesel" ] },
+      { "x": -4, "y": 3, "chance": 10, "item_groups": [ "car_kit" ] }
+    ]
+  },
+  {
+    "id": "truck_trailer_test",
+    "type": "vehicle",
+    "name": "Truck Trailer",
+    "blueprint": [
+      [ "--OO------" ],
+      [ "||OO||||||" ],
+      [ "+|++|=|++|" ],
+      [ "+|++|=|++|" ],
+      [ "||OO||||||" ],
+      [ "--OO------" ]
+    ],
+    "parts": [
+      { "x": -3, "y": 1, "parts": [ "hdframe_horizontal", "cargo_space", "roof" ] },
+      {
+        "x": -1,
+        "y": 1,
+        "parts": [ "hdframe_horizontal", "wheel_mount_medium", "wheel_wide", "cargo_space", "roof" ]
+      },
+      { "x": 2, "y": 2, "parts": [ "hdframe_vertical", "board_vertical" ] },
+      { "x": 2, "y": -1, "parts": [ "hdframe_horizontal", "cargo_space", "roof" ] },
+      { "x": 4, "y": 0, "parts": [ "hdframe_cross", "cargo_space", "roof" ] },
+      { "x": 3, "y": 1, "parts": [ "hdframe_horizontal", "cargo_space", "roof" ] },
+      { "x": 5, "y": 0, "parts": [ "hdframe_horizontal", "board_horizontal" ] },
+      { "x": 1, "y": 0, "parts": [ "hdframe_horizontal", "cargo_space", "roof" ] },
+      { "x": -3, "y": 2, "parts": [ "hdframe_vertical", "board_vertical" ] },
+      { "x": -2, "y": -3, "parts": [ "hdframe_horizontal", "board_vertical", "wheel_mount_medium", "wheel_wide" ] },
+      { "x": -4, "y": -3, "parts": [ "hdframe_sw", "board_sw" ] },
+      { "x": 1, "y": -2, "parts": [ "hdframe_horizontal", "cargo_space", "roof" ] },
+      { "x": 5, "y": 1, "parts": [ "hdframe_horizontal", "board_horizontal" ] },
+      { "x": -4, "y": 0, "parts": [ "hdframe_horizontal", "door_shutter" ] },
+      { "x": 1, "y": 1, "parts": [ "hdframe_horizontal", "cargo_space", "roof" ] },
+      { "x": 3, "y": -1, "parts": [ "hdframe_horizontal", "cargo_space", "roof" ] },
+      { "x": -3, "y": -3, "parts": [ "hdframe_vertical", "board_vertical" ] },
+      { "x": -4, "y": 2, "parts": [ "hdframe_se", "board_se" ] },
+      { "x": -4, "y": -1, "parts": [ "hdframe_horizontal", "door_shutter" ] },
+      { "x": 0, "y": -3, "parts": [ "hdframe_vertical", "board_vertical" ] },
+      { "x": -2, "y": 0, "parts": [ "hdframe_cross", "cargo_space", "roof" ] },
+      { "x": 0, "y": 0, "parts": [ "hdframe_vertical_2", "cargo_space", "roof" ] },
+      { "x": 2, "y": 0, "parts": [ "hdframe_horizontal", "cargo_space", "roof" ] },
+      { "x": 5, "y": -1, "parts": [ "hdframe_horizontal", "board_horizontal" ] },
+      { "x": -1, "y": 0, "parts": [ "hdframe_cross", "cargo_space", "roof" ] },
+      {
+        "x": -2,
+        "y": 1,
+        "parts": [ "hdframe_horizontal", "wheel_mount_medium", "wheel_wide", "cargo_space", "roof" ]
+      },
+      { "x": -3, "y": -2, "parts": [ "hdframe_horizontal", "cargo_space", "roof" ] },
+      { "x": 4, "y": 2, "parts": [ "hdframe_vertical", "board_vertical" ] },
+      { "x": 0, "y": 1, "parts": [ "hdframe_horizontal", "cargo_space", "roof" ] },
+      { "x": 2, "y": -2, "parts": [ "hdframe_horizontal", "cargo_space", "roof" ] },
+      { "x": 0, "y": -1, "parts": [ "hdframe_vertical_2", "cargo_space", "roof" ] },
+      { "x": 1, "y": 2, "parts": [ "hdframe_vertical", "board_vertical" ] },
+      { "x": 5, "y": -2, "parts": [ "hdframe_horizontal", "board_horizontal" ] },
+      { "x": 3, "y": 2, "parts": [ "hdframe_vertical", "board_vertical" ] },
+      { "x": 3, "y": -3, "parts": [ "hdframe_vertical", "board_vertical" ] },
+      { "x": 5, "y": 2, "parts": [ "hdframe_ne", "board_ne" ] },
+      { "x": 0, "y": 2, "parts": [ "hdframe_vertical", "board_vertical" ] },
+      { "x": 2, "y": -3, "parts": [ "hdframe_vertical", "board_vertical" ] },
+      { "x": -1, "y": -1, "parts": [ "hdframe_cross", "cargo_space", "roof" ] },
+      { "x": -2, "y": 2, "parts": [ "hdframe_horizontal", "board_vertical", "wheel_mount_medium", "wheel_wide" ] },
+      { "x": -4, "y": -2, "parts": [ "hdframe_horizontal", "door_shutter" ] },
+      { "x": 3, "y": 0, "parts": [ "hdframe_horizontal", "cargo_space", "roof" ] },
+      { "x": 4, "y": -2, "parts": [ "hdframe_horizontal", "cargo_space", "roof" ] },
+      { "x": 0, "y": -2, "parts": [ "hdframe_horizontal", "cargo_space", "roof" ] },
+      {
+        "x": -1,
+        "y": -2,
+        "parts": [ "hdframe_horizontal", "wheel_mount_medium", "wheel_wide", "cargo_space", "roof" ]
+      },
+      { "x": 5, "y": -3, "parts": [ "hdframe_nw", "board_nw" ] },
+      { "x": 4, "y": 1, "parts": [ "hdframe_horizontal", "cargo_space", "roof" ] },
+      { "x": -3, "y": 0, "parts": [ "hdframe_horizontal", "cargo_space", "roof" ] },
+      {
+        "x": -2,
+        "y": -2,
+        "parts": [ "hdframe_horizontal", "wheel_mount_medium", "wheel_wide", "cargo_space", "roof" ]
+      },
+      { "x": -4, "y": 1, "parts": [ "hdframe_horizontal", "door_shutter" ] },
+      { "x": 4, "y": -1, "parts": [ "hdframe_cross", "cargo_space", "roof" ] },
+      { "x": -1, "y": 2, "parts": [ "hdframe_horizontal", "board_vertical", "wheel_mount_medium", "wheel_wide" ] },
+      { "x": 1, "y": -3, "parts": [ "hdframe_vertical", "board_vertical" ] },
+      { "x": 2, "y": 1, "parts": [ "hdframe_horizontal", "cargo_space", "roof" ] },
+      { "x": 4, "y": -3, "parts": [ "hdframe_vertical", "board_vertical" ] },
+      { "x": 1, "y": -1, "parts": [ "hdframe_horizontal", "cargo_space", "roof" ] },
+      { "x": 3, "y": -2, "parts": [ "hdframe_horizontal", "cargo_space", "roof" ] },
+      { "x": -1, "y": -3, "parts": [ "hdframe_horizontal", "board_vertical", "wheel_mount_medium", "wheel_wide" ] },
+      { "x": -2, "y": -1, "parts": [ "hdframe_cross", "cargo_space", "roof" ] },
+      { "x": -3, "y": -1, "parts": [ "hdframe_horizontal", "cargo_space", "roof" ] }
+    ],
+    "items": [
+      { "x": 4, "y": -2, "chance": 2, "items": [ "bubblewrap" ] },
+      { "x": 4, "y": -1, "chance": 3, "items": [ "bubblewrap" ] },
+      { "x": 4, "y": 0, "chance": 5, "items": [ "rope_30" ] },
+      { "x": 4, "y": 1, "chance": 3, "items": [ "bubblewrap" ] },
+      { "x": 3, "y": -2, "chance": 4, "items": [ "bubblewrap" ] },
+      { "x": 3, "y": -1, "chance": 3, "items": [ "bubblewrap" ] },
+      { "x": 3, "y": 0, "chance": 2, "items": [ "rope_30" ] },
+      { "x": 3, "y": 1, "chance": 3, "items": [ "bubblewrap" ] },
+      { "x": 2, "y": -2, "chance": 2, "items": [ "bubblewrap" ] },
+      { "x": 2, "y": -1, "chance": 1, "items": [ "bubblewrap" ] },
+      { "x": 2, "y": 0, "chance": 4, "items": [ "bubblewrap" ] },
+      { "x": 2, "y": 1, "chance": 3, "items": [ "bubblewrap" ] },
+      { "x": 1, "y": -2, "chance": 2, "items": [ "bubblewrap" ] },
+      { "x": 1, "y": -1, "chance": 5, "items": [ "bubblewrap" ] },
+      { "x": 1, "y": 0, "chance": 3, "items": [ "rope_30" ] },
+      { "x": 1, "y": 1, "chance": 3, "items": [ "bubblewrap" ] },
+      { "x": 0, "y": -2, "chance": 1, "items": [ "bubblewrap" ] },
+      { "x": 0, "y": -1, "chance": 3, "items": [ "bubblewrap" ] },
+      { "x": 0, "y": 0, "chance": 3, "items": [ "bubblewrap" ] },
+      { "x": 0, "y": 1, "chance": 2, "items": [ "bubblewrap" ] },
+      { "x": -1, "y": -2, "chance": 3, "items": [ "bubblewrap" ] },
+      { "x": -1, "y": -1, "chance": 3, "items": [ "bubblewrap" ] },
+      { "x": -1, "y": 0, "chance": 3, "items": [ "bubblewrap" ] },
+      { "x": -1, "y": 1, "chance": 1, "items": [ "bubblewrap" ] },
+      { "x": -2, "y": -2, "chance": 3, "items": [ "rope_6" ] },
+      { "x": -2, "y": -1, "chance": 1, "items": [ "bubblewrap" ] },
+      { "x": -2, "y": 0, "chance": 2, "items": [ "bubblewrap" ] },
+      { "x": -2, "y": 1, "chance": 3, "items": [ "bubblewrap" ] },
+      { "x": -3, "y": -2, "chance": 1, "items": [ "bubblewrap" ] },
+      { "x": -3, "y": -1, "chance": 3, "items": [ "bubblewrap" ] },
+      { "x": -3, "y": 0, "chance": 2, "items": [ "bubblewrap" ] },
+      { "x": -3, "y": 1, "chance": 5, "items": [ "bubblewrap" ] }
+    ]
+  },
+  {
+    "id": "tatra_truck_test",
+    "type": "vehicle",
+    "name": "Heavy Duty Cargo Truck",
+    "blueprint": [
+      [ "-OO--+-O " ],
+      [ "|+++'#'|>" ],
+      [ "|+++'#'=>" ],
+      [ "|+++'#'|>" ],
+      [ "-OO--+-O " ]
+    ],
+    "parts": [
+      { "x": -3, "y": 1, "parts": [ "hdframe_horizontal", "wooden_aisle_vertical", "roof_cloth" ] },
+      { "x": -1, "y": 1, "parts": [ "hdframe_vertical_2", "windshield" ] },
+      { "x": 2, "y": 2, "parts": [ "hdframe_horizontal", "hdhalfboard_horizontal", "headlight_reinforced" ] },
+      {
+        "x": 0,
+        "y": 2,
+        "parts": [ "hdframe_vertical_2", "seat", { "part": "tank", "fuel": "diesel" }, "seatbelt", "hdroof" ]
+      },
+      { "x": 1, "y": 3, "parts": [ "hdframe_vertical", "windshield" ] },
+      {
+        "x": 2,
+        "y": -1,
+        "parts": [ "hdframe_horizontal", "hdhalfboard_nw", "wheel_mount_medium_steerable", "wheel_wide" ]
+      },
+      { "x": -1, "y": -1, "parts": [ "hdframe_vertical", "hdhalfboard_sw", "muffler" ] },
+      {
+        "x": -3,
+        "y": 3,
+        "parts": [ "hdframe_horizontal", "clothboard_vertical", "wheel_mount_medium", "wheel_wide", "roof_cloth" ]
+      },
+      { "x": -2, "y": 2, "parts": [ "hdframe_vertical_2", "cargo_space", "roof_cloth" ] },
+      { "x": -1, "y": 3, "parts": [ "hdframe_vertical", "hdhalfboard_se", "muffler" ] },
+      { "x": 1, "y": 0, "parts": [ "hdframe_horizontal", "windshield" ] },
+      { "x": 3, "y": 1, "parts": [ "frame_horizontal_2" ] },
+      { "x": 3, "y": 0, "parts": [ "frame_horizontal_2" ] },
+      { "x": -3, "y": 2, "parts": [ "hdframe_horizontal", "cargo_space", "roof_cloth" ] },
+      { "x": -5, "y": -1, "parts": [ "hdframe_vertical", "clothboard_sw", "roof_cloth" ] },
+      { "x": -2, "y": 3, "parts": [ "hdframe_vertical", "clothboard_vertical", "roof_cloth" ] },
+      {
+        "x": 2,
+        "y": 3,
+        "parts": [ "hdframe_horizontal", "hdhalfboard_ne", "wheel_mount_medium_steerable", "wheel_wide" ]
+      },
+      { "x": -5, "y": 3, "parts": [ "hdframe_vertical", "clothboard_se", "roof_cloth" ] },
+      { "x": -4, "y": 0, "parts": [ "hdframe_horizontal", "cargo_space", "roof_cloth" ] },
+      { "x": 1, "y": 1, "parts": [ "hdframe_horizontal", "windshield" ] },
+      { "x": -4, "y": 2, "parts": [ "hdframe_horizontal", "cargo_space", "roof_cloth" ] },
+      { "x": -3, "y": 0, "parts": [ "hdframe_horizontal", "cargo_space", "roof_cloth" ] },
+      {
+        "x": -4,
+        "y": -1,
+        "parts": [ "hdframe_horizontal", "clothboard_vertical", "wheel_mount_medium", "wheel_wide", "roof_cloth" ]
+      },
+      { "x": -2, "y": 0, "parts": [ "hdframe_vertical_2", "cargo_space", "roof_cloth" ] },
+      {
+        "x": 0,
+        "y": 0,
+        "parts": [
+          "hdframe_vertical_2",
+          "seat",
+          { "part": "tank", "fuel": "diesel" },
+          "seatbelt",
+          "hdroof",
+          "controls",
+          "dashboard",
+          "vehicle_clock",
+          "horn_big"
+        ]
+      },
+      { "x": 2, "y": 0, "parts": [ "hdframe_horizontal", "hdhalfboard_horizontal", "headlight_reinforced" ] },
+      { "x": -1, "y": 0, "parts": [ "hdframe_horizontal", "windshield" ] },
+      { "x": -2, "y": 1, "parts": [ "hdframe_horizontal", "wooden_aisle_vertical", "roof_cloth" ] },
+      { "x": -4, "y": 1, "parts": [ "hdframe_horizontal", "wooden_aisle_vertical", "roof_cloth" ] },
+      { "x": 0, "y": 3, "parts": [ "hdframe_vertical", "hddoor_right" ] },
+      {
+        "x": 0,
+        "y": 1,
+        "parts": [ "hdframe_vertical_2", "seat", { "part": "tank", "fuel": "diesel" }, "seatbelt", "hdroof" ]
+      },
+      { "x": 0, "y": -1, "parts": [ "hdframe_vertical", "hddoor_left" ] },
+      { "x": -1, "y": 2, "parts": [ "hdframe_horizontal", "windshield" ] },
+      { "x": 1, "y": 2, "parts": [ "hdframe_horizontal", "windshield" ] },
+      {
+        "x": -4,
+        "y": 3,
+        "parts": [ "hdframe_horizontal", "clothboard_vertical", "wheel_mount_medium", "wheel_wide", "roof_cloth" ]
+      },
+      { "x": -5, "y": 1, "parts": [ "hdframe_horizontal", "door_shutter", "roof_cloth" ] },
+      {
+        "x": 2,
+        "y": 1,
+        "parts": [ "hdframe_horizontal", "hdhalfboard_horizontal", "diesel_engine_v12", "alternator_truck", "battery_car" ]
+      },
+      { "x": 3, "y": 2, "parts": [ "frame_horizontal_2" ] },
+      { "x": 1, "y": -1, "parts": [ "hdframe_vertical", "windshield" ] },
+      { "x": -5, "y": 2, "parts": [ "hdframe_horizontal", "door_shutter", "roof_cloth" ] },
+      { "x": -2, "y": -1, "parts": [ "hdframe_vertical", "clothboard_vertical", "roof_cloth" ] },
+      {
+        "x": -3,
+        "y": -1,
+        "parts": [ "hdframe_horizontal", "clothboard_vertical", "wheel_mount_medium", "wheel_wide", "roof_cloth" ]
+      },
+      { "x": -5, "y": 0, "parts": [ "hdframe_horizontal", "door_shutter", "roof_cloth" ] }
+    ],
+    "items": [
+      { "x": 0, "y": 0, "chance": 6, "items": [ "vodka" ] },
+      { "x": 0, "y": 1, "chance": 2, "items": [ "ax" ] },
+      { "x": 0, "y": 2, "chance": 2, "items": [ "jumper_cable" ] }
+    ]
+  },
+  {
+    "id": "animalctrl_test",
+    "type": "vehicle",
+    "name": "Animal Control Truck",
+    "blueprint": [
+      [ "o++-+-o" ],
+      [ "+==+#'|" ],
+      [ "+==+#'|" ],
+      [ "o++-+-o" ]
+    ],
+    "parts": [
+      { "x": -3, "y": 1, "parts": [ "frame_vertical", "animal_compartment", "roof" ] },
+      { "x": -1, "y": 1, "parts": [ "frame_vertical_2", "stowboard_horizontal", "roof" ] },
+      {
+        "x": 2,
+        "y": 2,
+        "parts": [ "frame_ne", "halfboard_ne", "wheel_mount_medium_steerable", "wheel", "headlight" ]
+      },
+      { "x": 0, "y": 2, "parts": [ "frame_vertical", "door" ] },
+      {
+        "x": 2,
+        "y": -1,
+        "parts": [ "frame_nw", "halfboard_nw", "wheel_mount_medium_steerable", "wheel", "headlight" ]
+      },
+      { "x": -1, "y": -1, "parts": [ "frame_vertical", "halfboard_vertical" ] },
+      { "x": -2, "y": 2, "parts": [ "frame_vertical", "hatch" ] },
+      { "x": 1, "y": 0, "parts": [ "frame_horizontal", "windshield" ] },
+      { "x": -3, "y": 2, "parts": [ "frame_vertical", "hatch", "wheel_mount_medium", "wheel" ] },
+      { "x": -4, "y": 0, "parts": [ "frame_horizontal", "stowboard_horizontal" ] },
+      { "x": 1, "y": 1, "parts": [ "frame_horizontal", "windshield" ] },
+      { "x": -4, "y": 2, "parts": [ "frame_horizontal", "halfboard_se" ] },
+      { "x": -3, "y": 0, "parts": [ "frame_vertical", "animal_compartment", "muffler", "roof" ] },
+      { "x": -4, "y": -1, "parts": [ "frame_horizontal", "halfboard_sw" ] },
+      { "x": -2, "y": 0, "parts": [ "frame_vertical", "animal_compartment", "muffler", "roof" ] },
+      {
+        "x": 0,
+        "y": 0,
+        "parts": [ "frame_vertical_2", "seat", "seatbelt", "controls", "dashboard", "vehicle_alarm", "stereo", "horn_car", "roof" ]
+      },
+      {
+        "x": 2,
+        "y": 0,
+        "parts": [ "frame_horizontal", "halfboard_horizontal", "engine_v6", "alternator_truck", "battery_car" ]
+      },
+      { "x": -1, "y": 0, "parts": [ "frame_vertical_2", "stowboard_horizontal", "roof" ] },
+      { "x": -2, "y": 1, "parts": [ "frame_vertical", "animal_compartment", "roof" ] },
+      { "x": -4, "y": 1, "parts": [ "frame_horizontal", "stowboard_horizontal" ] },
+      { "x": 0, "y": 1, "parts": [ "frame_vertical_2", "seat", "seatbelt", "roof" ] },
+      { "x": 0, "y": -1, "parts": [ "frame_vertical", "door" ] },
+      { "x": -1, "y": 2, "parts": [ "frame_vertical", "halfboard_vertical" ] },
+      { "x": 1, "y": 2, "parts": [ "frame_vertical", "windshield" ] },
+      { "x": 2, "y": 1, "parts": [ "frame_horizontal", "halfboard_horizontal" ] },
+      { "x": 1, "y": -1, "parts": [ "frame_vertical", "windshield" ] },
+      { "x": -2, "y": -1, "parts": [ "frame_vertical", "hatch", { "part": "tank", "fuel": "gasoline" } ] },
+      { "x": -3, "y": -1, "parts": [ "frame_vertical", "hatch", "wheel_mount_medium", "wheel" ] }
+    ],
+    "items": [
+      { "x": 0, "y": 0, "chance": 25, "items": [ "file" ] },
+      { "x": 0, "y": 1, "chance": 25, "items": [ "file" ] },
+      { "x": 0, "y": 1, "chance": 5, "items": [ "energy_drink" ] },
+      { "x": 0, "y": 1, "chance": 5, "items": [ "sports_drink" ] },
+      { "x": 0, "y": 1, "chance": 5, "items": [ "irish_coffee" ] },
+      { "x": 0, "y": 1, "chance": 5, "items": [ "dog_whistle" ] },
+      { "x": -1, "y": 0, "chance": 5, "items": [ "tazer" ] },
+      { "x": -1, "y": 0, "chance": 5, "items": [ "dog_whistle" ] },
+      { "x": -1, "y": 1, "chance": 25, "items": [ "file" ] },
+      { "x": -1, "y": 1, "chance": 5, "items": [ "rope_6" ] },
+      { "x": -2, "y": 0, "chance": 20, "items": [ "blanket" ] },
+      { "x": -2, "y": 1, "chance": 20, "items": [ "blanket" ] },
+      { "x": -3, "y": 0, "chance": 20, "items": [ "blanket" ] },
+      { "x": -3, "y": 1, "chance": 20, "items": [ "blanket" ] },
+      { "x": -4, "y": 0, "chance": 10, "//": { "item": "dog_food", "container-item": "can_medium" } },
+      { "x": -4, "y": 0, "chance": 10, "//": { "item": "dog_food", "container-item": "can_medium" } },
+      { "x": -4, "y": 1, "chance": 10, "//": { "item": "cat_food", "container-item": "can_food" } },
+      { "x": -4, "y": 1, "chance": 10, "//": { "item": "cat_food", "container-item": "can_food" } },
+      { "x": -4, "y": 0, "chance": 3, "items": [ "beartrap" ] }
+    ]
+  },
+  {
+    "id": "autosweeper_test",
+    "type": "vehicle",
+    "name": "Automatic Street Sweeper",
+    "blueprint": [
+      [ "o--o" ],
+      [ "+=Xo" ],
+      [ "o--o" ]
+    ],
+    "parts": [
+      { "x": -1, "y": 1, "parts": [ "frame_vertical", "board_vertical" ] },
+      { "x": -1, "y": -1, "parts": [ "frame_vertical", "board_vertical" ] },
+      { "x": 1, "y": 0, "parts": [ "frame_horizontal", "board_horizontal", "headlight", "omnicam" ] },
+      { "x": 1, "y": 1, "parts": [ "frame_horizontal", "wheel_mount_medium_steerable", "wheel", "board_ne" ] },
+      { "x": -2, "y": 0, "parts": [ "frame_horizontal", "hatch" ] },
+      { "x": 0, "y": 0, "parts": [ "frame_vertical_2", "robot_controls", "engine_electric", "roof" ] },
+      { "x": -1, "y": 0, "parts": [ "frame_vertical_2", "roof", "vehicle_scoop" ] },
+      {
+        "x": -2,
+        "y": 1,
+        "parts": [
+          "frame_horizontal",
+          "wheel_mount_medium_steerable",
+          "wheel",
+          "storage_battery_mount",
+          "storage_battery_removable",
+          "board_se"
+        ]
+      },
+      { "x": 0, "y": 1, "parts": [ "frame_vertical", "board_vertical" ] },
+      { "x": 0, "y": -1, "parts": [ "frame_vertical", "board_vertical" ] },
+      { "x": 1, "y": -1, "parts": [ "frame_horizontal", "wheel_mount_medium_steerable", "wheel", "board_nw" ] },
+      {
+        "x": -2,
+        "y": -1,
+        "parts": [
+          "frame_horizontal",
+          "wheel_mount_medium_steerable",
+          "wheel",
+          "storage_battery_mount",
+          "storage_battery_removable",
+          "board_sw"
+        ]
+      }
+    ],
+    "items": [
+      { "x": -2, "y": 0, "chance": 50, "item_groups": [ "trash", "trash", "trash", "trash", "trash", "trash" ] },
+      { "x": -1, "y": 0, "chance": 100, "item_groups": [ "trash" ] }
+    ]
+  },
+  {
+    "id": "excavator_test",
+    "type": "vehicle",
+    "name": "Excavator",
+    "blueprint": [
+      [ "o-=o" ],
+      [ "|X={" ],
+      [ "o-=o" ]
+    ],
+    "parts": [
+      { "x": -1, "y": 1, "parts": [ "frame_se", "roof", "wheel_mount_medium", "wheel", "board_se", "muffler" ] },
+      { "x": 2, "y": -1, "parts": [ "frame_nw", "halfboard_nw", "headlight_reinforced" ] },
+      { "x": -1, "y": -1, "parts": [ "frame_sw", "roof", "wheel_mount_medium", "wheel", "board_sw" ] },
+      {
+        "x": 1,
+        "y": 0,
+        "parts": [ "frame_cross", "roof", "reinforced_windshield", "diesel_engine_i6", "alternator_truck", "battery_car" ]
+      },
+      {
+        "x": 1,
+        "y": 1,
+        "parts": [ "frame_vertical", "roof", "wheel_mount_medium_steerable", "wheel", "reinforced_windshield" ]
+      },
+      {
+        "x": 0,
+        "y": 0,
+        "parts": [ "frame_cross", "roof", "seat", "seatbelt", "floodlight", "controls", "dashboard", "horn_big" ]
+      },
+      { "x": 2, "y": 0, "parts": [ "crane_medium" ] },
+      { "x": -1, "y": 0, "parts": [ "frame_horizontal", "roof", "hatch", { "part": "tank", "fuel": "diesel" } ] },
+      { "x": 0, "y": 1, "parts": [ "frame_vertical", "roof", "door" ] },
+      { "x": 0, "y": -1, "parts": [ "frame_vertical", "roof", "door" ] },
+      { "x": 2, "y": 1, "parts": [ "frame_ne", "halfboard_ne", "headlight_reinforced" ] },
+      {
+        "x": 1,
+        "y": -1,
+        "parts": [ "frame_vertical", "roof", "wheel_mount_medium_steerable", "wheel", "reinforced_windshield" ]
+      }
+    ],
+    "items": [  ]
+  },
+  {
+    "id": "road_roller_test",
+    "type": "vehicle",
+    "name": "Road Roller",
+    "blueprint": [
+      [ "B--+'B" ],
+      [ "B='H'B" ],
+      [ "B=+#'B" ],
+      [ "B='H'B" ],
+      [ "B--+'B" ]
+    ],
+    "parts": [
+      { "x": -3, "y": 1, "parts": [ "frame_horizontal", "roller_drum" ] },
+      { "x": -1, "y": 1, "parts": [ "frame_horizontal", "windshield", "roof" ] },
+      { "x": 2, "y": 2, "parts": [ "frame_horizontal", "roller_drum" ] },
+      { "x": 0, "y": 2, "parts": [ "frame_horizontal", "door", "roof" ] },
+      { "x": 2, "y": -1, "parts": [ "frame_horizontal", "roller_drum" ] },
+      { "x": -1, "y": -1, "parts": [ "frame_horizontal", "windshield", "roof" ] },
+      { "x": -2, "y": 2, "parts": [ "frame_horizontal", "halfboard_horizontal" ] },
+      {
+        "x": 1,
+        "y": 0,
+        "parts": [ "frame_horizontal", "windshield", "roof", "diesel_engine_i6", "alternator_truck", "battery_car" ]
+      },
+      { "x": -3, "y": 2, "parts": [ "frame_horizontal", "roller_drum" ] },
+      { "x": 0, "y": -2, "parts": [ "frame_horizontal", "door", "roof" ] },
+      { "x": 1, "y": -2, "parts": [ "frame_horizontal", "windshield", "roof" ] },
+      {
+        "x": -1,
+        "y": -2,
+        "parts": [ "frame_horizontal", "roof", "halfboard_horizontal", { "part": "tank", "fuel": "diesel" } ]
+      },
+      { "x": 1, "y": 1, "parts": [ "frame_horizontal", "windshield", "roof", "headlight" ] },
+      { "x": -3, "y": 0, "parts": [ "frame_horizontal", "roller_drum" ] },
+      { "x": -2, "y": 0, "parts": [ "frame_horizontal", "trunk" ] },
+      {
+        "x": 0,
+        "y": 0,
+        "parts": [ "frame_horizontal", "roof", "seat", "seatbelt", "controls", "dashboard", "vehicle_alarm", "horn_car" ]
+      },
+      { "x": 2, "y": 0, "parts": [ "frame_horizontal", "roller_drum" ] },
+      { "x": -2, "y": -2, "parts": [ "frame_horizontal", "halfboard_horizontal" ] },
+      { "x": -1, "y": 0, "parts": [ "frame_horizontal", "door", "roof" ] },
+      { "x": -2, "y": 1, "parts": [ "frame_horizontal", "trunk" ] },
+      { "x": -3, "y": -2, "parts": [ "frame_horizontal", "roller_drum" ] },
+      { "x": 2, "y": -2, "parts": [ "frame_horizontal", "roller_drum" ] },
+      { "x": 0, "y": 1, "parts": [ "frame_horizontal", "roof", "trunk_floor" ] },
+      { "x": 0, "y": -1, "parts": [ "frame_horizontal", "roof", "trunk_floor" ] },
+      {
+        "x": -1,
+        "y": 2,
+        "parts": [ "frame_horizontal", "roof", "halfboard_horizontal", { "part": "tank", "fuel": "diesel" } ]
+      },
+      { "x": 1, "y": 2, "parts": [ "frame_horizontal", "windshield", "roof" ] },
+      { "x": 2, "y": 1, "parts": [ "frame_horizontal", "roller_drum" ] },
+      { "x": 1, "y": -1, "parts": [ "frame_horizontal", "windshield", "roof", "headlight" ] },
+      { "x": -3, "y": -1, "parts": [ "frame_horizontal", "roller_drum" ] },
+      { "x": -2, "y": -1, "parts": [ "frame_horizontal", "trunk" ] }
+    ],
+    "items": [ { "x": 0, "y": 0, "chance": 5, "items": [ "hat_hard" ] } ]
+  },
+  {
+    "id": "forklift_test",
+    "type": "vehicle",
+    "name": "Forklift",
+    "blueprint": [
+      [ "o#o-" ],
+      [ "o|o-" ]
+    ],
+    "parts": [
+      { "x": -1, "y": 1, "parts": [ "frame_se", "halfboard_se", "wheel_mount_light_steerable", "wheel_small" ] },
+      { "x": 1, "y": 0, "parts": [ "frame_nw", "halfboard_nw", "wheel_mount_light_steerable", "wheel_small" ] },
+      { "x": 1, "y": 1, "parts": [ "frame_ne", "halfboard_ne", "wheel_mount_light_steerable", "wheel_small" ] },
+      { "x": 0, "y": 0, "parts": [ "frame_horizontal", "seat", "roof", "controls", "dashboard" ] },
+      { "x": 2, "y": 0, "parts": [ "forklift_fork" ] },
+      { "x": -1, "y": 0, "parts": [ "frame_sw", "halfboard_sw", "wheel_mount_light_steerable", "wheel_small" ] },
+      {
+        "x": 0,
+        "y": 1,
+        "parts": [ "frame_horizontal", "engine_electric", "roof", "halfboard_vertical", "storage_battery" ]
+      },
+      { "x": 2, "y": 1, "parts": [ "forklift_fork" ] }
+    ],
+    "items": [
+      { "x": 0, "y": 0, "chance": 5, "items": [ "hat_hard" ] },
+      { "x": 2, "y": 0, "chance": 10, "items": [ "2x4" ] },
+      { "x": 2, "y": 1, "chance": 10, "items": [ "2x4" ] }
+    ]
+  },
+  {
+    "id": "trencher_test",
+    "type": "vehicle",
+    "name": "Trencher",
+    "blueprint": [
+      [ "o-=o " ],
+      [ "|X==&" ],
+      [ "o-=o " ]
+    ],
+    "parts": [
+      { "x": -1, "y": 1, "parts": [ "frame_se", "roof", "wheel_mount_medium", "wheel_wide_or", "board_se" ] },
+      { "x": 2, "y": -1, "parts": [ "frame_nw", "halfboard_nw", "headlight_reinforced" ] },
+      { "x": -1, "y": -1, "parts": [ "frame_sw", "roof", "wheel_mount_medium", "wheel_wide_or", "board_sw" ] },
+      { "x": 1, "y": 0, "parts": [ "frame_cross", "roof", "reinforced_windshield" ] },
+      { "x": 3, "y": 0, "parts": [ "rockwheel" ] },
+      {
+        "x": 1,
+        "y": 1,
+        "parts": [ "frame_vertical", "roof", "wheel_mount_medium_steerable", "wheel_wide_or", "reinforced_windshield" ]
+      },
+      {
+        "x": 0,
+        "y": 0,
+        "parts": [
+          "frame_cross",
+          "roof",
+          "seat",
+          "seatbelt",
+          "floodlight",
+          "controls",
+          "dashboard",
+          "horn_big",
+          "engine_electric",
+          "storage_battery"
+        ]
+      },
+      { "x": 2, "y": 0, "parts": [ "frame_horizontal" ] },
+      { "x": -1, "y": 0, "parts": [ "frame_horizontal", "roof", "hatch" ] },
+      { "x": 0, "y": 1, "parts": [ "frame_vertical", "roof", "door" ] },
+      { "x": 0, "y": -1, "parts": [ "frame_vertical", "roof", "door" ] },
+      { "x": 2, "y": 1, "parts": [ "frame_ne", "halfboard_ne", "headlight_reinforced" ] },
+      {
+        "x": 1,
+        "y": -1,
+        "parts": [ "frame_vertical", "roof", "wheel_mount_medium_steerable", "wheel_wide_or", "reinforced_windshield" ]
+      }
+    ],
+    "items": [  ]
+  },
+  {
+    "id": "armored_car_test",
+    "type": "vehicle",
+    "name": "Armored Car",
+    "blueprint": [
+      [ "O-++-O>" ],
+      [ "|H##'|>" ],
+      [ "t###'|>" ],
+      [ "|H#t'|>" ],
+      [ "O-++-O>" ]
+    ],
+    "parts": [
+      {
+        "x": -3,
+        "y": 1,
+        "parts": [
+          "hdframe_horizontal",
+          "plating_steel",
+          "turret_mount",
+          { "part": "m249", "ammo": 60, "ammo_types": [ "556" ], "ammo_qty": [ 10, 100 ] },
+          "hddoor_opaque"
+        ]
+      },
+      {
+        "x": 2,
+        "y": 2,
+        "parts": [ "hdframe_horizontal", "hdhalfboard_horizontal", "plating_steel", "headlight_reinforced" ]
+      },
+      { "x": -1, "y": 1, "parts": [ "hdframe_horizontal_2", "seat", "seatbelt", "roof" ] },
+      {
+        "x": 0,
+        "y": 2,
+        "parts": [
+          "hdframe_vertical_2",
+          "seat",
+          "seatbelt",
+          "hdroof",
+          { "part": "tank", "fuel": "diesel" },
+          "turret_mount",
+          { "part": "m249", "ammo": 80, "ammo_types": [ "556" ], "ammo_qty": [ 10, 100 ] }
+        ]
+      },
+      { "x": 1, "y": 3, "parts": [ "hdframe_vertical", "reinforced_windshield" ] },
+      {
+        "x": 2,
+        "y": -1,
+        "parts": [ "hdframe_nw", "hdhalfboard_nw", "plating_steel", "wheel_mount_heavy_steerable", "wheel_armor" ]
+      },
+      { "x": -1, "y": -1, "parts": [ "hdframe_vertical", "hddoor_left", "plating_steel" ] },
+      { "x": 3, "y": 1, "parts": [ "hdframe_cover", "plating_spiked" ] },
+      { "x": -2, "y": 2, "parts": [ "hdframe_horizontal_2", "trunk", "hdroof" ] },
+      { "x": -1, "y": 3, "parts": [ "hdframe_vertical", "hddoor_right", "plating_steel" ] },
+      { "x": 1, "y": 0, "parts": [ "hdframe_horizontal", "reinforced_windshield" ] },
+      { "x": 3, "y": 0, "parts": [ "hdframe_cover", "plating_spiked" ] },
+      {
+        "x": -3,
+        "y": 3,
+        "parts": [ "hdframe_se", "hdboard_se", "plating_steel", "wheel_mount_heavy", "wheel_armor" ]
+      },
+      { "x": -3, "y": 2, "parts": [ "hdframe_horizontal", "hdboard_horizontal", "plating_steel" ] },
+      { "x": -2, "y": 3, "parts": [ "hdframe_vertical", "hdboard_vertical", "plating_steel" ] },
+      {
+        "x": 2,
+        "y": 3,
+        "parts": [ "hdframe_ne", "hdhalfboard_ne", "plating_steel", "wheel_mount_heavy_steerable", "wheel_armor" ]
+      },
+      { "x": 1, "y": 1, "parts": [ "hdframe_horizontal", "reinforced_windshield" ] },
+      { "x": 3, "y": -1, "parts": [ "hdframe_cover", "plating_spiked" ] },
+      { "x": -3, "y": 0, "parts": [ "hdframe_horizontal", "hdboard_horizontal", "plating_steel" ] },
+      { "x": -2, "y": 0, "parts": [ "hdframe_horizontal_2", "trunk", "hdroof" ] },
+      {
+        "x": 0,
+        "y": 0,
+        "parts": [
+          "hdframe_vertical_2",
+          "controls",
+          "dashboard",
+          "vehicle_clock",
+          "vehicle_alarm",
+          "horn_big",
+          "seat",
+          "seatbelt",
+          "hdroof",
+          { "part": "tank", "fuel": "diesel" }
+        ]
+      },
+      {
+        "x": 2,
+        "y": 0,
+        "parts": [ "hdframe_horizontal", "hdhalfboard_horizontal", "plating_steel", "headlight_reinforced" ]
+      },
+      { "x": -1, "y": 0, "parts": [ "hdframe_horizontal_2", "seat", "seatbelt", "hdroof" ] },
+      { "x": -2, "y": 1, "parts": [ "hdframe_horizontal_2", "aisle_horizontal", "roof" ] },
+      { "x": 0, "y": 3, "parts": [ "hdframe_vertical", "hddoor_right", "plating_steel" ] },
+      {
+        "x": 0,
+        "y": 1,
+        "parts": [ "hdframe_vertical_2", "diesel_engine_v8", "alternator_truck", "battery_car", "seat", "seatbelt", "hdroof" ]
+      },
+      { "x": 3, "y": 3, "parts": [ "hdframe_cover", "plating_spiked" ] },
+      { "x": 0, "y": -1, "parts": [ "hdframe_vertical", "hddoor_left", "plating_steel" ] },
+      { "x": 1, "y": 2, "parts": [ "hdframe_horizontal", "reinforced_windshield" ] },
+      { "x": -1, "y": 2, "parts": [ "hdframe_horizontal_2", "seat", "seatbelt", "hdroof" ] },
+      { "x": 2, "y": 1, "parts": [ "hdframe_horizontal", "hdhalfboard_horizontal", "plating_steel" ] },
+      { "x": 3, "y": 2, "parts": [ "hdframe_cover", "plating_spiked" ] },
+      { "x": 1, "y": -1, "parts": [ "hdframe_vertical", "reinforced_windshield" ] },
+      { "x": -2, "y": -1, "parts": [ "hdframe_vertical", "hdboard_vertical", "plating_steel" ] },
+      {
+        "x": -3,
+        "y": -1,
+        "parts": [ "hdframe_sw", "hdboard_sw", "plating_steel", "wheel_mount_heavy", "wheel_armor" ]
+      }
+    ],
+    "items": [  ]
+  },
+  {
+    "id": "cube_van_test",
+    "type": "vehicle",
+    "name": "Cube Van",
+    "blueprint": [
+      [ "     o " ],
+      [ "O----+-O" ],
+      [ "+===|#'|" ],
+      [ "+===|o'>" ],
+      [ "+===|#'|" ],
+      [ "O----+-O" ],
+      [ "     o " ]
+    ],
+    "parts": [
+      { "x": -3, "y": 1, "parts": [ "frame_horizontal", "aisle_vertical", "roof" ] },
+      { "x": 2, "y": 2, "parts": [ "frame_horizontal", "halfboard_horizontal_front" ] },
+      { "x": -1, "y": 1, "parts": [ "frame_horizontal", "board_horizontal_front" ] },
+      { "x": 0, "y": 2, "parts": [ "frame_vertical_2", "seat", "seatbelt", "roof" ] },
+      { "x": 1, "y": 3, "parts": [ "frame_vertical", "windshield_ne" ] },
+      {
+        "x": 2,
+        "y": -1,
+        "parts": [ "frame_nw", "halfboard_nw", "headlight", "wheel_mount_medium_steerable", "wheel_wide" ]
+      },
+      { "x": -1, "y": -1, "parts": [ "frame_sw", "board_nw", { "part": "tank", "fuel": "gasoline" } ] },
+      { "x": -3, "y": 3, "parts": [ "frame_vertical", "board_vertical_right", "roof" ] },
+      { "x": -2, "y": 2, "parts": [ "frame_vertical", "cargo_space", "roof" ] },
+      { "x": -1, "y": 3, "parts": [ "frame_se", "board_ne", { "part": "tank", "fuel": "gasoline" } ] },
+      { "x": 1, "y": 0, "parts": [ "frame_horizontal", "windshield_horizontal_front" ] },
+      { "x": -5, "y": -1, "parts": [ "frame_sw", "board_sw", "roof" ] },
+      { "x": -3, "y": 2, "parts": [ "frame_horizontal", "cargo_space", "roof" ] },
+      { "x": 1, "y": 4, "parts": [ "wing_mirror_right" ] },
+      { "x": 1, "y": -2, "parts": [ "wing_mirror_left" ] },
+      { "x": -2, "y": 3, "parts": [ "frame_vertical", "board_vertical_right", "roof" ] },
+      {
+        "x": 2,
+        "y": 3,
+        "parts": [ "frame_ne", "halfboard_ne", "headlight", "wheel_mount_medium_steerable", "wheel_wide" ]
+      },
+      { "x": -5, "y": 3, "parts": [ "frame_se", "board_se", "roof" ] },
+      { "x": -4, "y": 0, "parts": [ "frame_horizontal", "cargo_space", "roof" ] },
+      { "x": 1, "y": 1, "parts": [ "frame_horizontal", "windshield_horizontal_front" ] },
+      { "x": -4, "y": 2, "parts": [ "frame_horizontal", "cargo_space", "roof" ] },
+      { "x": -3, "y": 0, "parts": [ "frame_horizontal", "cargo_space", "roof" ] },
+      {
+        "x": -4,
+        "y": -1,
+        "parts": [ "frame_vertical", "board_vertical_left", "wheel_mount_medium", "wheel_wide", "roof" ]
+      },
+      { "x": -2, "y": 0, "parts": [ "frame_vertical", "cargo_space", "roof" ] },
+      {
+        "x": 0,
+        "y": 0,
+        "parts": [ "frame_vertical_2", "seat", "seatbelt", "controls", "dashboard", "vehicle_alarm", "horn_car", "roof" ]
+      },
+      { "x": 2, "y": 0, "parts": [ "frame_horizontal", "halfboard_horizontal_front" ] },
+      { "x": -1, "y": 0, "parts": [ "frame_horizontal", "board_horizontal_front" ] },
+      { "x": -2, "y": 1, "parts": [ "frame_vertical", "aisle_vertical", "roof" ] },
+      { "x": -4, "y": 1, "parts": [ "frame_horizontal", "aisle_vertical", "roof" ] },
+      { "x": 0, "y": 3, "parts": [ "frame_vertical", "door_front_right" ] },
+      { "x": 0, "y": 1, "parts": [ "frame_vertical", "box", "roof" ] },
+      { "x": 0, "y": -1, "parts": [ "frame_vertical", "door_front_left" ] },
+      { "x": 1, "y": 2, "parts": [ "frame_horizontal", "windshield_horizontal_front" ] },
+      { "x": -1, "y": 2, "parts": [ "frame_horizontal", "board_horizontal_front" ] },
+      {
+        "x": -4,
+        "y": 3,
+        "parts": [ "frame_vertical", "board_vertical_right", "wheel_mount_medium", "wheel_wide", "roof" ]
+      },
+      { "x": -5, "y": 1, "parts": [ "frame_horizontal", "door_shutter", "beeper", "roof" ] },
+      { "x": 2, "y": 1, "parts": [ "frame_cover", "halfboard_cover", "engine_v6", "alternator_car", "battery_car" ] },
+      { "x": 1, "y": -1, "parts": [ "frame_vertical", "windshield_nw" ] },
+      { "x": -5, "y": 2, "parts": [ "frame_horizontal", "door_shutter", "roof" ] },
+      { "x": -2, "y": -1, "parts": [ "frame_vertical", "board_vertical_left", "roof" ] },
+      { "x": -3, "y": -1, "parts": [ "frame_vertical", "board_vertical_left", "roof" ] },
+      { "x": -5, "y": 0, "parts": [ "frame_horizontal", "door_shutter", "roof" ] }
+    ],
+    "items": [
+      { "x": -2, "y": 0, "chance": 15, "items": [ "2x4" ] },
+      { "x": -2, "y": 0, "chance": 12, "items": [ "2x4" ] },
+      { "x": -2, "y": 2, "chance": 9, "items": [ "2x4" ] },
+      { "x": -3, "y": 0, "chance": 7, "item_groups": [ "car_kit" ] },
+      { "x": -3, "y": 0, "chance": 7, "items": [ "jack", "wheel_wide" ] },
+      { "x": -2, "y": 2, "chance": 14, "items": [ "2x4" ] },
+      { "x": -2, "y": 0, "chance": 15, "items": [ "2x4" ] },
+      { "x": -3, "y": 0, "chance": 2, "item_groups": [ "hardware" ] },
+      { "x": -3, "y": 2, "chance": 10, "item_groups": [ "hardware" ] },
+      { "x": -3, "y": 2, "chance": 5, "item_groups": [ "tools_carpentry" ] }
+    ]
+  },
+  {
+    "id": "cube_van_cheap_test",
+    "type": "vehicle",
+    "name": "Low-End Cube Van",
+    "blueprint": [
+      [ "     o " ],
+      [ "O----+-O" ],
+      [ "+===|#'|" ],
+      [ "+===|o'>" ],
+      [ "+===|#'|" ],
+      [ "O----+-O" ]
+    ],
+    "parts": [
+      { "x": -3, "y": 1, "parts": [ "frame_horizontal", "aisle_vertical", "roof" ] },
+      { "x": 2, "y": 2, "parts": [ "frame_horizontal", "halfboard_horizontal" ] },
+      { "x": -1, "y": 1, "parts": [ "frame_horizontal", "board_horizontal" ] },
+      { "x": 0, "y": 2, "parts": [ "frame_vertical_2", "seat", "seatbelt", "roof" ] },
+      { "x": 1, "y": 3, "parts": [ "frame_vertical", "windshield" ] },
+      {
+        "x": 2,
+        "y": -1,
+        "parts": [ "frame_nw", "halfboard_nw", "headlight", "wheel_mount_medium_steerable", "wheel_wide" ]
+      },
+      { "x": -1, "y": -1, "parts": [ "frame_sw", "board_sw", { "part": "tank", "fuel": "gasoline" } ] },
+      { "x": -3, "y": 3, "parts": [ "frame_vertical", "board_vertical", "roof" ] },
+      { "x": -2, "y": 2, "parts": [ "frame_vertical", "cargo_space", "roof" ] },
+      { "x": -1, "y": 3, "parts": [ "frame_se", "board_se", { "part": "tank", "fuel": "gasoline" } ] },
+      { "x": 1, "y": 0, "parts": [ "frame_horizontal", "windshield" ] },
+      { "x": -5, "y": -1, "parts": [ "frame_sw", "board_sw", "roof" ] },
+      { "x": -3, "y": 2, "parts": [ "frame_horizontal", "cargo_space", "roof" ] },
+      { "x": 1, "y": -2, "parts": [ "wing_mirror_left" ] },
+      { "x": -2, "y": 3, "parts": [ "frame_vertical", "board_vertical", "roof" ] },
+      {
+        "x": 2,
+        "y": 3,
+        "parts": [ "frame_ne", "halfboard_ne", "headlight", "wheel_mount_medium_steerable", "wheel_wide" ]
+      },
+      { "x": -5, "y": 3, "parts": [ "frame_se", "board_se", "roof" ] },
+      { "x": -4, "y": 0, "parts": [ "frame_horizontal", "cargo_space", "roof" ] },
+      { "x": 1, "y": 1, "parts": [ "frame_horizontal", "windshield" ] },
+      { "x": -4, "y": 2, "parts": [ "frame_horizontal", "cargo_space", "roof" ] },
+      { "x": -3, "y": 0, "parts": [ "frame_horizontal", "cargo_space", "roof" ] },
+      {
+        "x": -4,
+        "y": -1,
+        "parts": [ "frame_vertical", "board_vertical", "wheel_mount_medium", "wheel_wide", "roof" ]
+      },
+      { "x": -2, "y": 0, "parts": [ "frame_vertical", "cargo_space", "roof" ] },
+      {
+        "x": 0,
+        "y": 0,
+        "parts": [ "frame_vertical_2", "seat", "seatbelt", "controls", "dashboard", "vehicle_alarm", "horn_car", "roof" ]
+      },
+      { "x": 2, "y": 0, "parts": [ "frame_horizontal", "halfboard_horizontal" ] },
+      { "x": -1, "y": 0, "parts": [ "frame_horizontal", "board_horizontal" ] },
+      { "x": -2, "y": 1, "parts": [ "frame_vertical", "aisle_vertical", "roof" ] },
+      { "x": -4, "y": 1, "parts": [ "frame_horizontal", "aisle_vertical", "roof" ] },
+      { "x": 0, "y": 3, "parts": [ "frame_vertical", "door" ] },
+      { "x": 0, "y": 1, "parts": [ "frame_vertical", "box", "roof" ] },
+      { "x": 0, "y": -1, "parts": [ "frame_vertical", "door" ] },
+      { "x": 1, "y": 2, "parts": [ "frame_horizontal", "windshield" ] },
+      { "x": -1, "y": 2, "parts": [ "frame_horizontal", "board_horizontal" ] },
+      { "x": -4, "y": 3, "parts": [ "frame_vertical", "board_vertical", "wheel_mount_medium", "wheel_wide", "roof" ] },
+      { "x": -5, "y": 1, "parts": [ "frame_horizontal", "door_shutter", "beeper", "roof" ] },
+      {
+        "x": 2,
+        "y": 1,
+        "parts": [ "frame_cover", "halfboard_cover", "engine_inline4", "alternator_car", "battery_car" ]
+      },
+      { "x": 1, "y": -1, "parts": [ "frame_vertical", "windshield" ] },
+      { "x": -5, "y": 2, "parts": [ "frame_horizontal", "door_shutter", "roof" ] },
+      { "x": -2, "y": -1, "parts": [ "frame_vertical", "board_vertical", "roof" ] },
+      { "x": -3, "y": -1, "parts": [ "frame_vertical", "board_vertical", "roof" ] },
+      { "x": -5, "y": 0, "parts": [ "frame_horizontal", "door_shutter", "roof" ] }
+    ],
+    "items": [
+      { "x": -2, "y": 0, "chance": 5, "item_groups": [ "hardware" ] },
+      { "x": -2, "y": 2, "chance": 5, "item_groups": [ "hardware" ] },
+      { "x": -3, "y": 2, "chance": 2, "item_groups": [ "tools_carpentry" ] }
+    ]
+  },
+  {
+    "id": "hippie_van_test",
+    "type": "vehicle",
+    "name": "Hippie Van",
+    "blueprint": [
+      [ "o---+-o" ],
+      [ "+=###'|" ],
+      [ "+===#'|" ],
+      [ "o-+++-o" ]
+    ],
+    "parts": [
+      { "x": -3, "y": 1, "parts": [ "frame_vertical", "trunk", "roof" ] },
+      { "x": -1, "y": 1, "parts": [ "frame_vertical_2", "aisle_vertical", "roof" ] },
+      {
+        "x": 2,
+        "y": 2,
+        "parts": [ "frame_ne", "halfboard_ne", "headlight", "wheel_mount_medium_steerable", "wheel" ]
+      },
+      { "x": 0, "y": 2, "parts": [ "frame_vertical", "door", "roof" ] },
+      {
+        "x": 2,
+        "y": -1,
+        "parts": [ "frame_nw", "halfboard_nw", "headlight", "wheel_mount_medium_steerable", "wheel" ]
+      },
+      { "x": -1, "y": -1, "parts": [ "frame_vertical", "board_vertical", "roof" ] },
+      { "x": -2, "y": 2, "parts": [ "frame_vertical", "door_sliding", "roof" ] },
+      { "x": 1, "y": 0, "parts": [ "frame_horizontal", "windshield" ] },
+      { "x": -3, "y": 2, "parts": [ "frame_vertical", "board_vertical", "roof" ] },
+      { "x": -4, "y": 0, "parts": [ "frame_horizontal", "door_trunk", "roof" ] },
+      { "x": 1, "y": 1, "parts": [ "frame_horizontal", "windshield" ] },
+      { "x": -4, "y": 2, "parts": [ "frame_se", "board_se", "wheel_mount_medium", "wheel", "roof" ] },
+      { "x": -3, "y": 0, "parts": [ "frame_vertical", "trunk", "muffler", "roof" ] },
+      { "x": -4, "y": -1, "parts": [ "frame_sw", "board_sw", "wheel_mount_medium", "wheel", "roof" ] },
+      { "x": -2, "y": 0, "parts": [ "frame_vertical_2", "seat", "seatbelt", "roof" ] },
+      {
+        "x": 0,
+        "y": 0,
+        "parts": [
+          "frame_vertical_2",
+          "reclining_seat",
+          "seatbelt",
+          "controls",
+          "dashboard",
+          "vehicle_clock",
+          "vehicle_alarm",
+          "horn_car",
+          "roof"
+        ]
+      },
+      {
+        "x": 2,
+        "y": 0,
+        "parts": [ "frame_horizontal", "halfboard_horizontal", "engine_inline4", "alternator_car", "battery_car" ]
+      },
+      { "x": -1, "y": 0, "parts": [ "frame_vertical_2", "seat", "seatbelt", "roof" ] },
+      { "x": -2, "y": 1, "parts": [ "frame_vertical_2", "aisle_vertical", "roof" ] },
+      { "x": -4, "y": 1, "parts": [ "frame_horizontal", "door_trunk", "roof" ] },
+      { "x": 0, "y": 1, "parts": [ "frame_vertical_2", "reclining_seat", "seatbelt", "roof" ] },
+      { "x": 0, "y": -1, "parts": [ "frame_vertical", "door", "roof" ] },
+      { "x": -1, "y": 2, "parts": [ "frame_vertical", "door_sliding", "roof" ] },
+      { "x": 1, "y": 2, "parts": [ "frame_vertical", "windshield" ] },
+      { "x": 2, "y": 1, "parts": [ "frame_horizontal", "halfboard_horizontal" ] },
+      { "x": 1, "y": -1, "parts": [ "frame_vertical", "windshield" ] },
+      { "x": -2, "y": -1, "parts": [ "frame_vertical", "board_vertical", "roof" ] },
+      {
+        "x": -3,
+        "y": -1,
+        "parts": [ "frame_vertical", "board_vertical", { "part": "tank", "fuel": "gasoline" }, "roof" ]
+      }
+    ],
+    "items": [
+      { "x": 0, "y": 0, "chance": 3, "items": [ "sunglasses" ] },
+      { "x": 0, "y": 1, "chance": 10, "items": [ "fancy_sunglasses" ] },
+      { "x": -1, "y": 0, "chance": 5, "items": [ "weed", "rolling_paper" ] },
+      { "x": -2, "y": 0, "chance": 2, "items": [ "weed", "rolling_paper" ] },
+      { "x": -3, "y": 0, "chance": 5, "items": [ "acoustic_guitar" ] },
+      { "x": -3, "y": 1, "chance": 8, "items": [ "joint_roach" ] }
+    ]
+  },
+  {
+    "id": "icecream_truck_test",
+    "type": "vehicle",
+    "name": "Ice Cream Truck",
+    "blueprint": [
+      [ "     o " ],
+      [ "O---+-O" ],
+      [ "|&&H#'|" ],
+      [ "+===='>" ],
+      [ "|o==#'|" ],
+      [ "O-#-+-O" ],
+      [ "     o " ]
+    ],
+    "parts": [
+      { "x": -3, "y": 1, "parts": [ "frame_vertical_2", "aisle_vertical", "roof" ] },
+      { "x": 2, "y": 2, "parts": [ "frame_horizontal", "halfboard_horizontal" ] },
+      { "x": -1, "y": 1, "parts": [ "frame_vertical_2", "aisle_vertical", "roof" ] },
+      { "x": 0, "y": 2, "parts": [ "frame_vertical_2", "seat", "seatbelt", "roof" ] },
+      { "x": 1, "y": 3, "parts": [ "frame_vertical", "windshield" ] },
+      {
+        "x": 2,
+        "y": -1,
+        "parts": [ "frame_nw", "halfboard_nw", "headlight", "wheel_mount_medium_steerable", "wheel" ]
+      },
+      { "x": -1, "y": -1, "parts": [ "frame_vertical", "board_vertical", { "part": "tank", "fuel": "gasoline" } ] },
+      { "x": -3, "y": 3, "parts": [ "frame_vertical", "board_vertical" ] },
+      { "x": -2, "y": 2, "parts": [ "frame_vertical_2", "aisle_vertical", "roof" ] },
+      { "x": -1, "y": 3, "parts": [ "frame_vertical", "board_vertical" ] },
+      { "x": 1, "y": 0, "parts": [ "frame_vertical_2", "windshield" ] },
+      { "x": -3, "y": 2, "parts": [ "frame_vertical_2", "storage_battery", "box", "roof" ] },
+      { "x": 1, "y": 4, "parts": [ "wing_mirror_right" ] },
+      { "x": 1, "y": -2, "parts": [ "wing_mirror_left" ] },
+      { "x": -2, "y": 3, "parts": [ "frame_vertical", "windshield" ] },
+      {
+        "x": 2,
+        "y": 3,
+        "parts": [ "frame_ne", "halfboard_ne", "headlight", "wheel_mount_medium_steerable", "wheel" ]
+      },
+      { "x": -4, "y": 0, "parts": [ "frame_horizontal", "board_horizontal", "muffler", "roof" ] },
+      { "x": 1, "y": 1, "parts": [ "frame_vertical_2", "windshield" ] },
+      { "x": -4, "y": 2, "parts": [ "frame_horizontal", "board_horizontal", "beeper", "roof" ] },
+      { "x": -3, "y": 0, "parts": [ "frame_vertical_2", "minifreezer", "roof" ] },
+      { "x": -4, "y": -1, "parts": [ "frame_sw", "board_sw", "wheel_mount_medium", "wheel", "roof" ] },
+      { "x": -2, "y": 0, "parts": [ "frame_vertical_2", "minifreezer", "roof" ] },
+      {
+        "x": 0,
+        "y": 0,
+        "parts": [
+          "frame_vertical_2",
+          "seat",
+          "seatbelt",
+          "controls",
+          "dashboard",
+          "vehicle_clock",
+          "vehicle_alarm",
+          "horn_car",
+          "roof"
+        ]
+      },
+      { "x": 2, "y": 0, "parts": [ "frame_horizontal", "halfboard_horizontal" ] },
+      { "x": -1, "y": 0, "parts": [ "frame_vertical_2", "box", "roof" ] },
+      { "x": -2, "y": 1, "parts": [ "frame_vertical_2", "aisle_vertical", "roof" ] },
+      { "x": -4, "y": 1, "parts": [ "frame_horizontal", "door", "roof" ] },
+      { "x": 0, "y": 3, "parts": [ "frame_vertical", "door", "roof" ] },
+      { "x": 0, "y": 1, "parts": [ "frame_vertical_2", "aisle_vertical", "chimes", "roof" ] },
+      { "x": 0, "y": -1, "parts": [ "frame_vertical", "door", "roof" ] },
+      { "x": 1, "y": 2, "parts": [ "frame_vertical_2", "windshield" ] },
+      { "x": -1, "y": 2, "parts": [ "frame_vertical_2", "aisle_vertical", "roof" ] },
+      { "x": -4, "y": 3, "parts": [ "frame_se", "board_se", "wheel_mount_medium", "wheel", "roof" ] },
+      {
+        "x": 2,
+        "y": 1,
+        "parts": [ "frame_cover", "halfboard_cover", "engine_v6", "alternator_truck", "battery_car" ]
+      },
+      { "x": 1, "y": -1, "parts": [ "frame_vertical", "windshield" ] },
+      { "x": -2, "y": -1, "parts": [ "frame_vertical", "board_vertical" ] },
+      { "x": -3, "y": -1, "parts": [ "frame_vertical", "board_vertical" ] }
+    ],
+    "items": [
+      { "x": -3, "y": 0, "chance": 60, "item_groups": [ "fridgesnacks" ] },
+      { "x": -3, "y": 0, "chance": 30, "item_groups": [ "fridgesnacks" ] },
+      { "x": -3, "y": 0, "chance": 30, "item_groups": [ "fridgesnacks" ] },
+      { "x": -3, "y": 0, "chance": 30, "item_groups": [ "fridgesnacks" ] },
+      { "x": -2, "y": 0, "chance": 60, "item_groups": [ "fridgesnacks" ] },
+      { "x": -2, "y": 0, "chance": 30, "item_groups": [ "fridgesnacks" ] },
+      { "x": -2, "y": 0, "chance": 30, "item_groups": [ "fridgesnacks" ] },
+      { "x": -2, "y": 0, "chance": 30, "item_groups": [ "fridgesnacks" ] },
+      { "x": -3, "y": 2, "chance": 60, "item_groups": [ "snacks" ] },
+      { "x": -3, "y": 2, "chance": 30, "item_groups": [ "snacks" ] },
+      { "x": -3, "y": 2, "chance": 30, "item_groups": [ "snacks" ] },
+      { "x": -3, "y": 2, "chance": 40, "items": [ "ketchup" ] },
+      { "x": -3, "y": 2, "chance": 40, "items": [ "mustard" ] },
+      { "x": -3, "y": 2, "chance": 40, "items": [ "mayonnaise" ] },
+      { "x": -1, "y": 0, "chance": 15, "items": [ "money_bundle" ] }
+    ]
+  },
+  {
+    "id": "lux_rv_test",
+    "type": "vehicle",
+    "name": "Luxury RV",
+    "blueprint": [  ],
+    "parts": [
+      { "x": -3, "y": 1, "parts": [ "frame_vertical_2", "aisle_horizontal", "floodlight", "roof" ] },
+      { "x": -1, "y": 1, "parts": [ "frame_horizontal", "door_internal" ] },
+      { "x": 1, "y": 3, "parts": [ "frame_ne", "windshield" ] },
+      { "x": -6, "y": 3, "parts": [ "frame_vertical", "stowboard_vertical" ] },
+      { "x": 1, "y": 0, "parts": [ "frame_horizontal", "headlight", "windshield" ] },
+      { "x": -8, "y": 2, "parts": [ "frame_vertical_2", "bed", "roof" ] },
+      { "x": -3, "y": 2, "parts": [ "frame_vertical_2", "seat_leather", "roof" ] },
+      { "x": 1, "y": -2, "parts": [ "wing_mirror_left" ] },
+      { "x": -7, "y": 2, "parts": [ "frame_vertical_2", "bed", "roof" ] },
+      { "x": -8, "y": 1, "parts": [ "frame_vertical_2", "aisle_horizontal", "roof" ] },
+      { "x": -4, "y": 0, "parts": [ "frame_vertical_2", "washing_machine", "roof" ] },
+      { "x": 1, "y": 1, "parts": [ "frame_horizontal", "windshield" ] },
+      { "x": -9, "y": 2, "parts": [ "frame_horizontal", "muffler", "board_horizontal", "solar_panel" ] },
+      { "x": -4, "y": 2, "parts": [ "frame_vertical_2", "veh_table", "roof" ] },
+      { "x": -4, "y": -1, "parts": [ "frame_vertical", "windshield", "v_curtain" ] },
+      {
+        "x": -2,
+        "y": 0,
+        "parts": [ "frame_vertical_2", { "part": "tank", "fuel": "water_clean" }, "kitchen_unit", "towel_hanger", "roof" ]
+      },
+      {
+        "x": 0,
+        "y": 0,
+        "parts": [
+          "frame_vertical_2",
+          "reclining_seat_leather",
+          "seatbelt",
+          "controls",
+          "dashboard",
+          "vehicle_clock",
+          "vehicle_alarm",
+          "stereo",
+          "roof"
+        ]
+      },
+      { "x": -7, "y": 1, "parts": [ "frame_vertical_2", "aisle_horizontal", "roof" ] },
+      { "x": -1, "y": 0, "parts": [ "frame_horizontal", "board_horizontal" ] },
+      { "x": -2, "y": 1, "parts": [ "frame_vertical_2", "aisle_horizontal", "roof" ] },
+      { "x": -7, "y": -1, "parts": [ "frame_vertical", "board_vertical" ] },
+      { "x": -7, "y": 3, "parts": [ "frame_vertical", "stowboard_vertical" ] },
+      { "x": -9, "y": 3, "parts": [ "frame_se", "wheel_mount_medium", "wheel_wide", "board_se", "solar_panel" ] },
+      { "x": 0, "y": 3, "parts": [ "frame_vertical", "wheel_mount_medium_steerable", "wheel_wide", "door" ] },
+      {
+        "x": 0,
+        "y": 1,
+        "parts": [
+          "frame_vertical_2",
+          "storage_battery",
+          "diesel_engine_v6",
+          "alternator_truck",
+          "horn_big",
+          "aisle_horizontal",
+          "roof"
+        ]
+      },
+      { "x": 0, "y": -1, "parts": [ "frame_vertical", "wheel_mount_medium_steerable", "wheel_wide", "door" ] },
+      { "x": 1, "y": 2, "parts": [ "frame_horizontal", "headlight", "windshield" ] },
+      { "x": -6, "y": 2, "parts": [ "frame_horizontal", "board_horizontal" ] },
+      {
+        "x": -8,
+        "y": -1,
+        "parts": [
+          "frame_vertical",
+          "wheel_mount_medium",
+          "wheel_wide",
+          "windshield",
+          "v_curtain",
+          { "part": "tank", "fuel": "diesel" }
+        ]
+      },
+      { "x": -9, "y": 1, "parts": [ "frame_horizontal_2", "board_horizontal", "beeper", "floodlight" ] },
+      { "x": -7, "y": 0, "parts": [ "frame_vertical_2", "bed", "roof" ] },
+      { "x": -6, "y": -1, "parts": [ "frame_vertical", "board_vertical" ] },
+      { "x": -5, "y": 0, "parts": [ "frame_vertical_2", "dishwasher", "roof" ] },
+      { "x": -9, "y": -1, "parts": [ "frame_sw", "wheel_mount_medium", "wheel_wide", "board_sw", "solar_panel" ] },
+      { "x": 0, "y": 2, "parts": [ "frame_vertical_2", "reclining_seat_leather", "seatbelt", "roof" ] },
+      { "x": -5, "y": -1, "parts": [ "frame_vertical", "windshield", "v_curtain" ] },
+      { "x": -1, "y": -1, "parts": [ "frame_vertical", "board_vertical", "floodlight" ] },
+      { "x": -3, "y": 3, "parts": [ "frame_vertical", "windshield", "v_curtain" ] },
+      { "x": -2, "y": 2, "parts": [ "frame_vertical_2", "aisle_horizontal", "roof" ] },
+      { "x": -1, "y": 3, "parts": [ "frame_vertical", "board_vertical", "floodlight" ] },
+      { "x": 1, "y": 4, "parts": [ "wing_mirror_right" ] },
+      { "x": -2, "y": 3, "parts": [ "frame_vertical_2", "door", "v_curtain" ] },
+      { "x": -5, "y": 3, "parts": [ "frame_vertical", "windshield", "v_curtain" ] },
+      { "x": -3, "y": 0, "parts": [ "frame_vertical_2", "minifridge", "roof" ] },
+      { "x": -8, "y": 0, "parts": [ "frame_vertical_2", "bed", "roof" ] },
+      { "x": -6, "y": 1, "parts": [ "frame_vertical_2", "door_internal" ] },
+      { "x": -4, "y": 1, "parts": [ "frame_vertical_2", "aisle_horizontal", "roof" ] },
+      { "x": -6, "y": 0, "parts": [ "frame_horizontal", "board_horizontal", "controls_electronic" ] },
+      {
+        "x": -8,
+        "y": 3,
+        "parts": [
+          "frame_vertical",
+          "wheel_mount_medium",
+          "wheel_wide",
+          "windshield",
+          "v_curtain",
+          { "part": "tank", "fuel": "diesel" }
+        ]
+      },
+      { "x": -4, "y": 3, "parts": [ "frame_vertical", "windshield", "v_curtain" ] },
+      { "x": -1, "y": 2, "parts": [ "frame_horizontal", "board_horizontal" ] },
+      { "x": -9, "y": 0, "parts": [ "frame_horizontal", "board_horizontal", "solar_panel" ] },
+      { "x": -5, "y": 1, "parts": [ "frame_vertical_2", "aisle_horizontal", "floodlight", "roof" ] },
+      { "x": 1, "y": -1, "parts": [ "frame_nw", "windshield" ] },
+      { "x": -5, "y": 2, "parts": [ "frame_vertical_2", "seat_leather", "roof" ] },
+      { "x": -2, "y": -1, "parts": [ "frame_vertical", "board_vertical" ] },
+      { "x": -3, "y": -1, "parts": [ "frame_vertical", "windshield", "v_curtain" ] }
+    ],
+    "items": [
+      { "x": 0, "y": 0, "chance": 5, "items": [ "fancy_sunglasses" ] },
+      { "x": 0, "y": 0, "chance": 1, "items": [ "roadmap" ] },
+      { "x": 0, "y": 2, "chance": 16, "items": [ "cigar" ] },
+      { "x": 0, "y": 2, "chance": 8, "items": [ "cig" ] },
+      { "x": -2, "y": 0, "chance": 5, "item_groups": [ "fast_food" ] },
+      { "x": -3, "y": 0, "chance": 5, "item_groups": [ "snacks" ] },
+      { "x": -3, "y": 0, "chance": 2, "item_groups": [ "snacks_fancy" ] },
+      { "x": -3, "y": 0, "chance": 12, "item_groups": [ "fridgesnacks" ] },
+      { "x": -3, "y": 0, "chance": 8, "item_groups": [ "fridgesnacks" ] },
+      { "x": -3, "y": 0, "chance": 10, "item_groups": [ "wines_worthy" ] },
+      { "x": -6, "y": 3, "chance": 2, "items": [ "beer", "beer", "beer", "beer", "beer", "beer" ] },
+      { "x": -7, "y": 0, "chance": 15, "item_groups": [ "bed" ] },
+      { "x": -7, "y": 2, "chance": 15, "item_groups": [ "bed" ] },
+      { "x": -8, "y": 0, "chance": 15, "item_groups": [ "bed" ] },
+      { "x": -8, "y": 2, "chance": 15, "item_groups": [ "bed" ] },
+      { "x": -6, "y": 3, "chance": 5, "items": [ "brazier" ] },
+      { "x": -7, "y": 3, "chance": 12, "items": [ "extinguisher" ] },
+      { "x": -7, "y": 3, "chance": 15, "items": [ "jack", "wheel_wide" ] }
+    ]
+  },
+  {
+    "id": "meth_lab_test",
+    "type": "vehicle",
+    "name": "Mobile Meth Lab",
+    "blueprint": [
+      [ "       o " ],
+      [ "+OO---+-O" ],
+      [ "|&===|#'|" ],
+      [ "|====+H'|" ],
+      [ "|===H|#'|" ],
+      [ "+OO-+-+-O" ],
+      [ "       o " ]
+    ],
+    "parts": [
+      { "x": -3, "y": 1, "parts": [ "frame_vertical_2", "lit_aisle_vertical", "roof" ] },
+      { "x": 2, "y": 2, "parts": [ "frame_horizontal", "halfboard_horizontal", "headlight" ] },
+      { "x": -1, "y": 1, "parts": [ "frame_vertical_2", "door_internal", "roof" ] },
+      { "x": 1, "y": 3, "parts": [ "frame_vertical", "windshield" ] },
+      { "x": 2, "y": -1, "parts": [ "frame_nw", "halfboard_nw", "wheel_mount_medium_steerable", "wheel_wide" ] },
+      { "x": -6, "y": 3, "parts": [ "frame_se", "board_se", "roof" ] },
+      { "x": 1, "y": 0, "parts": [ "frame_vertical_2", "windshield" ] },
+      { "x": -3, "y": 2, "parts": [ "frame_horizontal", "trunk", "roof" ] },
+      { "x": 1, "y": -2, "parts": [ "wing_mirror_left" ] },
+      { "x": -4, "y": 0, "parts": [ "frame_horizontal", "trunk", "roof" ] },
+      { "x": 1, "y": 1, "parts": [ "frame_vertical_2", "windshield" ] },
+      { "x": -4, "y": 2, "parts": [ "frame_horizontal", "trunk", "roof" ] },
+      {
+        "x": -4,
+        "y": -1,
+        "parts": [ "frame_vertical", "board_vertical", "storage_battery", "wheel_mount_medium", "wheel_wide", "roof" ]
+      },
+      { "x": -2, "y": 0, "parts": [ "frame_vertical_2", "trunk", "roof" ] },
+      {
+        "x": 0,
+        "y": 0,
+        "parts": [
+          "frame_vertical_2",
+          "seat",
+          "seatbelt",
+          "controls",
+          "dashboard",
+          "vehicle_clock",
+          "vehicle_alarm",
+          "horn_car",
+          "roof"
+        ]
+      },
+      { "x": 2, "y": 0, "parts": [ "frame_horizontal", "halfboard_horizontal", "headlight" ] },
+      { "x": -1, "y": 0, "parts": [ "frame_horizontal", "board_horizontal", "roof" ] },
+      { "x": -2, "y": 1, "parts": [ "frame_vertical_2", "lit_aisle_vertical", "roof" ] },
+      { "x": 0, "y": 3, "parts": [ "frame_vertical", "door", "roof" ] },
+      {
+        "x": 0,
+        "y": 1,
+        "parts": [ "frame_vertical_2", "aisle_horizontal", "engine_v6", "alternator_truck", "battery_car", "roof" ]
+      },
+      { "x": 0, "y": -1, "parts": [ "frame_vertical", "door", "roof" ] },
+      { "x": 1, "y": 2, "parts": [ "frame_vertical_2", "windshield" ] },
+      { "x": -6, "y": 2, "parts": [ "frame_horizontal", "board_horizontal", "roof" ] },
+      { "x": -6, "y": -1, "parts": [ "frame_sw", "board_sw", "roof" ] },
+      { "x": -5, "y": 0, "parts": [ "frame_vertical_2", "chemlab", "roof" ] },
+      { "x": 0, "y": 2, "parts": [ "frame_vertical_2", "seat", "seatbelt", "roof" ] },
+      {
+        "x": -5,
+        "y": -1,
+        "parts": [
+          "frame_vertical",
+          "board_vertical",
+          { "part": "tank", "fuel": "gasoline" },
+          "wheel_mount_medium",
+          "wheel_wide",
+          "roof"
+        ]
+      },
+      { "x": -1, "y": -1, "parts": [ "frame_vertical", "board_vertical", "roof" ] },
+      { "x": -3, "y": 3, "parts": [ "frame_vertical", "board_vertical", "roof" ] },
+      { "x": -2, "y": 2, "parts": [ "frame_vertical_2", "trunk", "roof" ] },
+      { "x": -1, "y": 3, "parts": [ "frame_vertical", "board_vertical", "roof" ] },
+      { "x": 1, "y": 4, "parts": [ "wing_mirror_right" ] },
+      { "x": -2, "y": 3, "parts": [ "frame_vertical", "door", "v_curtain", "roof" ] },
+      { "x": 2, "y": 3, "parts": [ "frame_ne", "halfboard_ne", "wheel_mount_medium_steerable", "wheel_wide" ] },
+      { "x": -5, "y": 3, "parts": [ "frame_vertical", "board_vertical", "wheel_mount_medium", "wheel_wide", "roof" ] },
+      { "x": -3, "y": 0, "parts": [ "frame_horizontal", "trunk", "roof" ] },
+      { "x": -6, "y": 1, "parts": [ "frame_horizontal", "board_horizontal", "roof" ] },
+      { "x": -4, "y": 1, "parts": [ "frame_vertical_2", "lit_aisle_vertical", "roof" ] },
+      { "x": -6, "y": 0, "parts": [ "frame_horizontal", "board_horizontal", "roof" ] },
+      { "x": -4, "y": 3, "parts": [ "frame_vertical", "board_vertical", "wheel_mount_medium", "wheel_wide", "roof" ] },
+      { "x": -1, "y": 2, "parts": [ "frame_horizontal", "board_horizontal", "roof" ] },
+      { "x": -5, "y": 1, "parts": [ "frame_vertical_2", "lit_aisle_vertical", "roof" ] },
+      { "x": 2, "y": 1, "parts": [ "frame_horizontal", "halfboard_horizontal", "headlight" ] },
+      { "x": 1, "y": -1, "parts": [ "frame_vertical", "windshield" ] },
+      { "x": -5, "y": 2, "parts": [ "frame_vertical_2", "trunk", "roof" ] },
+      { "x": -2, "y": -1, "parts": [ "frame_vertical", "board_vertical", "roof" ] },
+      { "x": -3, "y": -1, "parts": [ "frame_vertical", "board_vertical", "roof" ] }
+    ],
+    "items": [
+      { "x": 0, "y": 0, "chance": 100, "items": [ "porkpie" ] },
+      { "x": -2, "y": 0, "chance": 30, "items": [ "dayquil" ] },
+      { "x": -2, "y": 0, "chance": 8, "items": [ "dayquil" ] },
+      { "x": -2, "y": 0, "chance": 5, "items": [ "dayquil" ] },
+      { "x": -2, "y": 0, "chance": 5, "items": [ "dayquil" ] },
+      { "x": -2, "y": 0, "chance": 1, "items": [ "dayquil" ] },
+      { "x": -2, "y": 0, "chance": 1, "items": [ "dayquil" ] },
+      { "x": -2, "y": 0, "chance": 5, "item_groups": [ "methlab" ] },
+      { "x": -2, "y": 2, "chance": 30, "items": [ "aspirin" ] },
+      { "x": -2, "y": 2, "chance": 10, "items": [ "aspirin" ] },
+      { "x": -2, "y": 2, "chance": 10, "items": [ "aspirin" ] },
+      { "x": -2, "y": 2, "chance": 8, "items": [ "aspirin" ] },
+      { "x": -2, "y": 2, "chance": 5, "items": [ "aspirin" ] },
+      { "x": -2, "y": 2, "chance": 5, "items": [ "aspirin" ] },
+      { "x": -2, "y": 2, "chance": 5, "items": [ "aspirin" ] },
+      { "x": -2, "y": 2, "chance": 1, "items": [ "aspirin" ] },
+      { "x": -2, "y": 2, "chance": 5, "item_groups": [ "methlab" ] },
+      { "x": -3, "y": 0, "chance": 25, "items": [ "meth" ] },
+      { "x": -3, "y": 0, "chance": 8, "items": [ "meth" ] },
+      { "x": -3, "y": 0, "chance": 5, "items": [ "meth" ] },
+      { "x": -3, "y": 0, "chance": 5, "items": [ "meth" ] },
+      { "x": -3, "y": 0, "chance": 3, "items": [ "meth" ] },
+      { "x": -3, "y": 0, "chance": 1, "items": [ "meth" ] },
+      { "x": -3, "y": 0, "chance": 1, "items": [ "meth" ] },
+      { "x": -3, "y": 0, "chance": 7, "item_groups": [ "methlab" ] },
+      { "x": -3, "y": 2, "chance": 25, "items": [ "adderall" ] },
+      { "x": -3, "y": 2, "chance": 10, "items": [ "adderall" ] },
+      { "x": -3, "y": 2, "chance": 10, "item_groups": [ "stash_drugrunner" ] },
+      { "x": -3, "y": 2, "chance": 8, "items": [ "adderall" ] },
+      { "x": -3, "y": 2, "chance": 8, "items": [ "adderall" ] },
+      { "x": -3, "y": 2, "chance": 5, "items": [ "adderall" ] },
+      { "x": -3, "y": 2, "chance": 5, "items": [ "adderall" ] },
+      { "x": -3, "y": 2, "chance": 3, "items": [ "adderall" ] },
+      { "x": -3, "y": 2, "chance": 1, "items": [ "adderall" ] },
+      { "x": -4, "y": 0, "chance": 7, "item_groups": [ "methlab" ] },
+      { "x": -4, "y": 2, "chance": 7, "item_groups": [ "methlab" ] },
+      { "x": -5, "y": 2, "chance": 9, "item_groups": [ "methlab" ] }
+    ]
+  },
+  {
+    "id": "rv_test",
+    "type": "vehicle",
+    "name": "RV",
+    "blueprint": [
+      [ "       o " ],
+      [ "+OO---+-O" ],
+      [ "|&==#|#'|" ],
+      [ "|====+H'|" ],
+      [ "|#==H|#'|" ],
+      [ "+OO-+-+-O" ],
+      [ "       o " ]
+    ],
+    "parts": [
+      { "x": -3, "y": 1, "parts": [ "frame_vertical_2", "lit_aisle_vertical", "roof" ] },
+      { "x": 2, "y": 2, "parts": [ "frame_horizontal", "halfboard_horizontal_front", "headlight" ] },
+      { "x": -1, "y": 1, "parts": [ "frame_vertical_2", "door_internal", "roof" ] },
+      { "x": 1, "y": 3, "parts": [ "frame_vertical", "windshield_ne" ] },
+      { "x": 2, "y": -1, "parts": [ "frame_nw", "halfboard_nw", "wheel_mount_medium_steerable", "wheel_wide" ] },
+      { "x": -6, "y": 3, "parts": [ "frame_se", "board_se", "roof" ] },
+      { "x": 1, "y": 0, "parts": [ "frame_vertical_2", "windshield_horizontal_front" ] },
+      { "x": -3, "y": 2, "parts": [ "frame_horizontal", "trunk", "roof" ] },
+      { "x": 1, "y": -2, "parts": [ "wing_mirror_left" ] },
+      { "x": -4, "y": 0, "parts": [ "frame_horizontal", "minifridge", "roof" ] },
+      { "x": 1, "y": 1, "parts": [ "frame_vertical_2", "windshield_horizontal_front" ] },
+      { "x": -4, "y": 2, "parts": [ "frame_horizontal", "trunk", "roof" ] },
+      {
+        "x": -4,
+        "y": -1,
+        "parts": [ "frame_vertical", "board_vertical_left", "storage_battery", "wheel_mount_medium", "wheel_wide", "roof" ]
+      },
+      { "x": -2, "y": 0, "parts": [ "frame_vertical_2", "seat", "roof" ] },
+      {
+        "x": 0,
+        "y": 0,
+        "parts": [
+          "frame_vertical_2",
+          "seat",
+          "seatbelt",
+          "controls",
+          "dashboard",
+          "vehicle_clock",
+          "vehicle_alarm",
+          "horn_car",
+          "roof"
+        ]
+      },
+      { "x": 2, "y": 0, "parts": [ "frame_horizontal", "halfboard_horizontal_front", "headlight" ] },
+      { "x": -1, "y": 0, "parts": [ "frame_horizontal", "board_horizontal", "roof" ] },
+      { "x": -2, "y": 1, "parts": [ "frame_vertical_2", "lit_aisle_vertical", "roof" ] },
+      { "x": 0, "y": 3, "parts": [ "frame_vertical", "door_front_right", "roof" ] },
+      {
+        "x": 0,
+        "y": 1,
+        "parts": [ "frame_vertical_2", "aisle_horizontal", "engine_v6", "alternator_truck", "battery_car", "roof" ]
+      },
+      { "x": 0, "y": -1, "parts": [ "frame_vertical", "door_front_left", "roof" ] },
+      { "x": 1, "y": 2, "parts": [ "frame_vertical_2", "windshield_horizontal_front" ] },
+      { "x": -6, "y": 2, "parts": [ "frame_horizontal", "board_horizontal_rear", "roof" ] },
+      { "x": -6, "y": -1, "parts": [ "frame_sw", "board_sw", "roof" ] },
+      { "x": -5, "y": 0, "parts": [ "frame_vertical_2", "kitchen_unit", "towel_hanger", "roof" ] },
+      { "x": 0, "y": 2, "parts": [ "frame_vertical_2", "seat", "seatbelt", "roof" ] },
+      {
+        "x": -5,
+        "y": -1,
+        "parts": [
+          "frame_vertical",
+          "board_vertical",
+          { "part": "tank", "fuel": "gasoline" },
+          "wheel_mount_medium",
+          "wheel_wide",
+          "roof"
+        ]
+      },
+      { "x": -1, "y": -1, "parts": [ "frame_vertical", "board_nw", "roof" ] },
+      { "x": -3, "y": 3, "parts": [ "frame_vertical", "board_vertical_right", "roof" ] },
+      { "x": -2, "y": 2, "parts": [ "frame_vertical_2", "aisle_horizontal", "roof" ] },
+      { "x": -1, "y": 3, "parts": [ "frame_vertical", "board_ne", "roof" ] },
+      { "x": 1, "y": 4, "parts": [ "wing_mirror_right" ] },
+      { "x": -2, "y": 3, "parts": [ "frame_vertical", "door_front_right", "v_curtain", "roof" ] },
+      { "x": 2, "y": 3, "parts": [ "frame_ne", "halfboard_ne", "wheel_mount_medium_steerable", "wheel_wide" ] },
+      {
+        "x": -5,
+        "y": 3,
+        "parts": [ "frame_vertical", "board_vertical_right", "wheel_mount_medium", "wheel_wide", "roof" ]
+      },
+      { "x": -3, "y": 0, "parts": [ "frame_horizontal", "trunk", "roof" ] },
+      { "x": -6, "y": 1, "parts": [ "frame_horizontal", "board_horizontal_rear", "roof" ] },
+      { "x": -4, "y": 1, "parts": [ "frame_vertical_2", "lit_aisle_vertical", "roof" ] },
+      { "x": -6, "y": 0, "parts": [ "frame_horizontal", "board_horizontal_rear", "beeper", "roof" ] },
+      {
+        "x": -4,
+        "y": 3,
+        "parts": [ "frame_vertical", "board_vertical_right", "wheel_mount_medium", "wheel_wide", "roof" ]
+      },
+      { "x": -1, "y": 2, "parts": [ "frame_horizontal", "board_horizontal", "roof" ] },
+      { "x": -5, "y": 1, "parts": [ "frame_vertical_2", "lit_aisle_vertical", "roof" ] },
+      { "x": 2, "y": 1, "parts": [ "frame_horizontal", "halfboard_horizontal_front", "headlight" ] },
+      { "x": 1, "y": -1, "parts": [ "frame_vertical", "windshield_nw" ] },
+      { "x": -5, "y": 2, "parts": [ "frame_vertical_2", "bed", "roof" ] },
+      { "x": -2, "y": -1, "parts": [ "frame_vertical", "board_vertical_left", "roof" ] },
+      {
+        "x": -3,
+        "y": -1,
+        "parts": [ "frame_vertical", "board_vertical_left", { "part": "tank", "fuel": "water_clean" }, "roof" ]
+      }
+    ],
+    "items": [
+      { "x": 0, "y": 0, "chance": 5, "items": [ "sunglasses" ] },
+      { "x": -4, "y": 0, "chance": 12, "item_groups": [ "fridgesnacks" ] },
+      { "x": -4, "y": 0, "chance": 10, "item_groups": [ "fridgesnacks" ] },
+      { "x": -4, "y": 0, "chance": 8, "item_groups": [ "fridgesnacks" ] },
+      { "x": -4, "y": 0, "chance": 5, "item_groups": [ "fridgesnacks" ] },
+      { "x": -4, "y": 2, "chance": 5, "items": [ "gasoline_lantern", "matches" ] },
+      { "x": -5, "y": 2, "chance": 8, "item_groups": [ "bed" ] }
+    ]
+  },
+  {
+    "id": "schoolbus_test",
+    "type": "vehicle",
+    "name": "Schoolbus",
+    "blueprint": [
+      [ "''O'''''''O" ],
+      [ "'########'H" ],
+      [ "+........'>" ],
+      [ "'#######.'H" ],
+      [ "''O'''''+'O" ]
+    ],
+    "parts": [
+      { "x": -3, "y": 1, "parts": [ "frame_vertical_2", "aisle_vertical", "roof" ] },
+      { "x": 2, "y": 2, "parts": [ "frame_horizontal_2", "halfboard_horizontal_2", "headlight" ] },
+      { "x": -1, "y": 1, "parts": [ "frame_vertical_2", "aisle_vertical", "roof" ] },
+      { "x": 1, "y": 3, "parts": [ "frame_horizontal", "windshield" ] },
+      { "x": 2, "y": -1, "parts": [ "frame_nw", "halfboard_nw", "wheel_mount_medium_steerable", "wheel_wide" ] },
+      { "x": -6, "y": 3, "parts": [ "frame_horizontal", "wheel_mount_medium", "wheel_wide", "windshield" ] },
+      { "x": 1, "y": 0, "parts": [ "frame_horizontal", "windshield" ] },
+      { "x": -8, "y": 2, "parts": [ "frame_horizontal", "windshield" ] },
+      { "x": -3, "y": 2, "parts": [ "frame_horizontal_2", "seat", "roof" ] },
+      { "x": -7, "y": 2, "parts": [ "frame_horizontal_2", "seat", "roof" ] },
+      { "x": -8, "y": 1, "parts": [ "frame_vertical", "door" ] },
+      { "x": -4, "y": 0, "parts": [ "frame_horizontal_2", "seat", "roof" ] },
+      { "x": 1, "y": 1, "parts": [ "frame_horizontal", "windshield" ] },
+      { "x": -4, "y": 2, "parts": [ "frame_horizontal_2", "seat", "roof" ] },
+      { "x": -4, "y": -1, "parts": [ "frame_vertical", "windshield" ] },
+      { "x": -2, "y": 0, "parts": [ "frame_horizontal_2", "seat", "roof" ] },
+      {
+        "x": 0,
+        "y": 0,
+        "parts": [ "frame_vertical_2", "seat", "controls", "dashboard", "vehicle_clock", "vehicle_alarm", "horn_car", "roof" ]
+      },
+      { "x": 2, "y": 0, "parts": [ "frame_horizontal_2", "halfboard_horizontal_2", "headlight" ] },
+      { "x": -7, "y": 1, "parts": [ "frame_vertical_2", "aisle_vertical", "roof" ] },
+      { "x": -1, "y": 0, "parts": [ "frame_horizontal_2", "seat", "roof" ] },
+      { "x": -2, "y": 1, "parts": [ "frame_vertical_2", "trunk_floor", "roof" ] },
+      { "x": -7, "y": -1, "parts": [ "frame_vertical", "windshield" ] },
+      { "x": -7, "y": 3, "parts": [ "frame_vertical", "windshield" ] },
+      { "x": 0, "y": 3, "parts": [ "frame_vertical", "door" ] },
+      { "x": 0, "y": 1, "parts": [ "frame_vertical_2", "aisle_vertical", "roof" ] },
+      { "x": 0, "y": -1, "parts": [ "frame_vertical", "windshield" ] },
+      { "x": 1, "y": 2, "parts": [ "frame_horizontal", "windshield" ] },
+      { "x": -6, "y": 2, "parts": [ "frame_horizontal_2", "seat", "roof" ] },
+      { "x": -8, "y": -1, "parts": [ "frame_horizontal", "windshield" ] },
+      { "x": -7, "y": 0, "parts": [ "frame_horizontal_2", "seat", "roof" ] },
+      { "x": -6, "y": -1, "parts": [ "frame_horizontal", "wheel_mount_medium", "wheel_wide", "windshield" ] },
+      { "x": -5, "y": 0, "parts": [ "frame_horizontal_2", "seat", "roof" ] },
+      { "x": 0, "y": 2, "parts": [ "frame_vertical_2", "aisle_horizontal", "roof" ] },
+      { "x": -5, "y": -1, "parts": [ "frame_vertical", "windshield" ] },
+      { "x": -1, "y": -1, "parts": [ "frame_vertical", "windshield" ] },
+      { "x": -3, "y": 3, "parts": [ "frame_vertical", "windshield" ] },
+      { "x": -2, "y": 2, "parts": [ "frame_horizontal_2", "seat", "roof" ] },
+      { "x": -1, "y": 3, "parts": [ "frame_vertical", "windshield", { "part": "tank", "fuel": "diesel" } ] },
+      { "x": -2, "y": 3, "parts": [ "frame_vertical", "windshield", { "part": "tank", "fuel": "diesel" } ] },
+      { "x": 2, "y": 3, "parts": [ "frame_ne", "halfboard_ne", "wheel_mount_medium_steerable", "wheel_wide" ] },
+      { "x": -5, "y": 3, "parts": [ "frame_vertical", "windshield" ] },
+      { "x": -3, "y": 0, "parts": [ "frame_horizontal_2", "seat", "roof" ] },
+      { "x": -8, "y": 0, "parts": [ "frame_horizontal", "windshield" ] },
+      { "x": -6, "y": 1, "parts": [ "frame_vertical_2", "aisle_vertical", "roof" ] },
+      { "x": -4, "y": 1, "parts": [ "frame_vertical_2", "aisle_vertical", "roof" ] },
+      { "x": -6, "y": 0, "parts": [ "frame_horizontal_2", "seat", "roof" ] },
+      { "x": -8, "y": 3, "parts": [ "frame_horizontal", "beeper", "windshield" ] },
+      { "x": -4, "y": 3, "parts": [ "frame_vertical", "windshield" ] },
+      { "x": -1, "y": 2, "parts": [ "frame_horizontal_2", "seat", "roof" ] },
+      { "x": -5, "y": 1, "parts": [ "frame_vertical_2", "trunk_floor", "roof" ] },
+      {
+        "x": 2,
+        "y": 1,
+        "parts": [ "frame_cover", "halfboard_cover", "diesel_engine_v6", "alternator_truck", "battery_car" ]
+      },
+      { "x": 1, "y": -1, "parts": [ "frame_horizontal", "windshield" ] },
+      { "x": -5, "y": 2, "parts": [ "frame_horizontal_2", "seat", "roof" ] },
+      { "x": -2, "y": -1, "parts": [ "frame_vertical", "windshield" ] },
+      { "x": -3, "y": -1, "parts": [ "frame_vertical", "windshield" ] }
+    ],
+    "items": [
+      { "x": -1, "y": 0, "chance": 7, "item_groups": [ "child_items" ] },
+      { "x": -1, "y": 2, "chance": 6, "item_groups": [ "child_items" ] },
+      { "x": -2, "y": 0, "chance": 5, "item_groups": [ "child_items" ] },
+      { "x": -2, "y": 2, "chance": 11, "item_groups": [ "child_items" ] },
+      { "x": -3, "y": 0, "chance": 8, "item_groups": [ "child_items" ] },
+      { "x": -3, "y": 2, "chance": 5, "item_groups": [ "child_items" ] },
+      { "x": -4, "y": 0, "chance": 6, "item_groups": [ "school" ] },
+      { "x": -4, "y": 2, "chance": 10, "item_groups": [ "child_items" ] },
+      { "x": -5, "y": 0, "chance": 6, "item_groups": [ "child_items" ] },
+      { "x": -5, "y": 2, "chance": 11, "item_groups": [ "child_items" ] },
+      { "x": -6, "y": 0, "chance": 7, "item_groups": [ "child_items" ] },
+      { "x": -6, "y": 2, "chance": 9, "item_groups": [ "school", "child_items" ] },
+      { "x": -7, "y": 0, "chance": 8, "item_groups": [ "child_items" ] },
+      { "x": -7, "y": 2, "chance": 7, "item_groups": [ "child_items" ] }
+    ]
+  },
+  {
+    "id": "security_van_test",
+    "type": "vehicle",
+    "name": "Security Van",
+    "blueprint": [
+      [ "     o " ],
+      [ "O----+-O" ],
+      [ "|===|#'|" ],
+      [ "+===|o'>" ],
+      [ "|===|#'|" ],
+      [ "O--+-+-O" ],
+      [ "     o " ]
+    ],
+    "parts": [
+      { "x": -3, "y": 1, "parts": [ "hdframe_horizontal", "aisle_horizontal", "hdroof" ] },
+      { "x": 2, "y": 2, "parts": [ "hdframe_horizontal", "hdhalfboard_horizontal_2", "plating_steel" ] },
+      { "x": -1, "y": 1, "parts": [ "hdframe_horizontal", "hdboard_horizontal", "plating_steel" ] },
+      { "x": 0, "y": 2, "parts": [ "hdframe_vertical_2", "seat", "seatbelt", "hdroof" ] },
+      { "x": 1, "y": 3, "parts": [ "hdframe_vertical", "reinforced_windshield", "plating_steel" ] },
+      {
+        "x": 2,
+        "y": -1,
+        "parts": [
+          "hdframe_nw",
+          "hdhalfboard_nw",
+          "headlight_reinforced",
+          "wheel_mount_medium_steerable",
+          "wheel_wide",
+          "plating_steel"
+        ]
+      },
+      {
+        "x": -1,
+        "y": -1,
+        "parts": [ "hdframe_sw", "hdboard_sw", "plating_steel", { "part": "tank", "fuel": "diesel" } ]
+      },
+      { "x": -3, "y": 3, "parts": [ "hdframe_vertical", "hdboard_vertical", "hdroof", "plating_steel" ] },
+      { "x": -2, "y": 2, "parts": [ "hdframe_vertical", "aisle_horizontal", "hdroof" ] },
+      {
+        "x": -1,
+        "y": 3,
+        "parts": [ "hdframe_se", "hdboard_se", { "part": "tank", "fuel": "diesel" }, "plating_steel" ]
+      },
+      { "x": 1, "y": 0, "parts": [ "hdframe_horizontal", "reinforced_windshield", "plating_steel" ] },
+      {
+        "x": -5,
+        "y": -1,
+        "parts": [ "hdframe_sw", "hdboard_sw", "wheel_mount_medium", "wheel_wide", "hdroof", "plating_steel" ]
+      },
+      { "x": -3, "y": 2, "parts": [ "hdframe_horizontal", "seat", "seatbelt", "hdroof" ] },
+      { "x": 1, "y": 4, "parts": [ "wing_mirror_right" ] },
+      { "x": 1, "y": -2, "parts": [ "wing_mirror_left" ] },
+      { "x": -2, "y": 3, "parts": [ "hdframe_vertical", "hddoor_opaque_right", "hdroof", "plating_steel" ] },
+      {
+        "x": 2,
+        "y": 3,
+        "parts": [
+          "hdframe_ne",
+          "hdhalfboard_ne",
+          "headlight_reinforced",
+          "wheel_mount_medium_steerable",
+          "wheel_wide",
+          "plating_steel"
+        ]
+      },
+      {
+        "x": -5,
+        "y": 3,
+        "parts": [ "hdframe_se", "hdboard_se", "wheel_mount_medium", "wheel_wide", "hdroof", "plating_steel" ]
+      },
+      { "x": -4, "y": 0, "parts": [ "hdframe_horizontal", "trunk", "hdroof" ] },
+      {
+        "x": 1,
+        "y": 1,
+        "parts": [
+          "hdframe_horizontal",
+          "reinforced_windshield",
+          "plating_steel",
+          "diesel_engine_v6",
+          "alternator_truck",
+          "battery_car"
+        ]
+      },
+      { "x": -4, "y": 2, "parts": [ "hdframe_horizontal", "trunk", "hdroof" ] },
+      { "x": -3, "y": 0, "parts": [ "hdframe_horizontal", "trunk", "hdroof" ] },
+      { "x": -4, "y": -1, "parts": [ "hdframe_vertical", "hdboard_vertical", "hdroof", "plating_steel" ] },
+      { "x": -2, "y": 0, "parts": [ "hdframe_vertical", "trunk", "hdroof" ] },
+      {
+        "x": 0,
+        "y": 0,
+        "parts": [ "hdframe_vertical_2", "seat", "seatbelt", "controls", "dashboard", "vehicle_alarm", "horn_car", "hdroof" ]
+      },
+      { "x": 2, "y": 0, "parts": [ "hdframe_horizontal", "hdhalfboard_horizontal_2", "plating_steel" ] },
+      { "x": -1, "y": 0, "parts": [ "hdframe_horizontal", "hdboard_horizontal", "plating_steel" ] },
+      { "x": -2, "y": 1, "parts": [ "hdframe_vertical", "aisle_horizontal", "hdroof" ] },
+      { "x": -4, "y": 1, "parts": [ "hdframe_horizontal", "aisle_horizontal", "hdroof" ] },
+      { "x": 0, "y": 3, "parts": [ "hdframe_vertical", "hddoor_right", "plating_steel" ] },
+      { "x": 0, "y": 1, "parts": [ "hdframe_vertical", "box", "hdroof" ] },
+      { "x": 0, "y": -1, "parts": [ "hdframe_vertical", "hddoor_left", "plating_steel" ] },
+      { "x": 1, "y": 2, "parts": [ "hdframe_horizontal", "reinforced_windshield", "plating_steel" ] },
+      { "x": -1, "y": 2, "parts": [ "hdframe_horizontal", "hdboard_horizontal", "plating_steel" ] },
+      { "x": -4, "y": 3, "parts": [ "hdframe_vertical", "hdboard_vertical", "hdroof", "plating_steel" ] },
+      { "x": -5, "y": 1, "parts": [ "hdframe_horizontal", "hddoor_opaque", "hdroof", "plating_steel" ] },
+      { "x": 2, "y": 1, "parts": [ "hdframe_cover", "hdhalfboard_horizontal_2", "plating_steel" ] },
+      { "x": 1, "y": -1, "parts": [ "hdframe_vertical", "reinforced_windshield", "plating_steel" ] },
+      {
+        "x": -5,
+        "y": 2,
+        "parts": [ "hdframe_horizontal", "hdboard_horizontal", "beeper", "hdroof", "plating_steel" ]
+      },
+      { "x": -2, "y": -1, "parts": [ "hdframe_vertical", "hdboard_vertical", "hdroof", "plating_steel" ] },
+      { "x": -3, "y": -1, "parts": [ "hdframe_vertical", "hdboard_vertical", "hdroof", "plating_steel" ] },
+      { "x": -5, "y": 0, "parts": [ "hdframe_horizontal", "hdboard_horizontal", "hdroof", "plating_steel" ] }
+    ],
+    "items": [
+      { "x": 0, "y": 1, "chance": 70, "magazine": 100, "ammo": 50, "item_groups": [ "guns_cop" ] },
+      { "x": -2, "y": 0, "chance": 50, "item_groups": [ "supplies_metal_precious", "supplies_metal_precious" ] },
+      { "x": -2, "y": 0, "chance": 50, "item_groups": [ "supplies_metal_precious", "supplies_metal_precious" ] },
+      { "x": -3, "y": 0, "chance": 20, "item_groups": [ "supplies_metal_precious", "supplies_metal_precious" ] },
+      { "x": -4, "y": 0, "chance": 20, "item_groups": [ "supplies_metal_precious", "supplies_metal_precious" ] },
+      { "x": -4, "y": 0, "chance": 20, "items": [ "diamond", "diamond", "diamond", "diamond", "diamond" ] }
+    ]
+  },
+  {
+    "id": "wienermobile_test",
+    "type": "vehicle",
+    "name": "Wienermobile",
+    "blueprint": [
+      [ "      o " ],
+      [ "+-O---O+" ],
+      [ "|&|#H##'" ],
+      [ "|=+===='" ],
+      [ "|=|#H##'" ],
+      [ "+-O-+-O+" ],
+      [ "      o " ]
+    ],
+    "parts": [
+      { "x": -3, "y": 1, "parts": [ "frame_vertical_2", "aisle_vertical", "roof" ] },
+      { "x": -1, "y": 1, "parts": [ "frame_vertical_2", "aisle_vertical", "chimes", "roof" ] },
+      { "x": 0, "y": 2, "parts": [ "frame_vertical_2", "seat", "seatbelt", "roof" ] },
+      { "x": 1, "y": 3, "parts": [ "frame_ne", "halfboard_ne" ] },
+      { "x": -5, "y": -1, "parts": [ "frame_sw", "board_sw", "roof" ] },
+      { "x": -1, "y": -1, "parts": [ "frame_vertical", "halfboard_vertical", "roof" ] },
+      { "x": -3, "y": 3, "parts": [ "frame_vertical", "board_vertical", "roof" ] },
+      { "x": -2, "y": 2, "parts": [ "frame_vertical_2", "aisle_horizontal", "roof" ] },
+      { "x": -1, "y": 3, "parts": [ "frame_vertical", "halfboard_vertical", "roof" ] },
+      { "x": 1, "y": 0, "parts": [ "frame_horizontal", "windshield", "headlight" ] },
+      { "x": -6, "y": 3, "parts": [ "frame_se", "board_se", "roof" ] },
+      { "x": -3, "y": 2, "parts": [ "frame_vertical_2", "seat", "seatbelt", "roof" ] },
+      { "x": 0, "y": -2, "parts": [ "wing_mirror_left" ] },
+      { "x": -2, "y": 3, "parts": [ "frame_vertical", "door", "roof" ] },
+      { "x": -5, "y": 3, "parts": [ "frame_se", "board_se", "roof" ] },
+      { "x": -4, "y": 0, "parts": [ "frame_vertical_2", "board_horizontal", "roof" ] },
+      { "x": 1, "y": 1, "parts": [ "frame_horizontal", "windshield" ] },
+      { "x": -4, "y": 2, "parts": [ "frame_vertical_2", "board_horizontal", "muffler", "roof" ] },
+      { "x": -3, "y": 0, "parts": [ "frame_vertical_2", "seat", "seatbelt", "roof" ] },
+      {
+        "x": -4,
+        "y": -1,
+        "parts": [ "frame_vertical", "board_vertical", "roof", "wheel_mount_medium", "wheel_wide" ]
+      },
+      { "x": -2, "y": 0, "parts": [ "frame_vertical_2", "aisle_horizontal", "roof" ] },
+      {
+        "x": 0,
+        "y": 0,
+        "parts": [
+          "frame_vertical_2",
+          "seat",
+          "seatbelt",
+          "controls",
+          "dashboard",
+          "vehicle_clock",
+          "vehicle_alarm",
+          "horn_car",
+          "roof"
+        ]
+      },
+      { "x": 0, "y": 4, "parts": [ "wing_mirror_right" ] },
+      { "x": -1, "y": 0, "parts": [ "frame_vertical_2", "seat", "seatbelt", "roof" ] },
+      { "x": -2, "y": 1, "parts": [ "frame_vertical_2", "aisle_vertical", "roof" ] },
+      { "x": -4, "y": 1, "parts": [ "frame_vertical_2", "door_internal", "roof" ] },
+      { "x": -6, "y": 1, "parts": [ "frame_horizontal", "board_horizontal", "roof" ] },
+      {
+        "x": 0,
+        "y": 3,
+        "parts": [ "frame_vertical", "windshield", "roof", "wheel_mount_medium_steerable", "wheel_wide" ]
+      },
+      { "x": -6, "y": 0, "parts": [ "frame_horizontal", "board_horizontal", "roof" ] },
+      {
+        "x": 0,
+        "y": 1,
+        "parts": [ "frame_vertical_2", "aisle_vertical", "engine_v8", "alternator_truck", "battery_car", "roof" ]
+      },
+      {
+        "x": 0,
+        "y": -1,
+        "parts": [ "frame_vertical", "windshield", "roof", "wheel_mount_medium_steerable", "wheel_wide" ]
+      },
+      { "x": 1, "y": 2, "parts": [ "frame_horizontal", "windshield", "headlight" ] },
+      { "x": -1, "y": 2, "parts": [ "frame_vertical_2", "seat", "seatbelt", "roof" ] },
+      { "x": -4, "y": 3, "parts": [ "frame_vertical", "board_vertical", "roof", "wheel_mount_medium", "wheel_wide" ] },
+      { "x": -5, "y": 1, "parts": [ "frame_vertical_2", "trunk", "roof" ] },
+      { "x": -6, "y": 2, "parts": [ "frame_horizontal", "board_horizontal", "roof" ] },
+      { "x": 1, "y": -1, "parts": [ "frame_nw", "halfboard_nw" ] },
+      { "x": -6, "y": -1, "parts": [ "frame_sw", "board_sw", "roof" ] },
+      { "x": -5, "y": 2, "parts": [ "frame_vertical_2", "trunk", "roof" ] },
+      { "x": -2, "y": -1, "parts": [ "frame_vertical", "board_vertical", "roof" ] },
+      {
+        "x": -3,
+        "y": -1,
+        "parts": [ "frame_vertical", "board_vertical", "roof", { "part": "tank", "fuel": "gasoline" } ]
+      },
+      { "x": -5, "y": 0, "parts": [ "frame_vertical_2", "trunk", "roof" ] }
+    ],
+    "items": [
+      { "x": 0, "y": 0, "chance": 15, "item_groups": [ "car_misc" ] },
+      { "x": 0, "y": 2, "chance": 15, "item_groups": [ "car_misc" ] },
+      { "x": 0, "y": 2, "chance": 25, "items": [ "roadmap" ] },
+      { "x": -5, "y": 0, "chance": 15, "item_groups": [ "car_kit" ] },
+      { "x": -5, "y": 1, "chance": 15, "item_groups": [ "car_kit" ] },
+      { "x": -5, "y": 2, "chance": 15, "item_groups": [ "car_kit" ] },
+      { "x": -5, "y": 2, "chance": 15, "items": [ "jack", "wheel_wide" ] },
+      { "x": -5, "y": 0, "chance": 12, "item_groups": [ "fuel_gasoline" ] },
+      { "x": -5, "y": 1, "chance": 12, "item_groups": [ "fuel_gasoline" ] },
+      { "x": -5, "y": 2, "chance": 12, "item_groups": [ "fuel_gasoline" ] }
+    ]
+  },
+  {
+    "id": "canoe_test",
+    "type": "vehicle",
+    "name": "canoe",
+    "blueprint": [ [ "<OO>" ] ],
+    "parts": [
+      { "x": 1, "y": 0, "parts": [ "frame_wood_horizontal", "boat_board", "seat_wood_light" ] },
+      { "x": 0, "y": 0, "parts": [ "frame_wood_horizontal", "seat_wood_light", "hand_paddles", "boat_board" ] },
+      { "x": 2, "y": 0, "parts": [ "frame_wood_horizontal", "boat_board" ] },
+      { "x": -1, "y": 0, "parts": [ "frame_wood_horizontal", "boat_board" ] }
+    ],
+    "items": [  ]
+  },
+  {
+    "id": "DUKW_test",
+    "type": "vehicle",
+    "name": "Amphibious Truck",
+    "blueprint": [  ],
+    "parts": [
+      { "x": -3, "y": 1, "parts": [ "frame_cross", "cargo_space", "metal_boat_hull" ] },
+      { "x": 2, "y": 2, "parts": [ "frame_horizontal", "halfboard_horizontal", "headlight", "metal_boat_hull" ] },
+      { "x": -1, "y": 1, "parts": [ "frame_cross", "windshield", "metal_boat_hull" ] },
+      { "x": 0, "y": 2, "parts": [ "frame_cross", "seat", "seatbelt", "roof", "metal_boat_hull" ] },
+      { "x": 1, "y": 3, "parts": [ "frame_vertical", "windshield", "wheel_mount_medium_steerable", "wheel_wide" ] },
+      { "x": 2, "y": -1, "parts": [ "frame_nw", "halfboard_nw", "metal_boat_hull" ] },
+      {
+        "x": -1,
+        "y": -1,
+        "parts": [ "frame_vertical", "windshield", "metal_boat_hull", { "part": "tank", "fuel": "gasoline" } ]
+      },
+      { "x": -3, "y": 3, "parts": [ "frame_vertical", "halfboard_vertical", "wheel_mount_medium", "wheel_wide" ] },
+      { "x": -2, "y": 2, "parts": [ "frame_cross", "cargo_space", "metal_boat_hull" ] },
+      {
+        "x": -1,
+        "y": 3,
+        "parts": [ "frame_vertical", "windshield", "metal_boat_hull", { "part": "tank", "fuel": "gasoline" } ]
+      },
+      { "x": 1, "y": 0, "parts": [ "frame_cross", "windshield", "metal_boat_hull" ] },
+      { "x": -5, "y": -1, "parts": [ "frame_sw", "halfboard_sw", "metal_boat_hull" ] },
+      { "x": -3, "y": 2, "parts": [ "frame_cross", "cargo_space", "metal_boat_hull" ] },
+      { "x": -2, "y": 3, "parts": [ "frame_vertical", "halfboard_vertical", "metal_boat_hull" ] },
+      { "x": 2, "y": 3, "parts": [ "frame_ne", "halfboard_ne", "metal_boat_hull" ] },
+      { "x": -5, "y": 3, "parts": [ "frame_se", "halfboard_se", "metal_boat_hull" ] },
+      { "x": -4, "y": 0, "parts": [ "frame_cross", "cargo_space", "metal_boat_hull" ] },
+      { "x": 1, "y": 1, "parts": [ "frame_cross", "windshield", "metal_boat_hull" ] },
+      { "x": -4, "y": 2, "parts": [ "frame_cross", "cargo_space", "metal_boat_hull" ] },
+      { "x": -3, "y": 0, "parts": [ "frame_cross", "cargo_space", "metal_boat_hull" ] },
+      { "x": -4, "y": -1, "parts": [ "frame_vertical", "halfboard_vertical", "wheel_mount_medium", "wheel_wide" ] },
+      { "x": -2, "y": 0, "parts": [ "frame_cross", "cargo_space", "metal_boat_hull" ] },
+      {
+        "x": 0,
+        "y": 0,
+        "parts": [ "frame_cross", "seat", "seatbelt", "controls", "dashboard", "roof", "metal_boat_hull" ]
+      },
+      { "x": 2, "y": 0, "parts": [ "frame_horizontal", "halfboard_horizontal", "headlight", "metal_boat_hull" ] },
+      { "x": -1, "y": 0, "parts": [ "frame_cross", "windshield", "metal_boat_hull" ] },
+      { "x": -2, "y": 1, "parts": [ "frame_cross", "cargo_space", "metal_boat_hull" ] },
+      { "x": -4, "y": 1, "parts": [ "frame_cross", "cargo_space", "metal_boat_hull" ] },
+      { "x": 0, "y": 3, "parts": [ "frame_vertical", "door", "metal_boat_hull" ] },
+      { "x": 0, "y": 1, "parts": [ "frame_cross", "seat", "seatbelt", "roof", "metal_boat_hull" ] },
+      { "x": 0, "y": -1, "parts": [ "frame_vertical", "door", "metal_boat_hull" ] },
+      { "x": 1, "y": 2, "parts": [ "frame_cross", "windshield", "metal_boat_hull" ] },
+      { "x": -1, "y": 2, "parts": [ "frame_cross", "windshield", "metal_boat_hull" ] },
+      { "x": -4, "y": 3, "parts": [ "frame_vertical", "halfboard_vertical", "wheel_mount_medium", "wheel_wide" ] },
+      { "x": -5, "y": 1, "parts": [ "frame_cross", "cargo_space", "metal_boat_hull" ] },
+      {
+        "x": 2,
+        "y": 1,
+        "parts": [ "frame_horizontal", "halfboard_horizontal", "metal_boat_hull", "engine_v6", "alternator_truck", "battery_car" ]
+      },
+      { "x": 1, "y": -1, "parts": [ "frame_vertical", "windshield", "wheel_mount_medium_steerable", "wheel_wide" ] },
+      { "x": -5, "y": 2, "parts": [ "frame_cross", "cargo_space", "metal_boat_hull" ] },
+      { "x": -2, "y": -1, "parts": [ "frame_vertical", "halfboard_vertical", "metal_boat_hull" ] },
+      { "x": -3, "y": -1, "parts": [ "frame_vertical", "halfboard_vertical", "wheel_mount_medium", "wheel_wide" ] },
+      { "x": -5, "y": 0, "parts": [ "frame_cross", "cargo_space", "metal_boat_hull" ] }
+    ],
+    "items": [  ]
+  },
+  {
+    "id": "kayak_test",
+    "type": "vehicle",
+    "name": "kayak",
+    "blueprint": [ [ "<O>" ] ],
+    "parts": [
+      { "x": 1, "y": 0, "parts": [ "xlframe_horizontal", "plastic_boat_hull" ] },
+      { "x": 0, "y": 0, "parts": [ "xlframe_horizontal", "seat", "hand_paddles", "plastic_boat_hull" ] },
+      { "x": -1, "y": 0, "parts": [ "xlframe_horizontal", "plastic_boat_hull" ] }
+    ],
+    "items": [  ]
+  },
+  {
+    "id": "kayak_racing_test",
+    "type": "vehicle",
+    "name": "racing kayak",
+    "blueprint": [ [ "<O>" ] ],
+    "parts": [
+      { "x": 1, "y": 0, "parts": [ "xlframe_horizontal", "carbonfiber_boat_hull" ] },
+      { "x": 0, "y": 0, "parts": [ "xlframe_horizontal", "seat", "hand_paddles", "carbonfiber_boat_hull" ] },
+      { "x": -1, "y": 0, "parts": [ "xlframe_horizontal", "carbonfiber_boat_hull" ] }
+    ],
+    "items": [  ]
+  },
+  {
+    "id": "raft_test",
+    "type": "vehicle",
+    "name": "raft",
+    "blueprint": [
+      [ "OO" ],
+      [ "OO" ]
+    ],
+    "parts": [
+      { "x": 1, "y": 0, "parts": [ "frame_wood_cross", "raft_board" ] },
+      { "x": 1, "y": 1, "parts": [ "frame_wood_cross", "raft_board" ] },
+      { "x": 0, "y": 0, "parts": [ "frame_wood_cross", "seat_wood", "hand_paddles", "raft_board" ] },
+      { "x": 0, "y": 1, "parts": [ "frame_wood_cross", "sail", "raft_board" ] }
+    ],
+    "items": [  ]
+  },
+  {
+    "id": "inflatable_boat_test",
+    "type": "vehicle",
+    "name": "inflatable boat",
+    "blueprint": [
+      [ "OO" ],
+      [ "OO" ]
+    ],
+    "parts": [
+      { "x": 1, "y": 0, "parts": [ "inflatable_section", "inflatable_airbag" ] },
+      { "x": 1, "y": 1, "parts": [ "inflatable_section", "inflatable_airbag" ] },
+      { "x": 0, "y": 0, "parts": [ "inflatable_section", "folding_seat", "inflatable_airbag", "hand_paddles" ] },
+      { "x": 0, "y": 1, "parts": [ "inflatable_section", "inflatable_airbag" ] }
+    ],
+    "items": [  ]
+  }
+]

--- a/tests/vehicle_collision_test.cpp
+++ b/tests/vehicle_collision_test.cpp
@@ -38,7 +38,7 @@ TEST_CASE( "vehicle_collision_with_wall_terminates", "[vehicle]" )
     auto const veh_pos = tripoint( 60, 60, 0 );
     auto const wall_pos = tripoint( 60, 59, 0 );
 
-    auto *veh_ptr = here.add_vehicle( vproto_id( "bicycle" ), veh_pos, 270_degrees, 0, 0 );
+    auto *veh_ptr = here.add_vehicle( vproto_id( "bicycle_test" ), veh_pos, 270_degrees, 0, 0 );
     REQUIRE( veh_ptr != nullptr );
 
     REQUIRE( here.ter_set( wall_pos, ter_id( "t_concrete_wall" ) ) );

--- a/tests/vehicle_drag_test.cpp
+++ b/tests/vehicle_drag_test.cpp
@@ -145,75 +145,75 @@ static void test_vehicle_drag(
 
 std::vector<std::string> vehs_to_test_drag = {
     {
-        "bicycle",
-        "bicycle_electric",
-        "motorcycle",
-        "motorcycle_sidecart",
-        "quad_bike",
-        "scooter",
-        "scooter_electric",
-        "superbike",
-        "tandem",
-        "unicycle",
-        "beetle",
-        "bubble_car",
-        "car",
-        "car_mini",
-        "car_sports",
-        "car_sports_atomic",
-        "car_sports_electric",
-        "electric_car",
-        "rara_x",
-        "suv",
-        "suv_electric",
-        "golf_cart",
-        "golf_cart_4seat",
-        "hearse",
-        "pickup_technical",
-        "ambulance",
-        "car_fbi",
-        "fire_engine",
-        "fire_truck",
-        "policecar",
-        "policesuv",
-        "truck_swat",
-        "oldtractor",
-        "autotractor",
-        "tractor_plow",
-        "tractor_reaper",
-        "tractor_seed",
-        "aapc-mg",
-        "apc",
-        "humvee",
-        "military_cargo_truck",
-        "flatbed_truck",
-        "pickup",
-        "semi_truck",
-        "truck_trailer",
-        "tatra_truck",
-        "animalctrl",
-        "autosweeper",
-        "excavator",
-        "road_roller",
-        "forklift",
-        "trencher",
-        "armored_car",
-        "cube_van",
-        "cube_van_cheap",
-        "hippie_van",
-        "icecream_truck",
-        "lux_rv",
-        "meth_lab",
-        "rv",
-        "schoolbus",
-        "security_van",
-        "wienermobile",
-        "canoe",
-        "kayak",
-        "kayak_racing",
-        "DUKW",
-        "raft",
-        "inflatable_boat",
+        "bicycle_test",
+        "bicycle_electric_test",
+        "motorcycle_test",
+        "motorcycle_sidecart_test",
+        "quad_bike_test",
+        "scooter_test",
+        "scooter_electric_test",
+        "superbike_test",
+        "tandem_test",
+        "unicycle_test",
+        "beetle_test",
+        "bubble_car_test",
+        "car_test",
+        "car_mini_test",
+        "car_sports_test",
+        "car_sports_atomic_test",
+        "car_sports_electric_test",
+        "electric_car_test",
+        "rara_x_test",
+        "suv_test",
+        "suv_electric_test",
+        "golf_cart_test",
+        "golf_cart_4seat_test",
+        "hearse_test",
+        "pickup_technical_test",
+        "ambulance_test",
+        "car_fbi_test",
+        "fire_engine_test",
+        "fire_truck_test",
+        "policecar_test",
+        "policesuv_test",
+        "truck_swat_test",
+        "oldtractor_test",
+        "autotractor_test",
+        "tractor_plow_test",
+        "tractor_reaper_test",
+        "tractor_seed_test",
+        "aapc-mg_test",
+        "apc_test",
+        "humvee_test",
+        "military_cargo_truck_test",
+        "flatbed_truck_test",
+        "pickup_test",
+        "semi_truck_test",
+        "truck_trailer_test",
+        "tatra_truck_test",
+        "animalctrl_test",
+        "autosweeper_test",
+        "excavator_test",
+        "road_roller_test",
+        "forklift_test",
+        "trencher_test",
+        "armored_car_test",
+        "cube_van_test",
+        "cube_van_cheap_test",
+        "hippie_van_test",
+        "icecream_truck_test",
+        "lux_rv_test",
+        "meth_lab_test",
+        "rv_test",
+        "schoolbus_test",
+        "security_van_test",
+        "wienermobile_test",
+        "canoe_test",
+        "kayak_test",
+        "kayak_racing_test",
+        "DUKW_test",
+        "raft_test",
+        "inflatable_boat_test",
     }
 };
 
@@ -231,73 +231,73 @@ TEST_CASE( "vehicle_drag_calc_baseline", "[.]" )
 TEST_CASE( "vehicle_drag", "[vehicle] [engine]" )
 {
     clear_all_state();
-    test_vehicle_drag( "bicycle", 0.609525, 0.017205, 43.304167, 2355, 3078 );
-    test_vehicle_drag( "bicycle_electric", 0.609525, 0.025659, 64.583333, 2754, 3268 );
-    test_vehicle_drag( "motorcycle", 0.609525, 0.569952, 254.820312, 7296, 8687 );
-    test_vehicle_drag( "motorcycle_sidecart", 0.880425, 0.859065, 455.206250, 6423, 7657 );
-    test_vehicle_drag( "quad_bike", 0.537285, 1.112797, 710.745536, 7457, 8918 );
-    test_vehicle_drag( "scooter", 0.609525, 0.158886, 119.972917, 3840, 4569 );
-    test_vehicle_drag( "scooter_electric", 0.621965, 0.139267, 105.15874, 4842, 5018 );
-    test_vehicle_drag( "superbike", 0.609525, 0.846042, 378.257812, 9912, 11797 );
-    test_vehicle_drag( "tandem", 0.609525, 0.021521, 40.625000, 2755, 3601 );
-    test_vehicle_drag( "unicycle", 0.690795, 0.002493, 25.100000, 2266, 2958 );
-    test_vehicle_drag( "beetle", 0.785610, 1.800385, 1274.482812, 8969, 10711 );
-    test_vehicle_drag( "bubble_car", 0.823988, 1.918740, 1293.586310, 9280, 9627 );
-    test_vehicle_drag( "car", 0.294604, 2.473484, 1167.310417, 11916, 14350 );
-    test_vehicle_drag( "car_mini", 0.294604, 1.816015, 1285.546875, 12157, 14580 );
-    test_vehicle_drag( "car_sports", 0.294604, 2.547639, 1442.767500, 20848, 24904 );
-    test_vehicle_drag( "car_sports_atomic", 0.294604, 3.513942, 1658.333333, 25717, 26683 );
-    test_vehicle_drag( "car_sports_electric", 0.294604, 2.295540, 1300.000000, 26090, 27054 );
-    test_vehicle_drag( "electric_car", 0.304763, 1.937966, 914.583333, 16389, 17005 );
-    test_vehicle_drag( "rara_x", 0.880425, 2.009287, 1046.336207, 8392, 8708 );
-    test_vehicle_drag( "suv", 0.294604, 2.914201, 1178.826786, 13988, 16827 );
-    test_vehicle_drag( "suv_electric", 0.304763, 2.118960, 857.142857, 16329, 16945 );
-    test_vehicle_drag( "golf_cart", 0.943313, 1.056169, 664.583333, 7104, 7367 );
-    test_vehicle_drag( "golf_cart_4seat", 0.943313, 1.023060, 643.750000, 7109, 7372 );
-    test_vehicle_drag( "hearse", 0.355556, 3.216780, 1301.223214, 11046, 13340 );
-    test_vehicle_drag( "pickup_technical", 0.838097, 2.958591, 1196.783036, 10176, 12173 );
-    test_vehicle_drag( "ambulance", 1.049323, 2.334381, 1915.936458, 11308, 13473 );
-    test_vehicle_drag( "car_fbi", 0.457144, 2.741665, 1293.872917, 14625, 17491 );
-    test_vehicle_drag( "fire_engine", 2.305875, 3.069122, 2015.178571, 8724, 10390 );
-    test_vehicle_drag( "fire_truck", 1.092446, 8.014297, 5312.766947, 10561, 12729 );
-    test_vehicle_drag( "policecar", 0.629843, 2.742769, 1294.393750, 13235, 15808 );
-    test_vehicle_drag( "policesuv", 0.629843, 3.074006, 1243.469643, 13177, 15753 );
-    test_vehicle_drag( "truck_swat", 0.808830, 7.563401, 6207.639583, 9935, 11688 );
-    test_vehicle_drag( "oldtractor", 0.537285, 0.893482, 1319.981250, 12446, 14408 );
-    test_vehicle_drag( "autotractor", 1.165945, 1.3773, 1356.5, 7718, 8005 );
-    test_vehicle_drag( "tractor_plow", 0.609525, 0.918444, 1739.562500, 11941, 13822 );
-    test_vehicle_drag( "tractor_reaper", 0.609525, 0.804219, 1523.216346, 11963, 13843 );
-    test_vehicle_drag( "tractor_seed", 0.609525, 0.804219, 1523.216346, 11963, 13843 );
-    test_vehicle_drag( "aapc-mg", 0.922995, 8.662721, 4380.208333, 9440, 11121 );
-    test_vehicle_drag( "apc", 0.922995, 8.539115, 4317.708333, 9454, 11135 );
-    test_vehicle_drag( "humvee", 0.616298, 7.288223, 4913.611607, 12935, 15175 );
-    test_vehicle_drag( "military_cargo_truck", 0.840758, 9.507160, 4387.005556, 11554, 13581 );
-    test_vehicle_drag( "flatbed_truck", 0.883328, 4.6206, 2068.5, 9376, 11371 );
-    test_vehicle_drag( "pickup", 0.589208, 3.245, 1312.51, 11194, 13450 );
-    test_vehicle_drag( "semi_truck", 0.781317, 10.083741, 5826.445833, 11718, 13797 );
-    test_vehicle_drag( "truck_trailer", 1.176534, 12.89, 5713.04, 0, 0 );
-    test_vehicle_drag( "tatra_truck", 0.440213, 7.85,  4195, 17575, 20635 );
-    test_vehicle_drag( "animalctrl", 0.345398, 2.823777, 1142.249107, 13373, 16062 );
-    test_vehicle_drag( "autosweeper", 0.741965, 1.291241, 914.062500, 7628, 7914 );
-    test_vehicle_drag( "excavator", 0.659728, 1.793523, 1269.625000, 13204, 15305 );
-    test_vehicle_drag( "road_roller", 1.823738, 2.768224, 9197.104167, 9430, 10928 );
-    test_vehicle_drag( "forklift", 0.565988, 1.095900, 517.187500, 8356, 8668 );
-    test_vehicle_drag( "trencher", 0.659728, 1.007720, 1145.192308, 7977, 8273 );
-    test_vehicle_drag( "armored_car", 0.896872, 6.982755, 4707.669643, 11645, 13619 );
-    test_vehicle_drag( "cube_van", 0.518580, 2.738, 2247, 11657, 14011 );
-    test_vehicle_drag( "cube_van_cheap", 0.512775, 2.6738, 1927, 9853, 11885 );
-    test_vehicle_drag( "hippie_van", 0.386033, 2.886681, 1167.694643, 10881, 13109 );
-    test_vehicle_drag( "icecream_truck", 0.681673, 3.686107, 1974.662162, 10726, 12873 );
-    test_vehicle_drag( "lux_rv", 1.609183, 3.662015, 2066.995614, 8453, 9826 );
-    test_vehicle_drag( "meth_lab", 0.518580, 2.948098, 2018.085106, 11800, 14147 );
-    test_vehicle_drag( "rv", 0.541800, 2.926340, 2003.191489, 11648, 13961 );
-    test_vehicle_drag( "schoolbus", 0.411188, 3.331642, 1491.510227, 12930, 15101 );
-    test_vehicle_drag( "security_van", 0.541800, 7.617575, 6252.103125, 11074, 13079 );
-    test_vehicle_drag( "wienermobile", 1.063697, 2.385608, 1957.981250, 11253, 13409 );
-    test_vehicle_drag( "canoe", 0.609525, 6.970263, 1.973684, 337, 707 );
-    test_vehicle_drag( "kayak", 0.609525, 4.036067, 1.523792, 544, 1067 );
-    test_vehicle_drag( "kayak_racing", 0.609525, 3.704980, 1.398792, 586, 1133 );
-    test_vehicle_drag( "DUKW", 0.776903, 3.8956, 84.26, 9993, 12063 );
-    test_vehicle_drag( "raft", 1.59315, 9.177513, 5.197368, 225, 477 );
-    test_vehicle_drag( "inflatable_boat", 0.469560, 3.616690, 2.048188, 602, 1173 );
+    test_vehicle_drag( "bicycle_test", 0.609525, 0.017205, 43.304167, 2355, 3078 );
+    test_vehicle_drag( "bicycle_electric_test", 0.609525, 0.025659, 64.583333, 2754, 3268 );
+    test_vehicle_drag( "motorcycle_test", 0.609525, 0.569952, 254.820312, 7296, 8687 );
+    test_vehicle_drag( "motorcycle_sidecart_test", 0.880425, 0.859065, 455.206250, 6423, 7657 );
+    test_vehicle_drag( "quad_bike_test", 0.537285, 1.112797, 710.745536, 7457, 8918 );
+    test_vehicle_drag( "scooter_test", 0.609525, 0.158886, 119.972917, 3840, 4569 );
+    test_vehicle_drag( "scooter_electric_test", 0.621965, 0.139267, 105.15874, 4842, 5018 );
+    test_vehicle_drag( "superbike_test", 0.609525, 0.846042, 378.257812, 9912, 11797 );
+    test_vehicle_drag( "tandem_test", 0.609525, 0.021521, 40.625000, 2755, 3601 );
+    test_vehicle_drag( "unicycle_test", 0.690795, 0.002493, 25.100000, 2266, 2958 );
+    test_vehicle_drag( "beetle_test", 0.785610, 1.800385, 1274.482812, 8969, 10711 );
+    test_vehicle_drag( "bubble_car_test", 0.823988, 1.918740, 1293.586310, 9280, 9627 );
+    test_vehicle_drag( "car_test", 0.294604, 2.473484, 1167.310417, 11916, 14350 );
+    test_vehicle_drag( "car_mini_test", 0.294604, 1.816015, 1285.546875, 12157, 14580 );
+    test_vehicle_drag( "car_sports_test", 0.294604, 2.547639, 1442.767500, 20848, 24904 );
+    test_vehicle_drag( "car_sports_atomic_test", 0.294604, 3.513942, 1658.333333, 25717, 26683 );
+    test_vehicle_drag( "car_sports_electric_test", 0.294604, 2.295540, 1300.000000, 26090, 27054 );
+    test_vehicle_drag( "electric_car_test", 0.304763, 1.937966, 914.583333, 16389, 17005 );
+    test_vehicle_drag( "rara_x_test", 0.880425, 2.009287, 1046.336207, 8392, 8708 );
+    test_vehicle_drag( "suv_test", 0.294604, 2.914201, 1178.826786, 13988, 16827 );
+    test_vehicle_drag( "suv_electric_test", 0.304763, 2.118960, 857.142857, 16329, 16945 );
+    test_vehicle_drag( "golf_cart_test", 0.943313, 1.056169, 664.583333, 7104, 7367 );
+    test_vehicle_drag( "golf_cart_4seat_test", 0.943313, 1.023060, 643.750000, 7109, 7372 );
+    test_vehicle_drag( "hearse_test", 0.355556, 3.216780, 1301.223214, 11046, 13340 );
+    test_vehicle_drag( "pickup_technical_test", 0.838097, 2.958591, 1196.783036, 10176, 12173 );
+    test_vehicle_drag( "ambulance_test", 1.049323, 2.334381, 1915.936458, 11308, 13473 );
+    test_vehicle_drag( "car_fbi_test", 0.457144, 2.741665, 1293.872917, 14625, 17491 );
+    test_vehicle_drag( "fire_engine_test", 2.305875, 3.069122, 2015.178571, 8724, 10390 );
+    test_vehicle_drag( "fire_truck_test", 1.092446, 8.014297, 5312.766947, 10561, 12729 );
+    test_vehicle_drag( "policecar_test", 0.629843, 2.742769, 1294.393750, 13235, 15808 );
+    test_vehicle_drag( "policesuv_test", 0.629843, 3.074006, 1243.469643, 13177, 15753 );
+    test_vehicle_drag( "truck_swat_test", 0.808830, 7.563401, 6207.639583, 9935, 11688 );
+    test_vehicle_drag( "oldtractor_test", 0.537285, 0.893482, 1319.981250, 12446, 14408 );
+    test_vehicle_drag( "autotractor_test", 1.165945, 1.3773, 1356.5, 7718, 8005 );
+    test_vehicle_drag( "tractor_plow_test", 0.609525, 0.918444, 1739.562500, 11941, 13822 );
+    test_vehicle_drag( "tractor_reaper_test", 0.609525, 0.804219, 1523.216346, 11963, 13843 );
+    test_vehicle_drag( "tractor_seed_test", 0.609525, 0.804219, 1523.216346, 11963, 13843 );
+    test_vehicle_drag( "aapc-mg_test", 0.922995, 8.662721, 4380.208333, 9440, 11121 );
+    test_vehicle_drag( "apc_test", 0.922995, 8.539115, 4317.708333, 9454, 11135 );
+    test_vehicle_drag( "humvee_test", 0.616298, 7.288223, 4913.611607, 12935, 15175 );
+    test_vehicle_drag( "military_cargo_truck_test", 0.840758, 9.507160, 4387.005556, 11554, 13581 );
+    test_vehicle_drag( "flatbed_truck_test", 0.883328, 4.6206, 2068.5, 9376, 11371 );
+    test_vehicle_drag( "pickup_test", 0.589208, 3.245, 1312.51, 11194, 13450 );
+    test_vehicle_drag( "semi_truck_test", 0.781317, 10.083741, 5826.445833, 11718, 13797 );
+    test_vehicle_drag( "truck_trailer_test", 1.176534, 12.89, 5713.04, 0, 0 );
+    test_vehicle_drag( "tatra_truck_test", 0.440213, 7.85,  4195, 17575, 20635 );
+    test_vehicle_drag( "animalctrl_test", 0.345398, 2.823777, 1142.249107, 13373, 16062 );
+    test_vehicle_drag( "autosweeper_test", 0.741965, 1.291241, 914.062500, 7628, 7914 );
+    test_vehicle_drag( "excavator_test", 0.659728, 1.793523, 1269.625000, 13204, 15305 );
+    test_vehicle_drag( "road_roller_test", 1.823738, 2.768224, 9197.104167, 9430, 10928 );
+    test_vehicle_drag( "forklift_test", 0.565988, 1.095900, 517.187500, 8356, 8668 );
+    test_vehicle_drag( "trencher_test", 0.659728, 1.007720, 1145.192308, 7977, 8273 );
+    test_vehicle_drag( "armored_car_test", 0.896872, 6.982755, 4707.669643, 11645, 13619 );
+    test_vehicle_drag( "cube_van_test", 0.518580, 2.738, 2247, 11657, 14011 );
+    test_vehicle_drag( "cube_van_cheap_test", 0.512775, 2.6738, 1927, 9853, 11885 );
+    test_vehicle_drag( "hippie_van_test", 0.386033, 2.886681, 1167.694643, 10881, 13109 );
+    test_vehicle_drag( "icecream_truck_test", 0.681673, 3.686107, 1974.662162, 10726, 12873 );
+    test_vehicle_drag( "lux_rv_test", 1.609183, 3.662015, 2066.995614, 8453, 9826 );
+    test_vehicle_drag( "meth_lab_test", 0.518580, 2.948098, 2018.085106, 11800, 14147 );
+    test_vehicle_drag( "rv_test", 0.541800, 2.926340, 2003.191489, 11648, 13961 );
+    test_vehicle_drag( "schoolbus_test", 0.411188, 3.331642, 1491.510227, 12930, 15101 );
+    test_vehicle_drag( "security_van_test", 0.541800, 7.617575, 6252.103125, 11074, 13079 );
+    test_vehicle_drag( "wienermobile_test", 1.063697, 2.385608, 1957.981250, 11253, 13409 );
+    test_vehicle_drag( "canoe_test", 0.609525, 6.970263, 1.973684, 337, 707 );
+    test_vehicle_drag( "kayak_test", 0.609525, 4.036067, 1.523792, 544, 1067 );
+    test_vehicle_drag( "kayak_racing_test", 0.609525, 3.704980, 1.398792, 586, 1133 );
+    test_vehicle_drag( "DUKW_test", 0.776903, 3.8956, 84.26, 9993, 12063 );
+    test_vehicle_drag( "raft_test", 1.59315, 9.177513, 5.197368, 225, 477 );
+    test_vehicle_drag( "inflatable_boat_test", 0.469560, 3.616690, 2.048188, 602, 1173 );
 }

--- a/tests/vehicle_efficiency_test.cpp
+++ b/tests/vehicle_efficiency_test.cpp
@@ -380,24 +380,24 @@ static void test_vehicle(
 }
 
 std::vector<std::string> vehs_to_test = {{
-        "beetle",
-        "car",
-        "car_sports",
-        "electric_car",
-        "suv",
-        "motorcycle",
-        "quad_bike",
-        "scooter",
-        "superbike",
-        "ambulance",
-        "fire_engine",
-        "fire_truck",
-        "truck_swat",
-        "tractor_plow",
-        "apc",
-        "humvee",
-        "road_roller",
-        "golf_cart"
+        "beetle_test",
+        "car_test",
+        "car_sports_test",
+        "electric_car_test",
+        "suv_test",
+        "motorcycle_test",
+        "quad_bike_test",
+        "scooter_test",
+        "superbike_test",
+        "ambulance_test",
+        "fire_engine_test",
+        "fire_truck_test",
+        "truck_swat_test",
+        "tractor_plow_test",
+        "apc_test",
+        "humvee_test",
+        "road_roller_test",
+        "golf_car_testt"
     }
 };
 
@@ -436,42 +436,42 @@ TEST_CASE( "make_vehicle_efficiency_case", "[.]" )
 TEST_CASE( "vehicle_efficiency", "[vehicle] [engine]" )
 {
     clear_all_state();
-    test_vehicle( "beetle", 818837, 431300, 338700, 95610, 68060 );
-    test_vehicle( "car", 1125629, 617500, 386100, 52730, 25170 );
-    test_vehicle( "car_sports", 1157382, 352600, 267600, 36790, 22350 );
-    test_vehicle( "electric_car", 879098, 183880, 127125, 13410, 8705 );
-    test_vehicle( "suv", 1325297, 1163000, 614130, 85540, 32000 );
-    test_vehicle( "motorcycle", 163085, 120300, 99930, 63320, 50810 );
-    test_vehicle( "quad_bike", 264465, 116100, 116100, 46770, 46770 );
-    test_vehicle( "scooter", 57587, 233500, 233500, 167900, 167900 );
-    test_vehicle( "superbike", 244085, 109800, 65300, 41780, 24070 );
-    test_vehicle( "ambulance", 1854071, 613400, 504700, 77700, 57139 );
-    test_vehicle( "fire_engine", 2257115, 1938615, 1819475, 394660, 363895 );
-    test_vehicle( "fire_truck", 6319523, 410700, 83850, 19080, 4063 );
-    test_vehicle( "truck_swat", 5906166, 674453, 134446, 29610, 7604 );
-    test_vehicle( "tractor_plow", 725658, 681200, 681200, 132400, 132400 );
-    test_vehicle( "apc", 5797694, 2091626, 2091626, 110600, 110657 );
-    test_vehicle( "humvee", 5516216, 768000, 565000, 25620, 17450 );
-    test_vehicle( "road_roller", 8831804, 602500, 147100, 22760, 6925 );
-    test_vehicle( "golf_cart", 319630, 49585, 47185, 22700, 12745 );
+    test_vehicle( "beetle_test", 818837, 431300, 338700, 95610, 68060 );
+    test_vehicle( "car_test", 1125629, 617500, 386100, 52730, 25170 );
+    test_vehicle( "car_sports_test", 1157382, 352600, 267600, 36790, 22350 );
+    test_vehicle( "electric_car_test", 879098, 183880, 127125, 13410, 8705 );
+    test_vehicle( "suv_test", 1325297, 1163000, 614130, 85540, 32000 );
+    test_vehicle( "motorcycle_test", 163085, 120300, 99930, 63320, 50810 );
+    test_vehicle( "quad_bike_test", 264465, 116100, 116100, 46770, 46770 );
+    test_vehicle( "scooter_test", 57587, 233500, 233500, 167900, 167900 );
+    test_vehicle( "superbike_test", 244085, 109800, 65300, 41780, 24070 );
+    test_vehicle( "ambulance_test", 1854071, 613400, 504700, 77700, 57139 );
+    test_vehicle( "fire_engine_test", 2257115, 1938615, 1819475, 394660, 363895 );
+    test_vehicle( "fire_truck_test", 6319523, 410700, 83850, 19080, 4063 );
+    test_vehicle( "truck_swat_test", 5906166, 674453, 134446, 29610, 7604 );
+    test_vehicle( "tractor_plow_test", 725658, 681200, 681200, 132400, 132400 );
+    test_vehicle( "apc_test", 5797694, 2091626, 2091626, 110600, 110657 );
+    test_vehicle( "humvee_test", 5516216, 768000, 565000, 25620, 17450 );
+    test_vehicle( "road_roller_test", 8831804, 602500, 147100, 22760, 6925 );
+    test_vehicle( "golf_cart_test", 319630, 49585, 47185, 22700, 12745 );
 
     // in reverse
-    test_vehicle( "beetle", 818837, 58970, 58870, 44560, 43060, 0, 0, true );
-    test_vehicle( "car", 1125629, 76060, 76060, 44230, 24870, 0, 0, true );
-    test_vehicle( "car_sports", 1157382, 353200, 268000, 35200, 19540, 0, 0, true );
-    test_vehicle( "electric_car", 879098, 133100, 72520, 8140, 3390, 0, 0, true );
-    test_vehicle( "suv", 1325297, 112000, 111800, 66880, 31670, 0, 0, true );
-    test_vehicle( "motorcycle", 163085, 19980, 19030, 15490, 14890, 0, 0, true );
-    test_vehicle( "quad_bike", 264465, 19650, 19650, 15440, 15440, 0, 0, true );
-    test_vehicle( "scooter", 57587, 62440, 62440, 47990, 47990, 0, 0, true );
-    test_vehicle( "superbike", 244085, 18320, 10570, 13070, 8497, 0, 0, true );
-    test_vehicle( "ambulance", 1854071, 58460, 57780, 42480, 39130, 0, 0, true );
-    test_vehicle( "fire_engine", 2257115, 258000, 257800, 179800, 173300, 0, 0, true );
-    test_vehicle( "fire_truck", 6319523, 58480, 58640, 18600, 4471, 0, 0, true );
-    test_vehicle( "truck_swat", 5906166, 129300, 130100, 29350, 7668, 0, 0, true );
-    test_vehicle( "tractor_plow", 725658, 72240, 72240, 53610, 53610, 0, 0, true );
-    test_vehicle( "apc", 5830459, 418700, 419400, 107300, 74330, 0, 0, true );
-    test_vehicle( "humvee", 5531381, 89940, 89940, 25780, 9086, 0, 0, true );
-    test_vehicle( "road_roller", 8831804, 97490, 97690, 22880, 6606, 0, 0, true );
-    test_vehicle( "golf_cart", 319630, 37140, 11510, 14110, 4450, 0, 0, true );
+    test_vehicle( "beetle_test", 818837, 58970, 58870, 44560, 43060, 0, 0, true );
+    test_vehicle( "car_test", 1125629, 76060, 76060, 44230, 24870, 0, 0, true );
+    test_vehicle( "car_sports_test", 1157382, 353200, 268000, 35200, 19540, 0, 0, true );
+    test_vehicle( "electric_car_test", 879098, 133100, 72520, 8140, 3390, 0, 0, true );
+    test_vehicle( "suv_test", 1325297, 112000, 111800, 66880, 31670, 0, 0, true );
+    test_vehicle( "motorcycle_test", 163085, 19980, 19030, 15490, 14890, 0, 0, true );
+    test_vehicle( "quad_bike_test", 264465, 19650, 19650, 15440, 15440, 0, 0, true );
+    test_vehicle( "scooter_test", 57587, 62440, 62440, 47990, 47990, 0, 0, true );
+    test_vehicle( "superbike_test", 244085, 18320, 10570, 13070, 8497, 0, 0, true );
+    test_vehicle( "ambulance_test", 1854071, 58460, 57780, 42480, 39130, 0, 0, true );
+    test_vehicle( "fire_engine_test", 2257115, 258000, 257800, 179800, 173300, 0, 0, true );
+    test_vehicle( "fire_truck_test", 6319523, 58480, 58640, 18600, 4471, 0, 0, true );
+    test_vehicle( "truck_swat_test", 5906166, 129300, 130100, 29350, 7668, 0, 0, true );
+    test_vehicle( "tractor_plow_test", 725658, 72240, 72240, 53610, 53610, 0, 0, true );
+    test_vehicle( "apc_test", 5830459, 418700, 419400, 107300, 74330, 0, 0, true );
+    test_vehicle( "humvee_test", 5531381, 89940, 89940, 25780, 9086, 0, 0, true );
+    test_vehicle( "road_roller_test", 8831804, 97490, 97690, 22880, 6606, 0, 0, true );
+    test_vehicle( "golf_cart_test", 319630, 37140, 11510, 14110, 4450, 0, 0, true );
 }


### PR DESCRIPTION
## Purpose of change (The Why)
Prevents things like #8289 from being blocked due to tests
Protects my sanity
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Add a substancial number of vehicle definitions to TEST_DATA all with _test after them for testing purposes

## Describe alternatives you've considered
None

## Testing
Tests pass
Tests no longer depend on game data

## Additional context
Can we remove that data dir from tests itself at some point

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.