### PR TITLE
fix: Plutonium batteries now charge when outside the reality bubble, plutonium batteries now recharge while stashed

### DIFF
--- a/src/relic.cpp
+++ b/src/relic.cpp
@@ -461,10 +461,16 @@ bool process_recharge_entry( item &itm, const relic_recharge &rech, Character *c
         }
     }
     int rate_multiplier = 1; // Not quite sure where to put this
+    int ticks;
     if( rech.type == relic_recharge_type::time ) {
-        time_duration elapsed = calendar::turn - time_point::from_turn( itm.get_var( "last_relic_process",
-                                0.0 ) );
-        int ticks = elapsed / rech.interval;
+        int last_relic_process = itm.get_var( "last_relic_process", 0 );
+        if( last_relic_process == 0 &&
+            carrier ) { // We do not want batteries to fully charge while in a player's inventory
+            ticks = 1;
+        } else {
+            time_duration elapsed = calendar::turn - time_point::from_turn( last_relic_process );
+            ticks = elapsed / rech.interval;
+        }
         if( ticks > 0 ) {
             rate_multiplier = ticks;
         }


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->
fixes #8298
fixes #8119 (By sheer coincidence!)

## Describe the solution (The How)

<!-- e.g nerfs monster A -->
Taking a look around the code, it appears there is no kind of mechanism to take into account the time since an item it was last processed, apart for food rotting. This is why time-based charging relics don't charge out of the bubble, they are effectively frozen. This PR adds a `last_relic_process` variable to the item via `set_var`.

Ideally, the `last_relic_process` is set to the current time everytime `relic_process` is called. When the item is out of the bubble, the `last_relic_process` stops getting updated. When the item is back in the bubble, `last_relic_process` will be a certain amount of time, which is taken into account during `relic_process`, charging the relic appropriately.

The initial value is set to ~~calendar::turn_zero, like the rot timer~~ 0.0(implicitly casted to `int`, so equivalent to `calendar::turn_zero`). Just like you'd find rotten fresh food after a year, you'd find a plutonium battery to be fully charged after a year.

## Describe alternatives you've considered

Ideally you'd want a single, universal timer to be used for all the "catch-up" needs, but I do not feel confident as of right now to perform such a refactor. Perhaps it will be one of my future PRs?

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->
Keep in mind, plutonium batteries recharge 1% every 12 minutes. In the case of the light plutonium battery, it's 4 charges every 12 minutes.
For #8119:
Spawn electrified rapier, put empty light plutonium battery inside it. Put it inside worn survival belt. Wait 36 minutes. Expected charges are (36/12)*4=12.
Take out electrified rapier. Still at 0. Wait another 12 minutes. Charges are now at 16. Catch-up **does** work, albeit with a small caveat. See additional context.`*`

For #8298:
Activate electrified rapier to discharge the battery completely. Take out battery that is now completely drained, and drop it. Location is 0,-96,-70. Teleport to 0,-65,-70. Wait for 120 minutes. Expected charges are (120/12)*4=40. Teleport back to 0,-96,-70. Charges are still 0. Wait another 12 minutes. Charges are now... 1000/1000? Perhaps it's the teleport? 

Discharge battery again. Teleport to 0,-65,70 again. Note the time. 6:20:31 PM. Walk back to 0,-96,-70. Time is now 6:34:50PM. Expected charges are 40. Battery is still at 0. Wait 12 minutes. Battery is at now 1000/1000. Turn to ash right at my desk.`**`

Both tests now work as of commit [d571c1e](https://github.com/cataclysmbn/Cataclysm-BN/pull/8342/commits/d571c1ec8ad3eca5f94d62ce28d3ec6bbe33e4b6)!

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
`*`Catch-up works correctly when inside items that are stashed away, but since the process_relic is only triggered every interval, the charge is not updated when the item is taken out, but on the next interval. I am not sure if fixing this is in the scope of this PR, but it's most likely something I'll get onto eventually. For now I'll settle for what I got.

`**`The likely reason for this is that the `last_relic_check` is not saved to disk when unloading the item, and is instead set to the default value when loaded, which is `calendar::turn`. Fixing this should be as easy as adding the field in whatever list of properties is saved when the item is unloaded.

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->
I'm following more or less what last_rot_check does for this (except being used for rot checking, obviously)
- [x] Add the variable in a suitable place, and wherever it is needed
- [x] Actually use it during relic processing, take it into account during time-based relic charging
- [x] Does it _actually_ work? Yes!
- [x] Fix the fully charging bug (Fixed as of [c1ca81d](https://github.com/cataclysmbn/Cataclysm-BN/pull/8342/commits/c1ca81db589f9fb9b1fe1178a3e6f4ab11179ba6))

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Addendum

This is my absolute first PR and occasion on working on any Cataclysm codebase, or big C++ codebase in general. It's very likely that I will get things wrong, forget to add things where they are needed, and so on. If something is usually done in a way that I did not follow, please do tell, as I assume there is a certain "good way" to contribute to the code.

