### PR TITLE
refactor(UI): metrificate tire width

### DIFF
--- a/data/json/items/vehicle/animals.json
+++ b/data/json/items/vehicle/animals.json
@@ -14,8 +14,8 @@
     "material": [ "leather", "wood" ],
     "symbol": "H",
     "color": "yellow",
-    "diameter": 8,
-    "width": 4,
+    "diameter": "200 mm",
+    "width": "100 mm",
     "looks_like": "foldframe"
   }
 ]

--- a/data/json/items/vehicle/wheel.json
+++ b/data/json/items/vehicle/wheel.json
@@ -60,8 +60,8 @@
     "material": [ "steel", "rubber" ],
     "symbol": "]",
     "color": "dark_gray",
-    "diameter": 17,
-    "width": 9
+    "diameter": "425 mm",
+    "width": "225 mm"
   },
   {
     "id": "wheel_slick",
@@ -78,8 +78,8 @@
     "material": [ "steel", "rubber" ],
     "symbol": "]",
     "color": "dark_gray",
-    "diameter": 16,
-    "width": 11
+    "diameter": "400 mm",
+    "width": "275 mm"
   },
   {
     "type": "WHEEL",
@@ -96,8 +96,8 @@
     "material": [ "hardsteel", "rubber", "kevlar" ],
     "symbol": "]",
     "color": "green",
-    "diameter": 32,
-    "width": 20
+    "diameter": "800 mm",
+    "width": "500 mm"
   },
   {
     "id": "wheel_barrow",
@@ -114,8 +114,8 @@
     "material": [ "steel", "rubber" ],
     "symbol": "]",
     "color": "dark_gray",
-    "diameter": 8,
-    "width": 3
+    "diameter": "200 mm",
+    "width": "75 mm"
   },
   {
     "id": "wheel_bicycle",
@@ -132,8 +132,8 @@
     "material": [ "steel", "rubber" ],
     "symbol": "]",
     "color": "dark_gray",
-    "diameter": 27,
-    "width": 3
+    "diameter": "675 mm",
+    "width": "75 mm"
   },
   {
     "id": "wheel_bicycle_or",
@@ -157,8 +157,8 @@
     "material": [ "steel", "plastic" ],
     "symbol": "]",
     "color": "dark_gray",
-    "diameter": 4,
-    "width": 1
+    "diameter": "100 mm",
+    "width": "25 mm"
   },
   {
     "id": "wheel_skateboard",
@@ -175,8 +175,8 @@
     "material": [ "steel", "plastic" ],
     "symbol": "]",
     "color": "dark_gray",
-    "diameter": 2,
-    "width": 1
+    "diameter": "50 mm",
+    "width": "25 mm"
   },
   {
     "id": "wheel_mount_skateboard",
@@ -208,8 +208,8 @@
     "material": [ "rubber", "steel" ],
     "symbol": "]",
     "color": "dark_gray",
-    "diameter": 10,
-    "width": 4
+    "diameter": "250 mm",
+    "width": "100 mm"
   },
   {
     "id": "wheel_metal",
@@ -226,8 +226,8 @@
     "material": [ "steel" ],
     "symbol": "]",
     "color": "light_gray",
-    "diameter": 20,
-    "width": 4
+    "diameter": "500 mm",
+    "width": "100 mm"
   },
   {
     "id": "wheel_rail",
@@ -244,8 +244,8 @@
     "material": [ "steel" ],
     "symbol": "]",
     "color": "light_gray",
-    "diameter": 20,
-    "width": 4
+    "diameter": "500 mm",
+    "width": "100 mm"
   },
   {
     "id": "wheel_rail_small_pair",
@@ -257,8 +257,8 @@
     "price_postapoc": "1 USD",
     "weight": "12239 g",
     "symbol": "=",
-    "diameter": 10,
-    "width": 3
+    "diameter": "250 mm",
+    "width": "75 mm"
   },
   {
     "id": "wheel_motorbike",
@@ -275,15 +275,15 @@
     "material": [ "steel", "rubber" ],
     "symbol": "]",
     "color": "dark_gray",
-    "diameter": 16,
-    "width": 4
+    "diameter": "400 mm",
+    "width": "100 mm"
   },
   {
     "id": "wheel_motorbike_or",
     "copy-from": "wheel_motorbike",
     "type": "WHEEL",
     "name": { "str": "off-road motorbike wheel" },
-    "diameter": 20,
+    "diameter": "500 mm",
     "description": "A motorbike wheel, studded for improved off-road performance."
   },
   {
@@ -301,8 +301,8 @@
     "material": [ "steel" ],
     "symbol": "m",
     "color": "light_gray",
-    "diameter": 60,
-    "width": 30
+    "diameter": "1500 mm",
+    "width": "750 mm"
   },
   {
     "id": "wheel_small",
@@ -319,8 +319,8 @@
     "material": [ "steel", "rubber" ],
     "symbol": "]",
     "color": "dark_gray",
-    "diameter": 10,
-    "width": 3
+    "diameter": "250 mm",
+    "width": "75 mm"
   },
   {
     "id": "wheel_tricycle",
@@ -337,8 +337,8 @@
     "material": [ "plastic" ],
     "symbol": "]",
     "color": "dark_gray",
-    "diameter": 7,
-    "width": 1
+    "diameter": "175 mm",
+    "width": "25 mm"
   },
   {
     "id": "wheel_wheelchair",
@@ -355,8 +355,8 @@
     "material": [ "steel", "rubber" ],
     "symbol": "]",
     "color": "dark_gray",
-    "diameter": 20,
-    "width": 2
+    "diameter": "500 mm",
+    "width": "50 mm"
   },
   {
     "id": "wheel_wide",
@@ -373,8 +373,8 @@
     "material": [ "steel", "rubber" ],
     "symbol": "]",
     "color": "dark_gray",
-    "diameter": 24,
-    "width": 14
+    "diameter": "600 mm",
+    "width": "350 mm"
   },
   {
     "id": "wheel_wide_or",
@@ -397,8 +397,8 @@
     "material": [ "wood" ],
     "symbol": "]",
     "color": "brown",
-    "diameter": 20,
-    "width": 3
+    "diameter": "500 mm",
+    "width": "75 mm"
   },
   {
     "id": "wheel_wood_b",
@@ -430,8 +430,8 @@
     "material": [ "wood" ],
     "symbol": "]",
     "color": "brown",
-    "diameter": 1,
-    "width": 1
+    "diameter": "25 mm",
+    "width": "25 mm"
   },
   {
     "id": "tread1",
@@ -448,8 +448,8 @@
     "material": [ "rubber", "plastic", "steel" ],
     "symbol": "]",
     "color": "white",
-    "diameter": 30,
-    "width": 15
+    "diameter": "750 mm",
+    "width": "375 mm"
   },
   {
     "id": "tread2",
@@ -466,8 +466,8 @@
     "material": [ "steel" ],
     "symbol": "]",
     "color": "white",
-    "diameter": 50,
-    "width": 25
+    "diameter": "1250 mm",
+    "width": "625 mm"
   },
   {
     "id": "tread3",
@@ -484,7 +484,7 @@
     "material": [ "hardsteel", "steel" ],
     "symbol": "]",
     "color": "white",
-    "diameter": 60,
-    "width": 30
+    "diameter": "1500 mm",
+    "width": "750 mm"
   }
 ]

