### PR TITLE
ci: name nightly releases with the current UTC date

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,13 +21,13 @@ jobs:
       - uses: actions/checkout@v4
       - id: env_vars
         run: |
-          TAG_NAME=$(date -u --iso-8601 --date='1 day ago')
-          YESTERDAY_TAG_NAME=$(date -u --iso-8601 --date='2 day ago')
+          TAG_NAME=$(date -u --iso-8601)
+          YESTERDAY_TAG_NAME=$(date -u --iso-8601 --date='1 day ago')
           LAST_TAG_NAME=$(git for-each-ref --sort=-creatordate --format '%(creatordate:short)' refs/tags | head -n 1)
-          COMMITS=$(git log --oneline --since="$TAG_NAME" | wc -l)
+          COMMITS=$(git log --oneline --since="$YESTERDAY_TAG_NAME" --until="$TAG_NAME" | wc -l)
           RELEASE_NAME="Nightly $TAG_NAME"
 
-          echo "commits yesterday ($TAG_NAME): $COMMITS" >> "$GITHUB_STEP_SUMMARY"
+          echo "commits yesterday ($YESTERDAY_TAG_NAME): $COMMITS" >> "$GITHUB_STEP_SUMMARY"
 
           echo "count=$COMMITS" >> "$GITHUB_OUTPUT"
           echo "tag_name=$TAG_NAME" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Purpose of change (The Why)

Nightly releases triggered at 00:00 UTC are tagged and named with the previous day, so a `2026-04-01` run produces `Nightly 2026-03-31`.

## Describe the solution (The How)

Use the current UTC date for the nightly tag and release name, and count commits from the previous UTC day so the scheduled release still reflects the prior day's changes.

## Describe alternatives you've considered

## Testing

- `git diff --check upstream/main...HEAD`
- `actionlint .github/workflows/release.yml` not available in this environment

## Additional context

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<sup>PR opened by gpt-5.4 high on opencode</sup>