### PR TITLE
fix: make debug hammerspace install charged vehicle batteries

### DIFF
--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -86,6 +86,20 @@ static const activity_id ACT_VEHICLE( "ACT_VEHICLE" );
 
 static const std::string flag_MOUNTABLE( "MOUNTABLE" );
 
+namespace
+{
+
+auto spawn_debug_install_base( const vpart_info &vpinfo ) -> detached_ptr<item>
+{
+    auto spawned = item::spawn( vpinfo.item );
+    if( vpinfo.fuel_type == fuel_type_battery && spawned->ammo_capacity() > 0 ) {
+        spawned->ammo_set( spawned->ammo_default(), -1 );
+    }
+    return spawned;
+}
+
+} // namespace
+
 static inline std::string status_color( bool status )
 {
     return status ? "<color_green>" : "<color_red>";
@@ -3219,31 +3233,35 @@ void veh_interact::complete_vehicle( Character &who )
             const inventory &inv = who.crafting_inventory();
 
             const auto reqs = vpinfo.install_requirements();
-            if( !reqs.can_make_with_inventory( inv, is_crafting_component ) ) {
+            const auto using_debug_hammerspace = who.has_trait( trait_DEBUG_HS );
+            if( !using_debug_hammerspace && !reqs.can_make_with_inventory( inv, is_crafting_component ) ) {
                 add_msg( m_info, _( "You don't meet the requirements to install the %s." ), vpinfo.name() );
                 break;
             }
-            //TODO!: cheeeeck
-            // consume items extracting a match for the parts base item
             detached_ptr<item> base;
-            for( const auto &e : reqs.get_components() ) {
-                for( auto &obj : who.consume_items( e, 1, is_crafting_component ) ) {
-                    if( obj->typeId() == vpinfo.item ) {
-                        base = std::move( obj );
+            if( using_debug_hammerspace ) {
+                base = spawn_debug_install_base( vpinfo );
+            } else {
+                // Consume items, extracting the specific base item for the installed part.
+                for( const auto &e : reqs.get_components() ) {
+                    for( auto &obj : who.consume_items( e, 1, is_crafting_component ) ) {
+                        if( obj->typeId() == vpinfo.item ) {
+                            base = std::move( obj );
+                        }
                     }
+                }
+
+                for( const auto &e : reqs.get_tools() ) {
+                    who.consume_tools( e );
                 }
             }
             if( !base ) {
-                if( !who.has_trait( trait_DEBUG_HS ) ) {
+                if( !using_debug_hammerspace ) {
                     add_msg( m_info, _( "Could not find base part in requirements for %s." ), vpinfo.name() );
                     break;
                 } else {
-                    base = item::spawn( vpinfo.item );
+                    base = spawn_debug_install_base( vpinfo );
                 }
-            }
-
-            for( const auto &e : reqs.get_tools() ) {
-                who.consume_tools( e );
             }
 
             who.invalidate_crafting_inventory();

--- a/tests/vehicle_interact_test.cpp
+++ b/tests/vehicle_interact_test.cpp
@@ -1,5 +1,6 @@
 #include "catch/catch.hpp"
 
+#include <algorithm>
 #include <memory>
 #include <string>
 #include <vector>
@@ -12,13 +13,20 @@
 #include "map.h"
 #include "map_helpers.h"
 #include "player_helpers.h"
+#include "player_activity.h"
 #include "point.h"
 #include "requirements.h"
 #include "state_helpers.h"
 #include "type_id.h"
+#include "veh_interact.h"
 #include "veh_type.h"
 #include "vehicle.h"
 #include "vehicle_part.h"
+#include "vpart_position.h"
+#include "vpart_range.h"
+
+static const activity_id ACT_VEHICLE( "ACT_VEHICLE" );
+static const trait_id trait_DEBUG_HS( "DEBUG_HS" );
 
 static void test_repair( std::vector<detached_ptr<item>> &tools, bool expect_craftable )
 {
@@ -103,4 +111,53 @@ TEST_CASE( "repair_vehicle_part" )
         tools.push_back( item::spawn( "material_aluminium_ingot", bday, 10 ) );
         test_repair( tools, false );
     }
+}
+
+TEST_CASE( "debug_hammerspace_installs_full_vehicle_battery", "[vehicle][veh_interact]" )
+{
+    clear_all_state();
+
+    map &here = get_map();
+    avatar &you = get_avatar();
+    clear_avatar();
+    you.toggle_trait( trait_DEBUG_HS );
+    you.set_body();
+
+    const tripoint vehicle_origin( 60, 60, 0 );
+    you.setpos( vehicle_origin + point_south );
+
+    vehicle *veh_ptr = here.add_vehicle( vproto_id( "bicycle" ), vehicle_origin, 0_degrees, 0, 0 );
+    REQUIRE( veh_ptr != nullptr );
+
+    const auto install_part_id = vpart_id( "storage_battery" );
+    const auto reference_part_index = 0;
+    const auto reference_part = &veh_ptr->part( reference_part_index );
+    const auto reference_pos = here.getabs( veh_ptr->global_part_pos3( *reference_part ) );
+
+    you.assign_activity( ACT_VEHICLE, 1, static_cast<int>( 'i' ) );
+    you.activity->values = {
+        reference_pos.x,
+        reference_pos.y,
+        0,
+        0,
+        0,
+        0,
+        reference_part_index,
+        reference_pos.z,
+    };
+    you.activity->str_values.push_back( install_part_id.str() );
+    for( const tripoint &p : veh_ptr->get_points( true ) ) {
+        you.activity->coord_set.insert( here.getabs( p ) );
+    }
+
+    veh_interact::complete_vehicle( you );
+
+    const auto all_parts = veh_ptr->get_all_parts();
+    const auto installed_battery = std::find_if( all_parts.begin(), all_parts.end(),
+    [&install_part_id]( const vpart_reference & part ) {
+        return part.info().get_id() == install_part_id;
+    } );
+
+    REQUIRE( installed_battery != all_parts.end() );
+    CHECK( installed_battery->part().ammo_remaining() == installed_battery->part().ammo_capacity() );
 }


### PR DESCRIPTION
## Purpose of change (The Why)

`DEBUG_HS` vehicle installs synthesize a base part item. Battery installs were landing empty, so debug-installed vehicle batteries immediately showed `0/capacity` charge.

## Describe the solution (The How)

- skip item and tool consumption for `DEBUG_HS` vehicle part installs
- synthesize the install base directly for debug installs
- precharge synthesized battery installs to full capacity
- add a regression test for `DEBUG_HS` battery installation

## Testing

- `cmake --build --preset linux-full --target cataclysm-bn-tiles`
- `cmake --build --preset linux-full --target cata_test-tiles`
- `./out/build/linux-full/tests/cata_test-tiles "debug_hammerspace_installs_full_vehicle_battery"`
- `./out/build/linux-full/tests/cata_test-tiles "repair_vehicle_part"`

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<sup>PR opened by gpt-5.4 high on opencode</sup>