--- a/src/catalua_bindings_item.cpp
+++ b/src/catalua_bindings_item.cpp
@@ -982,10 +982,10 @@ void reg_islot( sol::state &lua )
     {
         sol::usertype<UT_CLASS> ut = luna::new_usertype<UT_CLASS>( lua, luna::no_bases, luna::no_constructor );
 
-        DOC( "Diameter of wheel in inches" );
+        DOC( "Diameter of wheel in millimeters.  Integer JSON values are legacy inches." );
         SET_MEMB_RO( diameter );
 
-        DOC( "Width of wheel in inches" );
+        DOC( "Width of wheel in millimeters.  Integer JSON values are legacy inches." );
         SET_MEMB_RO( width );
     }
 #undef UT_CLASS

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -117,6 +117,7 @@
 #include "vpart_position.h"
 #include "weather.h"
 #include "weather_gen.h"
+#include "wheel_dimensions.h"
 
 static const std::string GUN_MODE_VAR_NAME( "item::mode" );
 static const std::string CLOTHING_MOD_VAR_PREFIX( "clothing_mod_" );
@@ -4981,7 +4982,8 @@ std::string item::tname( unsigned int quantity, bool with_prefix, unsigned int t
                                  engine_displacement() / 100.0f );
 
     } else if( is_wheel() && type->wheel->diameter > 0 ) {
-        vehtext = string_format( pgettext( "vehicle adjective", "%d\" " ), type->wheel->diameter );
+        vehtext = string_format( pgettext( "vehicle adjective", "%s " ),
+                                 wheel_dimensions::format_for_display( type->wheel->diameter ).c_str() );
     }
 
     std::string burntext;

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -65,6 +65,7 @@ auto modify_fluid_grid_connections( player *, item *, bool, const tripoint & ) -
 #include "value_ptr.h"
 #include "veh_type.h"
 #include "vitamin.h"
