### PR TITLE
docs: Remove references to catapult from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,9 +133,7 @@ you wish to assign to that action.
 
 #### There is no music (or sound) in the game. How can I add it?
 
-First boot up the game, select help, click 6 ( resolved game directories )
-
-Take note of the folder after "user sounds: "
+See where to place 3rd party mods, but replace mods/ with sounds/, this is the folder you will put it into
 
 Find a soundpack such as the recommended one [Otopack](https://github.com/NarandBD/Otopack-BN-Mk-2).
 
@@ -145,9 +143,21 @@ Then finally select it from the settings, and then restart the game.
 
 #### Where should I put 3rd-party mods?
 
+If not in the List of common directories or it fails to work:
+
 First boot up the game, select help, click 6 ( resolved game directories )
 
 Place mods in the folder after "user mods: "
+
+Otherwise:
+
+For Windows users it is wherever your game folder is ( same level as the EXE ) /mods
+
+For Android users using the non-legacy storage, the user mods folder is `Documents/Cataclysm-BN/mods`
+
+For Linux users using the XDG directories (but NOT the flatpak): The user mods directory should be in `~/.local/share/cataclysm-bn/mods` (`~/.local/share/cataclysm-bn` is the user directory in general)
+
+For flatpak users, the user mods folder is `~/.var/app/org.cataclysmbn.CataclysmBN/data/cataclysm-bn/mods` (the user directory in general is `~/.var/app/org.cataclysmbn.CataclysmBN/data/cataclysm-bn/`)
 
 #### How do I update the game manually?
 


### PR DESCRIPTION
## Purpose of change (The Why)
Catapult has been known for causing problems on linux sometimes
Catapult also is 2 stables out of date, causing several people to go to stable 9... Which is not ideal going foward
I know of no other launcher to take it's place

## Describe the solution (The How)
Adjust all README documentation to remove references to catapult
Simplify mod installation instructions to point to the in game reference to where usermods is as a fallback
Include Windows & Android mod locations also

## Describe alternatives you've considered
Create a supported launcher

## Testing
Looks fine

## Additional context

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.