### PR TITLE
feat(balance): nerf senior citizen profession with elderly traits

### DIFF
--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -3939,7 +3939,7 @@
     "name": "Senior Citizen",
     "description": "You haven't seen this much blood since the war.  The whole world's gone crazy!  They ate your grandkids!  But dagnabbit, you'll make them all pay for what they've done.",
     "points": 0,
-	"traits": [ "BADKNEES", "BADBACK", "BADHEARING", "BADCARDIO", "SLOWRUNNER", "HYPEROPIC" ],
+    "traits": [ "BADKNEES", "BADBACK", "BADHEARING", "BADCARDIO", "SLOWRUNNER", "HYPEROPIC" ],
     "items": {
       "both": {
         "items": [ "tobacco", "pipe_tobacco", "ref_lighter", "socks", "dress_shoes", "knit_scarf" ],


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

Senior Citizen was a completely pointless profession. It was basically just a reskinned survivor with slightly fancy casual clothes and a tobacco pipe.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

Made the senior citizen, which is clearly intended to be a parody role of the porch-shouting rocking chair elderly american, more fleshed out.

They have the typical signs of old age in retirement now - bad back, bad knees, bad cardio, far-sighted [since stereotypical old people are portrayed needing reading glasses], and slow running.

## Describe alternatives you've considered

I also considered making them clumsy to represent just generally not moving very well anymore due to joint calcification, old injuries that never healed properly, or just "bad" joints,  but felt that might go from satirical to outright cartoonish.

The thought did cross my mind of making them also have psychosis to represent "since the war", with the random hallucinations standing in for "flashbacks from the war" but that felt a little silly.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->
<img width="1600" height="900" alt="cataclysm-bn-tiles_zhgJ2DNY3i" src="https://github.com/user-attachments/assets/9bdafdec-3d0e-4fe9-a473-79a60c2fd9d4" />

Tried new character screen. All traits displaying as intended.



## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

I'm well aware this is supposed to just be a joke profession. I thought the joke worked better when it's complete in this way.

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.