### PR TITLE
fix: guard mutation threshold lookups

### DIFF
--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -102,6 +102,26 @@ std::string enum_to_string<mutagen_technique>( mutagen_technique data )
 
 } // namespace io
 
+namespace
+{
+
+auto get_threshold_mutation_for_tier( const mutation_category_id &category_id,
+                                      const size_t tier ) -> trait_id
+{
+    if( !category_id.is_valid() ) {
+        return trait_id::NULL_ID();
+    }
+
+    const auto &threshold_muts = category_id->threshold_muts;
+    if( tier >= threshold_muts.size() ) {
+        return trait_id::NULL_ID();
+    }
+
+    return threshold_muts[tier];
+}
+
+} // namespace
+
 bool Character::has_trait( const trait_id &b ) const
 {
     return my_mutations.contains( b ) || enchantment_cache->get_mutations().contains( b );
@@ -1250,9 +1270,11 @@ bool Character::mutate_towards( const trait_id &mut )
         return false;
     }
 
-    for( auto cat : mdata.category ) {
-        if( has_trait( cat->threshold_muts[tierreq] ) ) {
+    for( const auto &cat : mdata.category ) {
+        const auto threshold_mut = get_threshold_mutation_for_tier( cat, tierreq );
+        if( threshold_mut && has_trait( threshold_mut ) ) {
             has_threshreq = true;
+            break;
         }
     }
 

--- a/tests/mutation_test.cpp
+++ b/tests/mutation_test.cpp
@@ -17,6 +17,7 @@
 #include "type_id.h"
 
 static const efftype_id effect_accumulated_mutagen( "accumulated_mutagen" );
+static const auto trait_marloss = trait_id( "MARLOSS" );
 
 std::string get_mutations_as_string( const player &p );
 
@@ -193,4 +194,12 @@ TEST_CASE( "Mutating with full mutagen accumulation results in multiple mutation
             }
         }
     }
+}
+
+TEST_CASE( "Mutating marloss does not crash on missing category data", "[mutations]" )
+{
+    npc dummy;
+
+    CHECK( dummy.mutate_towards( trait_marloss ) );
+    CHECK( dummy.has_trait( trait_marloss ) );
 }


### PR DESCRIPTION
## Purpose of change (The Why)

Prevent `mutate_towards` from crashing when a mutation references a missing category or threshold tier. found when testing #8380

## Describe the solution (The How)

Return `trait_id::NULL_ID()` for missing threshold category data before checking threshold ownership.
Add a regression test that covers mutating into `MARLOSS`.

## Testing

<img width="1410" height="850" alt="image" src="https://github.com/user-attachments/assets/040801e6-0e8a-419c-ad72-526ffb81440f" />

1. have rodent ears
2. change to rabbit ears (the one with ugly: -2 and category: `MUTCAT_CATTLE`)
3. it doesn't segfaults anymore