### PR TITLE
fix(i18n): normalize reinforced triple curtain window name

### DIFF
--- a/data/json/obsoletion/uncategorized.json
+++ b/data/json/obsoletion/uncategorized.json
@@ -1737,7 +1737,7 @@
   {
     "type": "terrain",
     "id": "t_reinforced_triple_pane_glass_with_curtain_open",
-    "name": "Reinforced triple glazed glass window With a curtain",
+    "name": "Reinforced triple glazed glass window with a curtain",
     "description": "A triple glazed window with fancy curtains on the inside that can be drawn closed to block visibility and shut out any light.",
     "looks_like": "t_window_open",
     "symbol": "|",


### PR DESCRIPTION
## Purpose of change (The Why)

closes #8191

A capitalization typo made the open reinforced triple glazed window use a different translatable name from the related closed variants.

## Describe the solution (The How)

Normalize `With a curtain` to `with a curtain` for `t_reinforced_triple_pane_glass_with_curtain_open` in `data/json/obsoletion/uncategorized.json`.
