### PR TITLE
feat(balance): make stomach harvesting by-mass to match all other organs

### DIFF
--- a/data/json/harvest.json
+++ b/data/json/harvest.json
@@ -187,7 +187,7 @@
     "entries": [
       { "drop": "mutant_blood", "type": "blood", "mass_ratio": 0.1 },
       { "drop": "mutant_human_flesh", "type": "flesh", "mass_ratio": 0.34 },
-      { "drop": "hstomach","type": "offal", "mass_ratio": 0.005 },
+      { "drop": "hstomach", "type": "offal", "mass_ratio": 0.005 },
       { "drop": "sinew", "type": "bone", "mass_ratio": 0.001 },
       { "drop": "bone_human", "type": "bone", "mass_ratio": 0.15 },
       { "drop": "raw_hfur", "type": "skin", "mass_ratio": 0.02 },
@@ -202,7 +202,7 @@
       { "drop": "cyborg_harvest_uncommon", "type": "bionic_group", "faults": [ "fault_bionic_nonsterile" ] },
       { "drop": "mutant_blood", "type": "blood", "mass_ratio": 0.1 },
       { "drop": "mutant_human_flesh", "type": "flesh", "mass_ratio": 0.34 },
-      { "drop": "hstomach","type": "offal", "mass_ratio": 0.005 },
+      { "drop": "hstomach", "type": "offal", "mass_ratio": 0.005 },
       { "drop": "sinew", "type": "bone", "mass_ratio": 0.001 },
       { "drop": "bone_human", "type": "bone", "mass_ratio": 0.15 },
       { "drop": "raw_hfur", "type": "skin", "mass_ratio": 0.02 },


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

Discussion with Rosa in game about inconsistency between kidneys being multiple units - when they realistically would be just two kidneys for most creatures - yielded the insight that they could be treated as "chunks of kidneys" or "kidneys by mass" - which could be abstracted as really big kidneys if you wanted to get creative. 

For some reason, stomachs were treated as identical size single organ harvests across all creatures - while everything else harvested was a mass ratio calculation, not simply "you get a fat."

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

Converted every stomach entry over to the nearest sensible mass ratio value - used similar organs where possible for balancing. 

## Describe alternatives you've considered

I considered doing hard research into how much mass an average stomach takes up relative to its host body, then plugging in scientifically accurate numbers - but lazy.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

Wow.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

This was done just to make organs consistent - it annoyed me that one thing was always a guaranteed single organ, but every other organ harvest was multiple quantity even well past what you'd logically harvest.

Now if a creature has a huge stomach, you'll get more stomach for your harvest, and if they've got a small one, you'll have the normal expected harvest.

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
