### PR TITLE
fix: default initialize tint_config when parsing json

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -2429,7 +2429,7 @@ void tileset_loader::load_internal( const JsonObject &config, const std::string 
                                  bool has_top_level, tint_blend_mode top_blend_mode,
                                  std::optional<float> top_contrast, std::optional<float> top_saturation,
         std::optional<float> top_brightness ) -> tint_config {
-            tint_config cfg = {};
+            tint_config cfg{};
             if( !obj.has_member( key ) )
             {
                 return cfg;


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

Fixes tint config parsing with random non-initialized values causing mutations to draw with unintended colors

<img width="201" height="214" alt="image" src="https://github.com/user-attachments/assets/7bb74b8e-8ab6-4b53-979b-f91bfdcf4be0" />
<img width="318" height="345" alt="image" src="https://github.com/user-attachments/assets/cee304ce-0ca8-4ba7-93ef-7d72770a0ef2" />

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)

Initialize the tint_config value when parsing, so lack of a value results in no tinting instead of junk data
<img width="318" height="345" alt="image" src="https://github.com/user-attachments/assets/0203dd98-fc42-4626-bf4e-e61c407fbfbf" />

<!-- e.g nerfs monster A -->

## Describe alternatives you've considered

## Testing

* Create new character
* Add rabbit ears trait
* Its not Neon colored

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

Someone *will* want the old random color value back

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
