### PR TITLE
feat: add cotton seeds from cotton boll recipe

### DIFF
--- a/data/json/recipes/food/seeds.json
+++ b/data/json/recipes/food/seeds.json
@@ -746,5 +746,18 @@
     "qualities": [ { "id": "CUT", "level": 1 } ],
     "components": [ [ [ "mycus_fruit", 1 ] ] ],
     "flags": [ "ALLOW_ROTTEN" ]
+  },
+  {
+    "result": "seed_cotton_boll",
+    "type": "recipe",
+    "category": "CC_FOOD",
+    "subcategory": "CSC_FOOD_SEEDS",
+    "skill_used": "survival",
+    "difficulty": 2,
+    "time": "5 m",
+    "autolearn": true,
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "cotton_boll", 1 ] ] ],
+    "flags": [ "ALLOW_ROTTEN" ]
   }
 ]


### PR DESCRIPTION
## Purpose of change (The Why)
Cotton seeds can only be crafted as a byproducting of crafting cotton balls from cotton bolls. This hides the ability to craft the seeds from the general interface and implies only tailors can extract seeds from bolls for replanting.

## Describe the solution (The How)
Adds a discreet recipe for crafting cotton seeds from cotton boll. Previously, cotton seeds are a byproduct of crafting cotton ball from cotton boll. This recipe allows a farmer to create seeds from the boll. This recipe is in-line with other food/seed recipes and uses the same basic values.

## Describe alternatives you've considered
A duplicate cotton ball recipe listed as cotton seeds. So that the player can search for, and find the cotton seed recipe and still craft the cotton ball at the same time. Basically, a duplicate cotton ball recipe renamed cotton seeds.

## Testing
Loaded an existing save and observed the recipe in the interface.

## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
