### PR TITLE
fix: use spellbook position for study light checks

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -4670,7 +4670,9 @@ void activity_handlers::study_spell_do_turn( player_activity *act, player *p )
     if( act->values.size() < 4 ) {
         act->values.push_back( 0 );
     }
-    if( !character_funcs::can_see_fine_details( *p ) ) {
+    const auto study_pos = act->placement == tripoint_zero ? p->pos() : get_map().getlocal(
+                               act->placement );
+    if( !character_funcs::can_see_fine_details( *p, study_pos ) ) {
         act->values[2] = -1;
         act->moves_left = 0;
         return;

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1362,7 +1362,8 @@ static void read()
     if( loc ) {
         if( loc->type->can_use( "learn_spell" ) ) {
             item &spell_book = *loc;
-            spell_book.get_use( "learn_spell" )->call( u, spell_book, spell_book.is_active(), u.pos() );
+            spell_book.get_use( "learn_spell" )->call( u, spell_book, spell_book.is_active(),
+                    spell_book.position() );
         } else {
             u.read( loc );
         }

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -2629,9 +2629,10 @@ void learn_spell_actor::info( const item &, std::vector<iteminfo> &dump ) const
     }
 }
 
-int learn_spell_actor::use( player &p, item &, bool, const tripoint & ) const
+int learn_spell_actor::use( player &p, item &book, bool, const tripoint &pos ) const
 {
-    if( !character_funcs::can_see_fine_details( p ) ) {
+    const auto study_pos = pos == p.pos() && book.has_position() ? book.position() : pos;
+    if( !character_funcs::can_see_fine_details( p, study_pos ) ) {
         p.add_msg_if_player( _( "It's too dark to read." ) );
         return 0;
     }
@@ -2710,6 +2711,7 @@ int learn_spell_actor::use( player &p, item &, bool, const tripoint & ) const
         study_spell->values[1] = 0; // reserved for levels
     }
     study_spell->name = spells[action];
+    study_spell->placement = get_map().getabs( study_pos );
     p.assign_activity( std::move( study_spell ), false );
     return 0;
 }

--- a/tests/reading_test.cpp
+++ b/tests/reading_test.cpp
@@ -7,6 +7,8 @@
 #include <utility>
 #include <vector>
 
+#include "activity_type.h"
+#include "activity_handlers.h"
 #include "avatar.h"
 #include "bodypart.h"
 #include "calendar.h"
@@ -351,6 +353,48 @@ TEST_CASE( "reasons for not being able to read", "[reading][reasons]" )
                 CHECK( reasons == expect_reasons );
             }
         }
+    }
+}
+
+TEST_CASE( "spell study uses the reading tile light", "[reading][spellbook][light]" )
+{
+    clear_all_state();
+    clear_map();
+    build_test_map( t_floor );
+    set_time( calendar::turn_zero );
+
+    avatar dummy;
+    dummy.setpos( tripoint( 62, 60, 0 ) );
+
+    map &here = get_map();
+    const auto study_pos = tripoint( 60, 60, 0 );
+    here.add_item_or_charges( study_pos, item::spawn( "candle_lit" ) );
+    here.invalidate_map_cache( study_pos.z );
+    here.build_map_cache( study_pos.z );
+
+    REQUIRE_FALSE( character_funcs::can_see_fine_details( dummy ) );
+    REQUIRE( character_funcs::can_see_fine_details( dummy, study_pos ) );
+
+    SECTION( "unplaced study uses the player tile" ) {
+        player_activity act( activity_id( "ACT_STUDY_SPELL" ), 100 );
+        act.values = { 0, 0, 0 };
+
+        activity_handlers::study_spell_do_turn( &act, &dummy );
+
+        CHECK( act.values[2] == -1 );
+        CHECK( act.moves_left == 0 );
+    }
+
+    SECTION( "placed study uses the lit reading tile" ) {
+        player_activity act( activity_id( "ACT_STUDY_SPELL" ), 100 );
+        act.values = { 0, 0, 0 };
+        act.placement = here.getabs( study_pos );
+
+        activity_handlers::study_spell_do_turn( &act, &dummy );
+
+        CHECK( act.values[2] == 0 );
+        CHECK( act.moves_left == 100 );
+        CHECK( act.values[3] == 1 );
     }
 }
 


### PR DESCRIPTION
## Purpose of change (The Why)

closes #8431

Spellbooks checked the player's tile for fine-detail light instead of the tile the book was being read from, so studying could incorrectly fail with \"It's too dark to read.\"

## Describe the solution (The How)

Pass the spellbook's actual position into `learn_spell`, store that reading position on `ACT_STUDY_SPELL`, and reuse it for ongoing light checks.

## Testing

- [x] `cmake --build --preset linux-full --target astyle`
- [x] `cmake --build --preset linux-full --target cataclysm-bn-tiles cata_test-tiles`
- [x] `./out/build/linux-full/tests/cata_test-tiles "[reading]"`

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<sup>PR opened by gpt-5.4 high on opencode</sup>