### PR TITLE
fix: lower volume of BP-12 to not have a bullpup be much bigger than comparable guns

### DIFF
--- a/data/json/items/gun/shot.json
+++ b/data/json/items/gun/shot.json
@@ -719,7 +719,7 @@
     "name": { "str": "BP-12" },
     "description": "A bullpup, magazine fed, semi-automatic shotgun, possessing the accuracy of a full-length barrel in a compact frame.",
     "weight": "3628 g",
-    "volume": "3443 ml",
+    "volume": "2250 ml",
     "price": "325 USD",
     "price_postapoc": "475 USD",
     "material": [ "steel", "plastic" ],


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

Somehow force-pushing changes in https://github.com/cataclysmbn/Cataclysm-BN/pull/8312 undid a commit I made that sanity-checked the volume of the new BP-12 bullpup shotgun so it's actually smaller than the saiga-12, which is important when there's not many other ways to actually represent the gun being a bullpup in game stat terms.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

Lowered item volume from hyper-realismic value of 3443 ml to 2250 ml. Decided to go a step further than my initial proposed change and make it 500 ml lower in volume than the saiga instead of only 250 ml lower.

## Describe alternatives you've considered

1. Also lowering the weight? I didn't do this for other bullpups during https://github.com/cataclysmbn/Cataclysm-BN/pull/7032 so eh.
2. Adding some other stat changes to make it more distinct from the saiga?
3. Only making it 250 ml smaller like I originally changed it in the initial PR?

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

Used my eyes plus elementary-school-level mathematics to confirm that 2250 is a smaller number than 3443.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

<img width="131" height="46" alt="image" src="https://github.com/user-attachments/assets/d14609ed-f8a1-4de0-9a9f-7fb0277dae9c" />

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
