### PR TITLE
fix: fix nested crafting recipe crash

### DIFF
--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -887,10 +887,12 @@ const recipe *select_crafting_recipe( int &batch_size_out )
         int recipe_scroll_window_max = std::min( recmax, recipe_scroll_window_min + dataLines );
 
         for( int i = recipe_scroll_window_min; i < recipe_scroll_window_max; ++i ) {
-            auto tmp_name = std::string( indent[i], ' ' ) +
-                            current[i]->result_name( /*decorated=*/true );
+            std::string tmp_name;
             if( batch ) {
-                tmp_name = string_format( _( "%2dx %s" ), i + 1, tmp_name );
+                tmp_name = string_format( _( "%2dx %s" ), i + 1, current[i]->result_name( true ) );
+            } else {
+                tmp_name = std::string( indent[i], ' ' ) +
+                           current[i]->result_name( /*decorated=*/true );
             }
             const bool rcp_known = available_recipes.contains( *current[i] );
             const bool rcp_read = !highlight_unread_recipes ||


### PR DESCRIPTION
## Purpose of change (The Why)
They segfault right now, issue from #8059 
Out of bounds vector

## Describe the solution (The How)
Remove indent checking for batch crafting

## Describe alternatives you've considered
I dunno something else

## Testing
Oats crafting no longer splodes

## Additional context
I can do things sometimes

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.