### PR TITLE
feat: convert short sledgehammers back to sledgehammers

### DIFF
--- a/data/json/recipes/other/tools.json
+++ b/data/json/recipes/other/tools.json
@@ -1537,16 +1537,16 @@
   {
     "type": "recipe",
     "result": "hammer_sledge",
-	"id_suffix": "handle_swap",
+    "id_suffix": "handle_swap",
     "category": "CC_OTHER",
     "subcategory": "CSC_OTHER_TOOLS",
     "skill_used": "fabrication",
-	"//": "This method involves hammering a chisel into the wooden shaft of a short sledgehammer until the hammer's head can be pried off - then mounting it on a cut and sanded-to-shape long handle.",
+    "//": "This method involves hammering a chisel into the wooden shaft of a short sledgehammer until the hammer's head can be pried off - then mounting it on a cut and sanded-to-shape long handle.",
     "difficulty": 1,
     "time": "15 m",
-	"autolearn": true,
+    "autolearn": true,
     "byproducts": [ [ "splinter", 7 ] ],
-	"qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "CHISEL", "level": 1 } ],
+    "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "CHISEL", "level": 1 } ],
     "components": [ [ [ "wood_structural_small", 1, "LIST" ] ] ]
   },
   {


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

I got annoyed seeing short sledgehammers in the game world and having no way to do the simple thing: pop the sledge off the handle and pop it on a proper length handle.

The only difference between a short and a normal sledgehammer is _literally the wood you hold it from_.  

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

With a few relatively simple tools, you can replace the handle on a sledge to turn it from a short sledgehammer to a full sledgehammer.

A hammering tool of any kind, a chiseling tool of any kind, sandpaper, and some kind of wood sawing tool are all you need to remove the old handle and smooth out and fit a new one to your perfectly good, already forged sledge head.

So you take: short sledgehammer, stick or plank, and swap piece. Wow! Full length sledgehammer again!

And you didn't even have to waste 2 hours forging!

## Describe alternatives you've considered

I considered making it require either glue or a wood splinter to secure the fit [with the splinter representing a wedge of wood between the sledge and the wood shaft]

But considering you don't use either of these to make a normal sledgehammer in-game anyway, I opted not to.  

I also considered making this thing require _just_ a cutting tool and abstracting all the "carving the handle away enough to pull off the sledge head" business, but felt that would be way too easy for turning a fairly gimped half-hammer into a fairly profound head smasher.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

Loaded game. Threw no errors. Recipe shows up as expected. 

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

I was created in a cloning vat by XEDRA to annoy ChaosVolt

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.