### PR TITLE
perf: only simulate NPCs in loaded submap

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5283,7 +5283,7 @@ void game::npcmove()
     const std::string &player_dim = m.get_bound_dimension();
     for( npc &guy : g->all_npcs() ) {
         const auto dim = guy.get_dimension();
-        const tripoint_abs_sm pos_sm( guy.pos() );
+        const auto pos_sm = tripoint_abs_sm( guy.pos() );
         // Don't process NPCs in unloaded submaps like a LEMON
         if( !submap_loader.is_simulated( dim, pos_sm ) ) {
             continue;


### PR DESCRIPTION
## Purpose of change (The Why)

All loaded NPCs were being processed. The only guard was against full processing in other dimensions. And that wasn't even correct.
This caused immense lag for players who had many NPCs in their world for one reason or another.

## Describe the solution (The How)

Guard against loaded submaps instead. NPCs in unloaded areas are still handled via the overmap NPC functions.
