### PR TITLE
perf: fix extreme lag (20x) when clutter intolerant

### DIFF
--- a/data/json/lua_traits.lua
+++ b/data/json/lua_traits.lua
@@ -228,7 +228,6 @@ local function tick_morale_traits()
       you:rem_morale(morale_outdoor_misery)
     end
   end
-
 end
 
 local function tick_clutter_intolerant()

--- a/data/json/preload.lua
+++ b/data/json/preload.lua
@@ -16,6 +16,6 @@ end)
 
 gapi.add_on_every_x_hook(TimeDuration.from_turns(300), function(...)
   if mod.on_clutter_intolerant_tick then mod.on_clutter_intolerant_tick(...) end
-end )
+end)
 
 game.add_hook("on_character_try_move", function(...) return mod.on_character_try_move(...) end)


### PR DESCRIPTION
## Purpose of change (The Why)
Fixes: #8319 

## Describe the solution (The How)
Increase tick duration from once per turn to once per 5 minutes
Apply sanity checks to code

## Describe alternatives you've considered
Remove sanity checks
Implement the cache that it implemented but didn't use

## Testing
### Before
<img width="1920" height="1080" alt="2026-03-16-230744_1920x1080_scrot" src="https://github.com/user-attachments/assets/47c9f03b-259e-4dab-9e0e-1c978906e354" />

### After
<img width="1920" height="1080" alt="2026-03-16-230546_1920x1080_scrot" src="https://github.com/user-attachments/assets/99741304-0445-43a5-a71e-65ca815baa29" />

## Additional context
~~Finally I have a performance PR that has big number~~

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.