### PR TITLE
fix: do not open window on `--jsonverify`

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -263,6 +263,7 @@ int main( int argc, char *argv[] )
                     "Checks the BN json files",
                     section_default,
                     [&verifyexit]( int, const char ** ) -> int {
+                        test_mode = true;
                         verifyexit = true;
                         return 0;
                     }


### PR DESCRIPTION
running `./cataclysm-bn-tiles --jsonverify data` opens empty window which is annoying. enabled test mode to make it not do that