### PR TITLE
feat(balance): add cross-z melee difficulty modifier

### DIFF
--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -52,6 +52,7 @@
 #include "mtype.h"
 #include "mutation.h"
 #include "npc.h"
+#include "options.h"
 #include "output.h"
 #include "player.h"
 #include "pldata.h"
@@ -78,6 +79,23 @@ static const itype_id itype_rag( "rag" );
 static const matec_id tec_none( "tec_none" );
 static const matec_id WBLOCK_1( "WBLOCK_1" );
 static const matec_id WBLOCK_2( "WBLOCK_2" );
+
+namespace
+{
+
+auto with_cross_z_melee_cost( const int base_cost, const tripoint &source,
+                              const tripoint &target ) -> int
+{
+    if( std::abs( source.z - target.z ) < 1 ) {
+        return base_cost;
+    }
+
+    const auto modifier = get_option<float>( "CROSS_Z_LEVEL_MELEE_DIFFICULTY_MODIFIER" );
+    return static_cast<int>( std::floor( base_cost * modifier ) );
+}
+
+} // namespace
+
 static const matec_id WBLOCK_3( "WBLOCK_3" );
 
 static const skill_id skill_stabbing( "stabbing" );
@@ -503,7 +521,7 @@ void Character::melee_attack( Creature &t, bool allow_special, const matec_id *f
         return;
     }
 
-    int move_cost = attack_cost( cur_weapon );
+    int move_cost = with_cross_z_melee_cost( attack_cost( cur_weapon ), pos(), t.pos() );
 
     if( !attack_hit ) {
         // Lua imelee on_miss callback
@@ -690,7 +708,8 @@ void Character::melee_attack( Creature &t, bool allow_special, const matec_id *f
         }
     }
 
-    const int mod_sta = -get_melee_stamina_cost( cur_weapon );
+    const int mod_sta = -with_cross_z_melee_cost( get_melee_stamina_cost( cur_weapon ), pos(),
+                        t.pos() );
     mod_stamina( std::min( -50, mod_sta ) );
     add_msg( m_debug, "Stamina burn: %d", std::min( -50, mod_sta ) );
     mod_moves( -move_cost );
@@ -729,7 +748,7 @@ void Character::reach_attack( const tripoint &p )
     // Max out recoil
     recoil = MAX_RECOIL;
 
-    int move_cost = attack_cost( primary_weapon() );
+    int move_cost = with_cross_z_melee_cost( attack_cost( primary_weapon() ), pos(), p );
     int skill = std::min( 10, get_skill_level( skill_stabbing ) );
     int t = 0;
     std::vector<tripoint> path = line_to( pos(), p, t, 0 );

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2749,6 +2749,12 @@ void options_manager::add_options_world_default()
          0.01, 10.0, 1.0, 0.01
        );
 
+    add( "CROSS_Z_LEVEL_MELEE_DIFFICULTY_MODIFIER", world_default,
+         translate_marker( "Cross z-level melee difficulty modifier" ),
+         translate_marker( "A scaling factor that determines additional move and stamina cost for melee attacks against a target above or below you.  1.00 disables the modifier." ),
+         1.00, 3.00, 1.20, 0.01
+       );
+
     add_empty_line();
 
     add_option_group( world_default, Group( "skill_buff_category",


### PR DESCRIPTION
## Purpose of change (The Why)

- bit more penalty for roof cheesing (like #8317)
- it's harder to spear things over or under a floor IRL
- of course it can be turned off completely

## Describe the solution (The How)

- Added cross-z melee difficulty option
- multiplies to movecost and stamina usage
- can be set to 1.00 (min, no penalty) to 3.00, defaults to 1.20

## Testing

<img width="1410" height="850" alt="image" src="https://github.com/user-attachments/assets/69681940-aece-46d1-8ed4-8457c18dcec1" />


copper spear at multiplier 3x:

<img width="1410" height="850" alt="image" src="https://github.com/user-attachments/assets/1f759b12-df3c-4fc4-847a-27713bc32868" />

same z-level: move 1s, stamina 120

<img width="1410" height="850" alt="image" src="https://github.com/user-attachments/assets/5d0cf17e-ffff-4444-b810-473d54a1d3ab" />

1 z-level above: move 3s, stamina 360

## Additional context

idea from https://github.com/CleverRaven/Cataclysm-DDA/pull/85753

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
