### PR TITLE
ci: use github action for PR title validation

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -11,8 +11,6 @@ permissions:
 
 jobs:
   validate:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
-      - uses: docker://ghcr.io/scarf005/conventional-prs:main
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: scarf005/conventional-prs@v0.5.1


### PR DESCRIPTION

https://github.com/scarf005/conventional-prs now uses node based actions over container based action
finally, #8003

| before | after |
| - | - | 
| <img width="1317" height="513" alt="image" src="https://github.com/user-attachments/assets/0a7003ce-2262-455a-ba29-19f0fcdd04b4" /> | <img width="1318" height="835" alt="image" src="https://github.com/user-attachments/assets/b9c2457c-a681-4728-ad1a-80c89a1a8686" /> |

testing: https://github.com/scarf005/Cataclysm-BN/pull/39#issuecomment-4117146735