### PR TITLE
fix: Ignore SDL rotation for multitile subtiles

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -2721,6 +2721,8 @@ void tileset_loader::load_tilejson_from_file( const JsonObject &config )
                     tile_type &curr_subtile = load_tile( subentry, m_id );
                     curr_subtile.offset = sprite_offset;
                     curr_subtile.rotates = true;
+                    curr_subtile.is_multitile_subtile = std::ranges::find( multitile_keys,
+                                                        s_id ) != multitile_keys.end();
                     curr_subtile.height_3d = t_h3d;
                     curr_subtile.animated = subentry.get_bool( "animated", false );
                     curr_subtile.default_tint = t_tint;
@@ -2737,6 +2739,7 @@ void tileset_loader::load_tilejson_from_file( const JsonObject &config )
             curr_tile.height_3d = t_h3d;
             curr_tile.default_tint = t_tint;
             curr_tile.flags = t_flags;
+            curr_tile.is_multitile_subtile = false;
             curr_tile.animated = entry.get_bool( "animated", false );
         }
     }
@@ -4243,7 +4246,9 @@ bool cata_tiles::draw_sprite_at( const tile_type &tile, point p,
      */
     const auto num_sprites = sprite_list.size();
     const auto is_single_sprite = num_sprites == 1;
-    const auto rotate_sprite = ( is_fg || tile.rotates ) && is_single_sprite;
+    const auto rotate_sprite = ( is_fg || tile.rotates )
+                               && is_single_sprite
+                               && !tile.is_multitile_subtile;
     const auto sprite_num = is_single_sprite
                             ? 0
                             : ( rota % num_sprites );

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -63,6 +63,7 @@ struct tile_type {
     bool rotates = false;
     bool animated = false;
     bool has_om_transparency = false;
+    bool is_multitile_subtile = false;
     int height_3d = 0;
     point offset = point_zero;
 


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

Fix graphical issue introduced by #8183, where rotation for background tiles was enabled

<img width="345" height="535" alt="image" src="https://github.com/user-attachments/assets/7d243bd5-c8b0-4b07-8064-7ab6a34f6e2a" />

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)

Identify and disable SDL sprite rotation for multitile subtiles, as they don't use the rotation field for rotating, but rather for indexing on an array of sprites.

<img width="1053" height="836" alt="image" src="https://github.com/user-attachments/assets/c48f97e4-96d5-4cd2-9ed5-7ea922e2e125" />

<!-- e.g nerfs monster A -->

## Describe alternatives you've considered

* Screm at multipurpose variables
* Separate sprite rotation from animation frames and autotiles index
* Rotate sprites from their origin 

## Testing

1. Climb Radio tower
2. No floating slabs of asphalt

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
