### PR TITLE
fix(mods/crt_expansion): C.R.I.T EM Vest and C.R.I.T Gas Mask recharging fix

### DIFF
--- a/data/mods/CRT_EXPANSION/items/crt_toolarmor.json
+++ b/data/mods/CRT_EXPANSION/items/crt_toolarmor.json
@@ -362,5 +362,34 @@
     },
     "armor_data": { "covers": [ "leg_either" ], "coverage": 5, "encumbrance": 2, "material_thickness": 2 },
     "flags": [ "WAIST", "COMPACT", "OVERSIZE", "WATER_FRIENDLY", "ALLOWS_TAIL_SNAKE" ]
+  },
+  {
+    "id": "crt_good_med_kit",
+    "type": "TOOL_ARMOR",
+    "looks_like": "1st_aid",
+    "name": "Advanced C.R.I.T. med kit",
+    "description": "C.R.I.T. special-issue med kit designed for repeated use. Uses photosynthesis to slowly regenerate the integrated antiseptic based on cattail jelly.",
+    "weight": "500 g",
+    "volume": "750 ml",
+    "price": "2500 USD",
+    "price_postapoc": "250 USD",
+    "to_hit": -1,
+    "bashing": 2,
+    "material": [ "superalloy", "ceramic" ],
+    "symbol": ";",
+    "color": "green",
+    "initial_charges": 0,
+    "max_charges": 42,
+    "charges_per_use": 1,
+    "relic_data": { "recharge_scheme": [ { "type": "solar", "interval": "2 h", "rate": 1 } ] },
+    "use_action": {
+      "type": "heal",
+      "disinfectant_power": 3,
+      "bite": 0.5,
+      "move_cost": 100,
+      "effects": [ { "id": "pkill1", "duration": 720 } ]
+    },
+    "armor_data": { "covers": [ "leg_either" ], "coverage": 5, "encumbrance": 2, "material_thickness": 2 },
+    "flags": [ "WAIST", "COMPACT", "OVERSIZE", "WATER_FRIENDLY", "ALLOWS_TAIL_SNAKE" ]
   }
 ]


### PR DESCRIPTION

## Purpose of change (The Why)

Fixing 

## Describe the solution (The How)

Add "     "ammo": "battery"," in crt_toolarmor.json

## Describe alternatives you've considered
 None
## Testing

Now charging normally

## Additional context

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/943d679b-666c-4857-856b-e2fd2c9df992" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/84789421-0883-4fca-a9e4-da46e7b903e7" />


## Checklist

### Mandatory

- [ ] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [ ] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional


- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have added [`port` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#port%3A-ports-from-dda-or-other-forks) to the PR title.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR adds/removes a mod.
  - [ ] I have added [`mods` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#mods-or-mods%2F<mod_id>%3A-mods) to the PR title.
  - [ ] The `mod_name` in `data/mods/<mod_name>` matches `id` in `modinfo.json`.
  - [ ] I have committed the output of `deno task semantic`.
- [ ] This PR modifies lua scripts or the lua API.
  - [ ] I have added [`lua` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#lua%3A-changes-to-lua-api) to the PR title.
  - [ ] I have added [type annotations](https://emmylua.github.io/annotation.html) to functions so that it's safe and easy to maintain.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
