### PR TITLE
feat: flying enemies flee vertically, use preferred Z levels

### DIFF
--- a/data/json/monsters/bird.json
+++ b/data/json/monsters/bird.json
@@ -63,6 +63,7 @@
     "color": "dark_gray",
     "aggression": -99,
     "morale": -8,
+    "preferred_z": 3,
     "melee_dice": 1,
     "melee_dice_sides": 1,
     "melee_cut": 0,

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -821,12 +821,26 @@ monster_plan_t monster::compute_plan( const monster::compute_plan_context &ctx )
 
     } else if( target != nullptr ) {
 
-        tripoint dest = target->pos();
-        auto att_to_target = attitude_to( *target );
+        const auto dest = target->pos();
+        const auto att_to_target = attitude_to( *target );
         if( att_to_target == Attitude::A_HOSTILE && !fleeing ) {
             local_goal = dest;
         } else if( fleeing ) {
-            local_goal = tripoint( posx() * 2 - dest.x, posy() * 2 - dest.y, posz() );
+            const auto current_pos = pos();
+            const auto away = current_pos - dest;
+            auto flee_goal = current_pos + tripoint( away.x, away.y, 0 );
+            if( flies() ) {
+                if( const auto preferred_z = type->preferred_z ) {
+                    flee_goal.z = *preferred_z;
+                } else if( away.z != 0 ) {
+                    flee_goal.z = current_pos.z + away.z;
+                } else {
+                    flee_goal.z = current_pos.z + 1;
+                }
+            } else {
+                flee_goal.z = current_pos.z;
+            }
+            local_goal = flee_goal;
         }
         if( angers_hostile_weak && att_to_target != Attitude::A_FRIENDLY ) {
             int hp_per = target->hp_percentage();

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -798,6 +798,7 @@ void mtype::load( const JsonObject &jo, const std::string &src )
 
     assign( jo, "vision_day", vision_day, strict, 0 );
     assign( jo, "vision_night", vision_night, strict, 0 );
+    optional( jo, was_loaded, "preferred_z", preferred_z );
 
     optional( jo, was_loaded, "regenerates", regenerates, 0 );
     optional( jo, was_loaded, "regenerates_in_dark", regenerates_in_dark, false );

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -314,6 +314,7 @@ struct mtype {
         int speed = 0;          /** e.g. human = 100 */
         int agro = 0;           /** chance will attack [-100,100] */
         int morale = 0;         /** initial morale level at spawn */
+        std::optional<int> preferred_z;
 
         // Number of hitpoints regenerated per turn.
         int regenerates = 0;
@@ -482,4 +483,3 @@ struct mtype {
 };
 
 mon_effect_data load_mon_effect_data( const JsonObject &e );
-


### PR DESCRIPTION
## Purpose of change (The Why)
Suggested in the discord, and I've wanted to improve flying enemy support for a while.

## Describe the solution (The How)
Allows flying enemies to flee upwards into the sky, and allows monsters to define a preferred Z level. Sunshine suggested a default of 3 for birds, which makes sense to me - preferrably zombie/aggro flying monsters should hover on 2, so they can use the hit and run style attacks if desired.

## Describe alternatives you've considered

## Testing

## Additional context

## Checklist

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.