### PR TITLE
fix: Prevent Submap Shift Crash While Driving

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -948,6 +948,11 @@ void map::vehmove()
     }
     TracyPlot( "Vehicles Moved", moved_count );
 
+    // A map shift can occur mid-loop when the player is a vehicle passenger:
+    if( last_full_vehicle_list_dirty ) {
+        vehicle_list = get_vehicles();
+    }
+
     // Process item removal on the vehicles that were modified this turn.
     // Use a copy because part_removal_cleanup can modify the container.
     {


### PR DESCRIPTION
## Purpose of change (The Why)

Driving vehicles causes intermittent crashes if other vehicles are loaded and later evicted due to submap shift.

## Describe the solution (The How)

Rebuild the list we iterate on if dirtied before iteration.

## Describe alternatives you've considered

## Testing

Due to the inconsistencies, testing is still somewhat inconclusive.
I'd drive such that vehicles from a town I'd never visited would be loaded at the edge of the reality bubble, then later unloaded. Potentially caused by no border setting, or maybe not.
Can't get it to crash in a place where it was > 50% chance to happen before.