### PR TITLE
build: autogenerate mods dir for non home/xdg directory releases

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -567,7 +567,7 @@ if (RELEASE)
         install(PROGRAMS ${CMAKE_SOURCE_DIR}/cataclysm-launcher
             DESTINATION .)
     endif()
-    if (WIN32)
+    if ( NOT USE_XDG_DIR AND NOT USE_HOME_DIR )
         install(DIRECTORY ${CMAKE_SOURCE_DIR}/mods
             DESTINATION .)
     endif()


### PR DESCRIPTION
## Purpose of change (The Why)
Chaos wishes for mod dir on unzip

## Describe the solution (The How)
Give windows zips a moddir

## Describe alternatives you've considered
Give it to more builds

## Testing
See: https://github.com/WishDuck/Cataclysm-BN/releases/tag/vwindows.mod.test
Windows build has mod dir

## Additional context
I screm

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.