### PR TITLE
fix(UI): keep construction availability colors while filtering

### DIFF
--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -1021,15 +1021,8 @@ std::optional<construction_id> construction_menu( const bool blueprint )
                 ui.set_cursor( w_list, print_from );
             }
             const std::string group_name = is_favorite( group ) ? "* " + group->name() : group->name();
-            if( filter_mode ) {
-                const nc_color base_col = c_dark_gray;
-                const nc_color final_col = highlight ? hilite( base_col ) : base_col;
-                trim_and_print( w_list, print_from, w_list_width, final_col, group_name );
-            } else {
-                const nc_color base_col = construction_color( group, false );
-                const nc_color final_col = highlight ? hilite( base_col ) : base_col;
-                trim_and_print( w_list, print_from, w_list_width, final_col, group_name );
-            }
+            const nc_color final_col = construction_color( group, highlight );
+            trim_and_print( w_list, print_from, w_list_width, final_col, group_name );
         }
 
         // Clear out lines for tools & materials


### PR DESCRIPTION
## Purpose of change (The Why)

closes #8379

Filtered construction results were always drawn in dark gray, so buildable entries looked unavailable.

## Describe the solution (The How)

Use the existing construction availability color helper for filtered results too.

## Testing

- `cmake --build out/build/linux-full --target astyle`
- `cmake --build --preset linux-full --target cataclysm-bn-tiles cata_test-tiles`

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<sup>PR opened by gpt-5.4 high on opencode</sup>