### PR TITLE
perf: Distribution Grid Iteration Fix

### DIFF
--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -2068,7 +2068,7 @@ std::set<tripoint_abs_omt> overmapbuffer::electric_grid_at( const tripoint_abs_o
         }
 
         const auto &connections_bitset = cached_om->electric_grid_connections[tripoint_om_omt( local_2d,
-                                         elem.z() )];
+                                                          elem.z() )];
         for( size_t i = 0; i < six_cardinal_directions.size(); i++ ) {
             if( connections_bitset.test( i ) ) {
                 tripoint_abs_omt other = elem + six_cardinal_directions[i];


### PR DESCRIPTION
## Purpose of change (The Why)

Some distribution grids (electric) were loading really, *really* slowly.

## Describe the solution (The How)

Just handle iteration better. Use unordered lists, don't handle the same submap multiple times, etc.

## Testing

I got the worst results from before in a military base, but I couldn't test that again because they didn't have electrical grids for some reason.
I tested with a large mall instead, and it's much faster. Teleporting was taking longer before vs after, and there's less pause lag for moving towards it as well.
Hopefully someone can test with their own pet *issue area*.