### PR TITLE
fix(lua): avoid double-free during callback teardown

### DIFF
--- a/src/catalua.cpp
+++ b/src/catalua.cpp
@@ -890,6 +890,10 @@ int get_lua_api_version()
 
 void lua_state_deleter::operator()( lua_state *state ) const
 {
+    cata::lua_action_menu::clear_entries();
+    bionic_callback_actors.clear();
+    mutation_callback_actors.clear();
+    get_hook_cache().clear();
     delete state;
 }
 

--- a/src/catalua_icallback_actor.cpp
+++ b/src/catalua_icallback_actor.cpp
@@ -15,8 +15,8 @@ lua_iuse_actor::lua_iuse_actor( const std::string &type,
                                 sol::protected_function &&use_func,
                                 sol::protected_function &&can_use_func )
     : iuse_actor( type ),
-      use_func( use_func ),
-      can_use_func( can_use_func ) {}
+      use_func( std::move( use_func ) ),
+      can_use_func( std::move( can_use_func ) ) {}
 
 lua_iuse_actor::~lua_iuse_actor() = default;
 


### PR DESCRIPTION
## Purpose of change (The Why)

Lua-backed mod validation could abort while unloading Lua callback state, especially with external mods like `NE_Staff_arts`.

## Describe the solution (The How)

- move `lua_iuse_actor` callback functions into actor storage instead of copying them
- clear Lua-owned static callback registries before deleting the Lua state

## Testing

- `cmake --build out/build/linux-full --target astyle`
- `cmake --build --preset linux-full --target cataclysm-bn-tiles`
- `gdb --batch -ex run -ex bt --args ./out/build/linux-full/src/cataclysm-bn-tiles --check-mods NE_Staff_arts`
- `./out/build/linux-full/src/cataclysm-bn-tiles --check-mods NE_Staff_arts`

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

- [x] This PR modifies lua scripts or the lua API.
- [x] I have added [`lua` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#lua%3A-changes-to-lua-api) to the PR title.
- [ ] I have added [type annotations](https://emmylua.github.io/annotation.html) to functions so that it's safe and easy to maintain.
- [x] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