+#include "wheel_dimensions.h"
 
 class player;
 struct tripoint;
@@ -1848,8 +1849,12 @@ void Item_factory::load_engine( const JsonObject &jo, const std::string &src )
 
 void Item_factory::load( islot_wheel &slot, const JsonObject &jo, const std::string & )
 {
-    assign( jo, "diameter", slot.diameter );
-    assign( jo, "width", slot.width );
+    if( const auto diameter = wheel_dimensions::read_from_json( jo, "diameter" ) ) {
+        slot.diameter = *diameter;
+    }
+    if( const auto width = wheel_dimensions::read_from_json( jo, "width" ) ) {
+        slot.width = *width;
+    }
 }
 
 void Item_factory::load_wheel( const JsonObject &jo, const std::string &src )

--- a/src/itype.h
+++ b/src/itype.h
@@ -479,10 +479,10 @@ struct islot_engine {
 
 struct islot_wheel {
     public:
-        /** diameter of wheel (inches) */
+        /** diameter of wheel (millimeters); integer JSON values are legacy inches */
         int diameter = 0;
 
-        /** width of wheel (inches) */
+        /** width of wheel (millimeters); integer JSON values are legacy inches */
         int width = 0;
 };
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1603,10 +1603,6 @@ void options_manager::add_options_interface()
          translate_marker( "Metric or Imperial" ),
     { { "metric", translate_marker( "Metric" ) }, { "imperial", translate_marker( "Imperial" ) } },
     "metric" );
-    add( "WHEEL_SIZE_UNITS", interface, translate_marker( "Wheel size units" ),
-         translate_marker( "Metric or Imperial" ),
-    { { "metric", translate_marker( "Metric" ) }, { "imperial", translate_marker( "Imperial" ) } },
-    "imperial" );
 
     add(
         "OVERMAP_COORDINATE_FORMAT",

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1603,6 +1603,10 @@ void options_manager::add_options_interface()
          translate_marker( "Metric or Imperial" ),
     { { "metric", translate_marker( "Metric" ) }, { "imperial", translate_marker( "Imperial" ) } },
     "metric" );
+    add( "WHEEL_SIZE_UNITS", interface, translate_marker( "Wheel size units" ),
+         translate_marker( "Metric or Imperial" ),
+    { { "metric", translate_marker( "Metric" ) }, { "imperial", translate_marker( "Imperial" ) } },
+    "imperial" );
 
     add(
         "OVERMAP_COORDINATE_FORMAT",

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -63,6 +63,7 @@
 #include "vehicle_selector.h"
 #include "vpart_position.h"
 #include "vpart_range.h"
+#include "wheel_dimensions.h"
 
 #if defined(TILES)
 #include "vehicle_preview.h"
@@ -3005,13 +3006,13 @@ void veh_interact::display_details( const vpart_info *part )
         // Note: there is no guarantee that whl is non-empty!
         const cata::value_ptr<islot_wheel> &whl = part->item->wheel;
         fold_and_print( w_details, point( col_1, line + 3 ), column_width, c_white,
-                        "%s: <color_light_gray>%d\"</color>",
+                        "%s: <color_light_gray>%s</color>",
                         small_mode ? _( "Dia" ) : _( "Wheel Diameter" ),
-                        whl ? whl->diameter : 0 );
+                        wheel_dimensions::format_for_display( whl ? whl->diameter : 0 ).c_str() );
         fold_and_print( w_details, point( col_2, line + 3 ), column_width, c_white,
-                        "%s: <color_light_gray>%d\"</color>",
+                        "%s: <color_light_gray>%s</color>",
                         small_mode ? _( "Wdt" ) : _( "Wheel Width" ),
-                        whl ? whl->width : 0 );
+                        wheel_dimensions::format_for_display( whl ? whl->width : 0 ).c_str() );
     }
 
     if( part->epower != 0 ) {

--- a/src/vehicle_part.cpp
+++ b/src/vehicle_part.cpp
@@ -27,6 +27,7 @@
 #include "veh_type.h"
 #include "vpart_position.h"
 #include "weather.h"
+#include "wheel_dimensions.h"
 
 static const itype_id fuel_type_battery( "battery" );
 static const itype_id fuel_type_none( "null" );
@@ -203,7 +204,8 @@ std::string vehicle_part::name( bool with_prefix ) const
         res.insert( 0, string_format( _( "%2.1fL " ), base->engine_displacement() / 100.0 ) );
 
     } else if( wheel_diameter() > 0 ) {
-        res.insert( 0, string_format( _( "%d\" " ), wheel_diameter() ) );
+        res.insert( 0, string_format( _( "%s " ),
+                                      wheel_dimensions::format_for_display( wheel_diameter() ).c_str() ) );
     }
 
     if( base->is_faulty() ) {
@@ -515,13 +517,13 @@ int vehicle_part::wheel_area() const
     return info().wheel_area();
 }
 
