### PR TITLE
fix: plutonium batteries no longer fully recharge if dropped before first charge cycle

### DIFF
--- a/src/relic.cpp
+++ b/src/relic.cpp
@@ -379,6 +379,9 @@ bool check_recharge_reqs( const item &itm, const relic_recharge &rech, const Cha
 
 bool process_recharge_entry( item &itm, const relic_recharge &rech, Character *carrier )
 {
+    if( carrier ) {
+        itm.set_var( "relic_was_in_inventory", true );
+    }
     if( !calendar::once_every( rech.interval ) ) {
         return false;
     }
@@ -465,7 +468,8 @@ bool process_recharge_entry( item &itm, const relic_recharge &rech, Character *c
     if( rech.type == relic_recharge_type::time ) {
         int last_relic_process = itm.get_var( "last_relic_process", 0 );
         if( last_relic_process == 0 &&
-            carrier ) { // We do not want batteries to fully charge while in a player's inventory
+            itm.get_var( "relic_was_in_inventory",
+                         false ) ) { // We do not want batteries to fully charge after it has been in a player's inventory
             ticks = 1;
         } else {
             time_duration elapsed = calendar::turn - time_point::from_turn( last_relic_process );


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->
Followup/Fix for an exploit caused by #8342
Professions that spawn with a plutonium battery and drop it before the first charge cycle causes it to fully charge.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->
This adds an item variable that is set to true when the player has it in their inventory. Even if the battery later gets dropped, it will "remember" it has been in a player inventory, and not fully charge, fixing the exploit. Contrary to what I thought, `process_recharge_entry` is actually called every tick, it just stops after the `once_every` check. This can thus be achieved without touching item.cpp.

## Describe alternatives you've considered

Ideally you'd want to set the item var only once, but we currently do not have hooks/callbacks for when an item is picked up (do we?) (or if spawning _with_ it would even trigger it)

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->
- Spawn plutonium battery inside the inventory
- Discharge it a bit
- Drop it _before_ 12 minutes have passed
- Wait 12 minutes
- Notice the battery does _not_ fully charge, instead charging normally

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
If there _is_ some sort of callback or signal I can use, I'd be glad to use it. I'm not particularly happy with this implementation either.

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [ ] ~~I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.~~ No issues have been opened regarding this exploit since it's so new
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.