### PR TITLE
fix: Crafting menu Segfaults when recipe list is empty

### DIFF
--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -1356,11 +1356,11 @@ const recipe *select_crafting_recipe( int &batch_size_out )
         } else if( action == "UP" ) {
             line--;
             user_moved_line = highlight_unread_recipes;
-        } else if( action == "CONFIRM" && current[line]->is_nested() ) {
-            nested_toggle( current[line]->ident(), recalc, keepline );
         } else if( action == "CONFIRM" ) {
-            if( available.empty() || !available[line].can_craft ) {
+            if( available.empty() || !( available[line].can_craft || available[line].is_nested_category ) ) {
                 popup( _( "You can't do that!  Press [<color_yellow>ESC</color>]!" ) );
+            } else if( current[line]->is_nested() ) {
+                nested_toggle( current[line]->ident(), recalc, keepline );
             } else if( !u.check_eligible_containers_for_crafting( *current[line],
                        ( batch ) ? line + 1 : 1 ) ) {
                 // popup is already inside check


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

Fixes an oversight from nested recipes PR which can segfault from an out-of-bounds read when the `current` vector is empty

* Closes: #8462
* Related PRs
  * #8059
  * #8424

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)

Change logic to handle nested recipe toggling on the same confirm action branch as normal recipes, which shows an error message when action is unavailable.

<!-- e.g nerfs monster A -->

## Describe alternatives you've considered

N/A

## Testing

* Open Crafting Menu with empty favorites
* Press Enter
* No Segfault
* Shows `You can't do that!` message instead 


<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<img width="721" height="458" alt="image" src="https://github.com/user-attachments/assets/67eee50a-7d8b-4628-8970-1df2384a4f73" />

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.