-/** Get wheel diameter (inches) or return 0 if part is not wheel */
+/** Get wheel diameter (millimeters) or return 0 if part is not wheel */
 int vehicle_part::wheel_diameter() const
 {
     return base->is_wheel() ? base->type->wheel->diameter : 0;
 }
 
-/** Get wheel width (inches) or return 0 if part is not wheel */
+/** Get wheel width (millimeters) or return 0 if part is not wheel */
 int vehicle_part::wheel_width() const
 {
     return base->is_wheel() ? base->type->wheel->width : 0;

--- a/src/vehicle_part.h
+++ b/src/vehicle_part.h
@@ -139,13 +139,13 @@ struct vehicle_part {
         /** Try to set fault returning false if specified fault cannot occur with this item */
         bool fault_set( const fault_id &f );
 
-        /** Get wheel diameter times wheel width (inches^2) or return 0 if part is not wheel */
+        /** Get wheel diameter times wheel width (millimeters^2) or return 0 if part is not wheel */
         int wheel_area() const;
 
-        /** Get wheel diameter (inches) or return 0 if part is not wheel */
+        /** Get wheel diameter (millimeters) or return 0 if part is not wheel */
         int wheel_diameter() const;
 
-        /** Get wheel width (inches) or return 0 if part is not wheel */
+        /** Get wheel width (millimeters) or return 0 if part is not wheel */
         int wheel_width() const;
 
         /**
@@ -336,5 +336,4 @@ struct vehicle_part {
          */
         std::vector<detached_ptr<item>> pieces_for_broken_part() const;
 };
-
 

--- a/src/wheel_dimensions.cpp
+++ b/src/wheel_dimensions.cpp
@@ -77,7 +77,7 @@ auto read_from_json( const JsonObject &jo, const std::string &member ) -> std::o
 
 auto format_for_display( const int millimeters ) -> std::string
 {
-    if( get_option<std::string>( "WHEEL_SIZE_UNITS" ) == "imperial" ) {
+    if( get_option<std::string>( "DISTANCE_UNITS" ) == "imperial" ) {
         const auto inches = static_cast<int>( std::lround( static_cast<double>( millimeters ) /
                                               legacy_millimeters_per_inch ) );
         return string_format( pgettext( "wheel dimension", "%d\"" ), inches );

--- a/src/wheel_dimensions.cpp
+++ b/src/wheel_dimensions.cpp
@@ -1,0 +1,89 @@
+#include "wheel_dimensions.h"
+
+#include <cmath>
+#include <locale>
+#include <sstream>
+#include <string>
+
+#include "json.h"
+#include "options.h"
+#include "string_formatter.h"
+#include "translations.h"
+
+namespace wheel_dimensions
+{
+
+namespace
+{
+
+auto parse_metric_dimension( const JsonObject &jo, const std::string &member ) -> int
+{
+    auto value = 0;
+    auto suffix = std::string{};
+
+    std::istringstream stream( jo.get_string( member ) );
+    stream.imbue( std::locale::classic() );
+    stream >> value >> suffix;
+
+    if( !stream || stream.peek() != std::istringstream::traits_type::eof() ) {
+        jo.throw_error( "syntax error when specifying wheel dimensions", member );
+    }
+
+    if( value < 0 ) {
+        jo.throw_error( "wheel dimensions must not be negative", member );
+    }
+
+    if( suffix != "mm" ) {
+        jo.throw_error( "wheel dimensions must use the mm suffix", member );
+    }
+
+    return value;
+}
+
+auto format_metric_dimension( const int millimeters ) -> std::string
+{
+    if( millimeters % 10 == 0 ) {
+        return string_format( pgettext( "wheel dimension", "%dcm" ), millimeters / 10 );
+    }
+
+    const auto centimeters = static_cast<double>( millimeters ) / 10.0;
+    return string_format( pgettext( "wheel dimension", "%.1fcm" ), centimeters );
+}
+
+} // namespace
+
+auto from_legacy_inches( const int legacy_inches ) -> int
+{
+    return legacy_inches * legacy_millimeters_per_inch;
+}
+
+auto read_from_json( const JsonObject &jo, const std::string &member ) -> std::optional<int>
+{
+    if( !jo.has_member( member ) ) {
+        return std::nullopt;
+    }
+
+    if( jo.has_int( member ) ) {
+        return from_legacy_inches( jo.get_int( member ) );
+    }
+
+    if( jo.has_string( member ) ) {
+        return parse_metric_dimension( jo, member );
+    }
+
+    jo.throw_error( "wheel dimensions must be an integer legacy inch value or a \"<n> mm\" string",
+                    member );
+}
+
+auto format_for_display( const int millimeters ) -> std::string
+{
+    if( get_option<std::string>( "WHEEL_SIZE_UNITS" ) == "imperial" ) {
+        const auto inches = static_cast<int>( std::lround( static_cast<double>( millimeters ) /
+                                              legacy_millimeters_per_inch ) );
+        return string_format( pgettext( "wheel dimension", "%d\"" ), inches );
+    }
+
+    return format_metric_dimension( millimeters );
+}
+
+} // namespace wheel_dimensions

--- a/src/wheel_dimensions.h
+++ b/src/wheel_dimensions.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <optional>
+#include <string>
+
+class JsonObject;
+
+namespace wheel_dimensions
+{
+
+inline constexpr auto legacy_millimeters_per_inch = 25;
+
+auto from_legacy_inches( int legacy_inches ) -> int;
+auto read_from_json( const JsonObject &jo, const std::string &member ) -> std::optional<int>;
+auto format_for_display( int millimeters ) -> std::string;
+
+} // namespace wheel_dimensions

--- a/tests/item_tname_test.cpp
+++ b/tests/item_tname_test.cpp
@@ -148,13 +148,23 @@ TEST_CASE( "wheel diameter", "[item][tname][wheel]" )
     item &wheel24 = *item::spawn_temporary( "wheel_wide" );
     item &wheel32 = *item::spawn_temporary( "wheel_armor" );
 
-    REQUIRE( wheel17.type->wheel->diameter == 17 );
-    REQUIRE( wheel24.type->wheel->diameter == 24 );
-    REQUIRE( wheel32.type->wheel->diameter == 32 );
+    REQUIRE( wheel17.type->wheel->diameter == 425 );
+    REQUIRE( wheel24.type->wheel->diameter == 600 );
+    REQUIRE( wheel32.type->wheel->diameter == 800 );
 
-    CHECK( wheel17.tname() == "17\" wheel" );
-    CHECK( wheel24.tname() == "24\" wide wheel" );
-    CHECK( wheel32.tname() == "32\" armored wheel" );
+    {
+        const override_option metric_display( "WHEEL_SIZE_UNITS", "metric" );
+        CHECK( wheel17.tname() == "42.5cm wheel" );
+        CHECK( wheel24.tname() == "60cm wide wheel" );
+        CHECK( wheel32.tname() == "80cm armored wheel" );
+    }
+
+    {
+        const override_option imperial_display( "WHEEL_SIZE_UNITS", "imperial" );
+        CHECK( wheel17.tname() == "17\" wheel" );
+        CHECK( wheel24.tname() == "24\" wide wheel" );
+        CHECK( wheel32.tname() == "32\" armored wheel" );
+    }
 }
 
 TEST_CASE( "item health or damage bar", "[item][tname][health][damage]" )

--- a/tests/item_tname_test.cpp
+++ b/tests/item_tname_test.cpp
@@ -153,14 +153,14 @@ TEST_CASE( "wheel diameter", "[item][tname][wheel]" )
     REQUIRE( wheel32.type->wheel->diameter == 800 );
 
     {
-        const override_option metric_display( "WHEEL_SIZE_UNITS", "metric" );
+        const override_option metric_display( "DISTANCE_UNITS", "metric" );
         CHECK( wheel17.tname() == "42.5cm wheel" );
         CHECK( wheel24.tname() == "60cm wide wheel" );
         CHECK( wheel32.tname() == "80cm armored wheel" );
     }
 
     {
-        const override_option imperial_display( "WHEEL_SIZE_UNITS", "imperial" );
+        const override_option imperial_display( "DISTANCE_UNITS", "imperial" );
         CHECK( wheel17.tname() == "17\" wheel" );
         CHECK( wheel24.tname() == "24\" wide wheel" );
         CHECK( wheel32.tname() == "32\" armored wheel" );

--- a/tests/wheel_dimensions_test.cpp
+++ b/tests/wheel_dimensions_test.cpp
@@ -32,13 +32,13 @@ TEST_CASE( "wheel dimensions accept metric strings and legacy inches", "[wheel][
 TEST_CASE( "wheel dimensions display in selected units", "[wheel][units]" )
 {
     {
-        const override_option metric_display( "WHEEL_SIZE_UNITS", "metric" );
+        const override_option metric_display( "DISTANCE_UNITS", "metric" );
         CHECK( wheel_dimensions::format_for_display( 425 ) == "42.5cm" );
         CHECK( wheel_dimensions::format_for_display( 500 ) == "50cm" );
     }
 
     {
-        const override_option imperial_display( "WHEEL_SIZE_UNITS", "imperial" );
+        const override_option imperial_display( "DISTANCE_UNITS", "imperial" );
         CHECK( wheel_dimensions::format_for_display( 425 ) == "17\"" );
         CHECK( wheel_dimensions::format_for_display( 500 ) == "20\"" );
     }

--- a/tests/wheel_dimensions_test.cpp
+++ b/tests/wheel_dimensions_test.cpp
@@ -1,0 +1,45 @@
+#include "catch/catch.hpp"
+
+#include <sstream>
+#include <string>
+
+#include "json.h"
+#include "options_helpers.h"
+#include "wheel_dimensions.h"
+
+namespace
+{
+
+auto read_dimension( const std::string &json, const std::string &member ) -> int
+{
+    std::istringstream buffer( json );
+    JsonIn jsin( buffer );
+    const auto jo = jsin.get_object();
+    const auto dimension = wheel_dimensions::read_from_json( jo, member );
+    REQUIRE( dimension.has_value() );
+    return *dimension;
+}
+
+} // namespace
+
+TEST_CASE( "wheel dimensions accept metric strings and legacy inches", "[wheel][units]" )
+{
+    CHECK( read_dimension( R"({"diameter":17})", "diameter" ) == 425 );
+    CHECK( read_dimension( R"({"diameter":"425 mm"})", "diameter" ) == 425 );
+    CHECK( read_dimension( R"({"width":"225mm"})", "width" ) == 225 );
+}
+
+TEST_CASE( "wheel dimensions display in selected units", "[wheel][units]" )
+{
+    {
+        const override_option metric_display( "WHEEL_SIZE_UNITS", "metric" );
+        CHECK( wheel_dimensions::format_for_display( 425 ) == "42.5cm" );
+        CHECK( wheel_dimensions::format_for_display( 500 ) == "50cm" );
+    }
+
+    {
+        const override_option imperial_display( "WHEEL_SIZE_UNITS", "imperial" );
+        CHECK( wheel_dimensions::format_for_display( 425 ) == "17\"" );
+        CHECK( wheel_dimensions::format_for_display( 500 ) == "20\"" );
+    }
+}


### PR DESCRIPTION
## Why

- Undo the harm done to automobile industry by US
- Consistency with other options that support metric units
- json: `{n} mm` is easier to grasp than `{n}` which may be in arbitrary unit
- I refuse to calculate vehicle parts in inches

## How

<img width="1410" height="850" alt="image" src="https://github.com/user-attachments/assets/8909a044-73bc-4af8-ab29-e14885364977" />
<img width="1410" height="850" alt="image" src="https://github.com/user-attachments/assets/824c802d-842a-458f-bf39-b8530a199399" />

- 1 inch == 25mm