### PR TITLE
fix: fix diggable transform terrain vehicle parts

### DIFF
--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -1386,7 +1386,6 @@ void vehicle::transform_terrain()
     for( const vpart_reference &vp : get_enabled_parts( "TRANSFORM_TERRAIN" ) ) {
         const tripoint start_pos = vp.pos();
         const transform_terrain_data &ttd = vp.info().transform_terrain;
-        const transform_terrain_data &ttd = vp.info().transform_terrain;
         bool prereq_fulfilled = ttd.diggable && g->m.ter( start_pos )->is_diggable();
         for( const std::string &flag : ttd.pre_flags ) {
             if( g->m.has_flag( flag, start_pos ) ) {


### PR DESCRIPTION
## Purpose of change (The Why)
Rockwheel not work
Fix: #8304

## Describe the solution (The How)
Fix rockwheel

## Describe alternatives you've considered
Splode

## Testing
Rockwheel dig

## Additional context
Loop not run annoying

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.