### PR TITLE
fix(lua): prevent segfault in check mods caused by mod mapgen

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1025,6 +1025,10 @@ bool init::check_mods_for_errors( loading_ui &ui, const std::vector<mod_id> &opt
         to_check.emplace( mod_management::get_default_core_content_pack() );
     }
 
+    // Ensure the last checked mod unloads before process exit so Lua-backed
+    // mapgen functions do not outlive the active Lua state.
+    on_out_of_scope clear_last_checked_data( [] { clear_loaded_data(); } );
+
     for( const mod_id &id : to_check ) {
         clear_loaded_data();
 


### PR DESCRIPTION
## Purpose of change (The Why)

`--check-mods` can leave the last loaded Lua-backed mapgen alive until process exit. That occasionally segfaults during teardown when `mapgen_function_lua` outlives the active Lua state.

## Describe the solution (The How)

Add a scope-exit unload in `check_mods_for_errors()` so the final mod load is cleared before process shutdown.

## Describe alternatives you've considered

Relying on process teardown order is not safe here.

## Testing

- `cmake --build --preset linux-full --target astyle`
- `cmake --build --preset linux-full --target cataclysm-bn-tiles`
- Reproduced on unpatched `upstream/main` with the minimal mods below:
  - `./cataclysm-bn-tiles --userdir /tmp/opencode/checkmods-repro-userdir --check-mods repro_a repro_b`
  - exited with `134` in 3/3 runs
- Verified on this branch with the same mods:
  - exited with `0` in 3/3 runs
- Verified full scan also exits cleanly:
  - `./cataclysm-bn-tiles --userdir /tmp/opencode/empty-userdir-fix --check-mods`

## Additional context

Minimal repro uses two local mods with a no-op Lua mapgen registration. `repro_b` is identical to `repro_a` except for the ids `repro_b` / `repro_mapgen_b`.

`repro_a/modinfo.json`
```json
[
  {
    "type": "MOD_INFO",
    "id": "repro_a",
    "name": "Check Mods Repro A",
    "authors": [ "OpenCode" ],
    "description": "Minimal Lua mapgen repro mod A.",
    "category": "content",
    "lua_api_version": 2,
    "dependencies": [ "bn" ]
  }
]
```

`repro_a/preload.lua`
```lua
local mod = game.mod_runtime[game.current_mod]

mod.noop = function(...)
end

game.mapgen_functions["repro_mapgen_a"] = function(...)
  return mod.noop(...)
end
```

`repro_a/mapgen.json`
```json
[
  {
    "type": "mapgen",
    "method": "lua",
    "om_terrain": [ "slimepit" ],
    "luamethod": "repro_mapgen_a"
  }
]
```

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

- [ ] This is a C++ PR that modifies JSON loading or behavior.

<sup>PR opened by gpt-5.4 high on opencode</sup>