### PR TITLE
fix: correct seasonal water temperature scaling

### DIFF
--- a/src/weather_gen.cpp
+++ b/src/weather_gen.cpp
@@ -320,10 +320,10 @@ units::temperature weather_generator::get_water_temperature(
     constexpr int lower_limit = units::to_millidegree_celsius( -10_c );
     constexpr int upper_limit = units::to_millidegree_celsius( 30_c );
     const int weighted_average_celsius = units::to_millidegree_celsius( weighted_avg );
-    const double t = logarithmic_range( lower_limit,
-                                        upper_limit,
-                                        weighted_average_celsius );
-    return multiply_any_unit( 0_c, 1 - t ) + multiply_any_unit( 30_c, t );
+    const auto cold_factor = logarithmic_range( lower_limit,
+                             upper_limit,
+                             weighted_average_celsius );
+    return multiply_any_unit( 0_c, cold_factor ) + multiply_any_unit( 30_c, 1 - cold_factor );
 }
 
 void weather_generator::test_weather( unsigned seed = 1000 ) const

--- a/tests/weather_test.cpp
+++ b/tests/weather_test.cpp
@@ -111,6 +111,41 @@ TEST_CASE( "eternal seasons", "[weather]" )
     }
 }
 
+TEST_CASE( "water temperatures track season temperatures", "[weather]" )
+{
+    auto generator = weather_generator();
+    auto &season_stats = generator.season_stats;
+    season_stats[SPRING].average_temperature = 10_c;
+    season_stats[SUMMER].average_temperature = 40_c;
+    season_stats[AUTUMN].average_temperature = 10_c;
+    season_stats[WINTER].average_temperature = -20_c;
+    generator.temperature_daily_amplitude = 0_c;
+    generator.temperature_noise_amplitude = 0_c;
+
+    const auto current_time = calendar::turn_zero + calendar::season_length() / 2;
+    const auto spring_calendar = calendar_config( calendar::turn_zero, calendar::turn_zero, SPRING,
+                                 true );
+    const auto summer_calendar = calendar_config( calendar::turn_zero, calendar::turn_zero, SUMMER,
+                                 true );
+    const auto winter_calendar = calendar_config( calendar::turn_zero, calendar::turn_zero, WINTER,
+                                 true );
+
+    const auto spring_water_temperature = generator.get_water_temperature( tripoint_abs_ms(),
+                                          current_time,
+                                          spring_calendar, 0 );
+    const auto summer_water_temperature = generator.get_water_temperature( tripoint_abs_ms(),
+                                          current_time,
+                                          summer_calendar, 0 );
+    const auto winter_water_temperature = generator.get_water_temperature( tripoint_abs_ms(),
+                                          current_time,
+                                          winter_calendar, 0 );
+
+    CHECK( winter_water_temperature == 0_c );
+    CHECK( spring_water_temperature > winter_water_temperature );
+    CHECK( summer_water_temperature > spring_water_temperature );
+    CHECK( summer_water_temperature == 30_c );
+}
+
 TEST_CASE( "weather realism", "[.]" )
 // Check our simulated weather against numbers from real data
 // from a few years in a few locations in New England. The numbers


### PR DESCRIPTION
## Purpose of change (The Why)

closes #7605

Water temperatures were scaled in the wrong direction, so summer water ended up colder than winter water.

## Describe the solution (The How)

- invert the seasonal water temperature weighting so cold averages map toward `0_c` and hot averages map toward `30_c`
- add a regression test that checks winter < spring < summer water temperatures

## Testing

- `cmake --preset linux-full`
- `cmake --build --preset linux-full --target astyle cata_test-tiles`
- `./out/build/linux-full/tests/cata_test-tiles "[weather]"`

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.