### PR TITLE
feat(mods): geomagnetic storm charges player bionics

### DIFF
--- a/data/mods/JP_Weather_Variants/main.lua
+++ b/data/mods/JP_Weather_Variants/main.lua
@@ -1,0 +1,18 @@
+local mod = game.mod_runtime[game.current_mod]
+
+mod.charge_per_tick_joule = 5000
+
+mod.on_weather_updated = function(params)
+  if params.weather_id ~= "geomagnetic_storm" then return end
+
+  local player = gapi.get_avatar()
+  if not player or not player:has_bionics() then return end
+
+  local current_joules = player:get_power_level():to_joule()
+  local max_joules = player:get_max_power_level():to_joule()
+  local available_space = math.max(0, max_joules - current_joules)
+  if available_space <= 0 then return end
+
+  local charge_delta = math.min(available_space, mod.charge_per_tick_joule)
+  player:mod_power_level(Energy.from_joule(charge_delta))
+end

--- a/data/mods/JP_Weather_Variants/modinfo.json
+++ b/data/mods/JP_Weather_Variants/modinfo.json
@@ -7,6 +7,7 @@
     "description": "Additional weathers ported from the Japanese CDDA variant and modified to fit BN.\n\nEnables acid rain and adds the following weather: Rainbows, Sundogs (renamed from Diamond Dust), Northern Lights, Geomagnetic Storms, Acid Flurries, Acid Snow, and Acid Snowstorms.",
     "category": "content",
     "dependencies": [ "bn" ],
+    "lua_api_version": 2,
     "version": "1",
     "obsolete": false
   }

--- a/data/mods/JP_Weather_Variants/preload.lua
+++ b/data/mods/JP_Weather_Variants/preload.lua
@@ -1,0 +1,3 @@
+local mod = game.mod_runtime[game.current_mod]
+
+game.add_hook("on_weather_updated", function(...) return mod.on_weather_updated(...) end)


### PR DESCRIPTION
## Purpose of change (The Why)
Geomagnetic storms are currently just for flavor, and I'd like to change that.

## Describe the solution (The How)
Gives them the ability to charge player bionics slowly over time when inside of the storm. I think this will be fun for players who discover it for the first time, as well as provide an interesting challenge for winter runs if people were to harvest all of their bionic energy form the storm. Would make a cool winter storm-chaser run.
## Describe alternatives you've considered
Making it drain power? Seemed lame, and I want to incentivize the player to chase storms down for fun.

## Testing
Spawned in a world, set time to night during winter. Stood under a storm and confirmed it charged my bionics.

## Additional context

## Checklist

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.