### PR TITLE
fix: Use Constant for Character Transfer Forced Tab

### DIFF
--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -534,7 +534,7 @@ bool avatar::create( character_type type, const std::string &tempname )
         }
 
         if( points.limit == points_left::TRANSFER ) {
-            tab = 6;
+            tab = NEWCHAR_TAB_MAX;
         }
 
         switch( tab ) {


### PR DESCRIPTION
## Purpose of change (The Why)

Resolves #8343

## Describe the solution (The How)

Uses correct constant rather than hard coded value of 6 that became incorrect when bionics tab was added.

## Describe alternatives you've considered

Setting the value to 7 like a lemon.

## Testing

I didn't, fight me.

## Additional context

I was busy so I did this via github itself.