### PR TITLE
fix(i18n): add "sound_effect" to ignorable list

### DIFF
--- a/lang/extract_json_strings.py
+++ b/lang/extract_json_strings.py
@@ -128,6 +128,7 @@ ignorable = {
     "vehicle_group",
     "vehicle_placement",
     "WORLD_OPTION",
+    "sound_effect",
 }
 
 # these objects can have their strings automatically extracted.


### PR DESCRIPTION
---


`fix(i18n): add "sound_effect" to ignorable list in extract_json_strings.py`

---


The translation extraction script `lang/extract_json_strings.py` currently crashes when it encounters a JSON object with `type: sound_effect`.
<img width="1223" height="359" alt="image" src="https://github.com/user-attachments/assets/8100587e-1592-4867-bb8f-719e8f943e48" />

Since `sound_effect` objects only contain technical data (ID, volume, and file paths) and no translatable strings, the script should ignore them.


Added `"sound_effect"` to the `ignorable` set in `lang/extract_json_strings.py`. This allows the script to safely skip these objects during the POT file generation process.

1. Ran the script against a JSON file containing a `sound_effect` object.
2. Verified that the "Unrecognized object type 'sound_effect'" error no longer occurs.
3. Verified that the script completes execution successfully.

<img width="320" height="195" alt="image" src="https://github.com/user-attachments/assets/dc43edcb-ad6c-4ca4-8853-1b6737540b05" />


---

