### PR TITLE
fix: fix door lock error & misc vehicle export fixes

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -729,7 +729,7 @@ void vehicle::init_state( const int init_veh_fuel, const int init_veh_status,
             } else {
                 // Already installed from blueprint
                 const auto lock = part_with_feature( door, str_DOOR_LOCKING, true );
-                if( idx >= 0 ) {
+                if( lock >= 0 ) {
                     parts[lock].enabled = lockDoors;
                 } else {
                     // Already installed from blueprint

--- a/src/vehicle_export.cpp
+++ b/src/vehicle_export.cpp
@@ -39,15 +39,14 @@ auto json_part_write( JsonOut &json, const vehicle_part *p ) -> void
     const auto &id  = p->info().get_id();
     const auto &ammo_type = p->ammo_current();
 
-    if( id == vpart_id( "door_lock" ) ) {
-        return;
-    }
     json.member( "part", id );
     if( p->is_tank() ) {
         json.member( "fuel", ammo_type );
     } else if( p->is_turret() ) {
         json.member( "ammo", 50 );
-        json.member( "ammo_types", std::array{ ammo_type } );
+        if( ammo_type.is_valid() && !ammo_type.is_null() && !ammo_type.is_empty() ) {
+            json.member( "ammo_types", std::array{ ammo_type } );
+        }
         json.member( "ammo_qty", std::array{ 0, p->ammo_capacity() } );
     }
 }
@@ -62,6 +61,9 @@ auto json_parts_write( JsonOut &json, const refs &parts ) -> void
         json.member( "parts" );
         json.start_array();
         for( const auto *p : parts ) {
+            if( p->info().get_id().str().contains( "door_lock" ) ) {
+                continue;
+            }
             if( is_plain_id( p ) ) {
                 json.write( p->info().get_id() );
             } else {


### PR DESCRIPTION
## Purpose of change (The Why)
Door locks still somehow were exported from vehicles
Apparently
```
if( id == vpart_id( "door_lock" ) ) {
    return;
}
```
Was not enough I guess

Also it would sometimes export null ammo; Remove that

## Describe the solution (The How)
Fix door lock error ( wrong index used )
Fixed ammo type exporting
Used contains on door lock export

## Describe alternatives you've considered
Add more safeguards on loading "null" ammo type

## Testing
Exported vehicle without ammo with doors
It no longer crashes

## Additional context
I swore it worked for me last time...

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.