### PR TITLE
feat(UI): prioritize hostile targets on aiming

### DIFF
--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -2954,8 +2954,6 @@ void target_ui::update_target_list()
         return;
     }
 
-    // Get targets in range and sort them by distance (targets[0] is the closest)
-
     if( mode == TargetMode::TurretManual ) {
         targets = ranged::targetable_creatures( *you, range, *turret );
     } else {
@@ -2965,11 +2963,12 @@ void target_ui::update_target_list()
     map &here = get_map();
     const auto player_pos = you->pos();
 
-    std::ranges::sort( targets, {}, [&]( const Creature * c ) -> std::tuple<bool, bool, int> {
+    std::ranges::sort( targets, {}, [&]( const Creature * c ) -> std::tuple<bool, bool, bool, int> {
         const auto target_pos = c->pos();
-        const bool same_z = player_pos.z == target_pos.z;
-        const bool has_los = here.sees( player_pos, target_pos, range );
-        return { !has_los, !same_z, rl_dist_exact( target_pos, player_pos ) };
+        const auto z_diff = std::abs( player_pos.z - target_pos.z );
+        const auto is_hostile = c->attitude_to( *you ) == Attitude::A_HOSTILE;
+        const auto has_los = here.sees( player_pos, target_pos, range );
+        return { !has_los, !is_hostile, z_diff, rl_dist_exact( target_pos, player_pos ) };
     } );
 }
 


### PR DESCRIPTION
## Purpose of change (The Why)

continuation of #7562

devcord mentioned https://github.com/CleverRaven/Cataclysm-DDA/pull/85765 and yeah that'd be a good idea.

## Describe the solution (The How)

on `target_ui::update_target_list()`:
- take hostility into account 
- also sort by z-level diff

## Testing

| before | after |
| - | - |
| <img width="1410" height="850" alt="image" src="https://github.com/user-attachments/assets/139c568d-33a4-4afe-ad32-a8fdbb1f4bfe" /> |  <img width="1410" height="850" alt="image" src="https://github.com/user-attachments/assets/115daf5a-6d98-4c54-9ec1-e86de552d110" /> | <img width="1410" height="850" alt="image" src="https://github.com/user-attachments/assets/e7cac8be-41e7-46f1-97a1-8ca5df38d631" /> |

1. spawn zombie and neutral NPC
2. after PR zombies are targeted first. 

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
