### PR TITLE
fix: make grid water purifier constructable

### DIFF
--- a/data/json/construction/construct_workshop.json
+++ b/data/json/construction/construct_workshop.json
@@ -613,6 +613,26 @@
   },
   {
     "type": "construction",
+    "id": "constr_gridwater_purifier",
+    "group": "install_water_purifier",
+    "category": "WORKSHOP",
+    "required_skills": [ [ "mechanics", 2 ], [ "electronics", 1 ] ],
+    "time": "30 m",
+    "qualities": [ [ { "id": "SCREW", "level": 1 } ], [ { "id": "WRENCH", "level": 1 } ] ],
+    "using": [ [ "soldering_standard", 20 ] ],
+    "components": [
+      [ [ "water_purifier", 1 ] ],
+      [ [ "cable", 5 ] ],
+      [ [ "power_supply", 1 ] ],
+      [ [ "hose", 1 ], [ "makeshift_hose", 1 ] ],
+      [ [ "cu_pipe", 2 ] ]
+    ],
+    "pre_note": "Will only work if constructed in/on a building that has an electric grid with a mounted battery.  Connect it to a fluid grid to purify water.",
+    "pre_special": "check_empty",
+    "post_furniture": "f_water_purifier_off"
+  },
+  {
+    "type": "construction",
     "id": "constr_gridcraftrig",
     "group": "place_craftrig",
     "category": "WORKSHOP",

--- a/data/json/construction_group.json
+++ b/data/json/construction_group.json
@@ -1331,6 +1331,11 @@
   },
   {
     "type": "construction_group",
+    "id": "install_water_purifier",
+    "name": "Install Water Purifier"
+  },
+  {
+    "type": "construction_group",
     "id": "place_craftrig",
     "name": "Place FOODCO Kitchen Buddy"
   },


### PR DESCRIPTION
followup to https://github.com/cataclysmbn/Cataclysm-BN/pull/8102

## Testing

<img width="1410" height="850" alt="image" src="https://github.com/user-attachments/assets/eb633914-7b7b-4a73-b09b-34038dd586b0" />
<img width="1410" height="850" alt="image" src="https://github.com/user-attachments/assets/7ee629af-83fe-4d0f-ab7c-8203cae29e5c" />
<img width="1410" height="850" alt="image" src="https://github.com/user-attachments/assets/91b968be-54da-4ae1-9e54-5c8f8cf3f215" />
<img width="1410" height="850" alt="image" src="https://github.com/user-attachments/assets/48ebaa89-2ec3-4418-968d-3a9df1eb46fe" />
<img width="1410" height="850" alt="image" src="https://github.com/user-attachments/assets/76725fbd-22ed-4728-99af-41aaeb21ff98" />

1. enable debug hammerspace
2. confirm water purifier is buildable and works