### PR TITLE
feat(lua): auto-mop when wielding mop

### DIFF
--- a/data/json/lua_traits.lua
+++ b/data/json/lua_traits.lua
@@ -13,6 +13,19 @@ local effect_shakes = EffectTypeId.new("shakes")
 local morale_indoor_misery = MoraleTypeDataId.new("morale_indoor_misery")
 local morale_outdoor_misery = MoraleTypeDataId.new("morale_outdoor_misery")
 local morale_clutter_intolerant = MoraleTypeDataId.new("morale_clutter_intolerant")
+local moppable_field_ids = {
+  FieldTypeId.new("fd_blood"):int_id(),
+  FieldTypeId.new("fd_blood_veggy"):int_id(),
+  FieldTypeId.new("fd_blood_insect"):int_id(),
+  FieldTypeId.new("fd_blood_invertebrate"):int_id(),
+  FieldTypeId.new("fd_gibs_flesh"):int_id(),
+  FieldTypeId.new("fd_gibs_veggy"):int_id(),
+  FieldTypeId.new("fd_gibs_insect"):int_id(),
+  FieldTypeId.new("fd_gibs_invertebrate"):int_id(),
+  FieldTypeId.new("fd_bile"):int_id(),
+  FieldTypeId.new("fd_slime"):int_id(),
+  FieldTypeId.new("fd_sludge"):int_id(),
+}
 
 local clutter_radius = 8
 local clutter_threshold = 12
@@ -50,6 +63,34 @@ local function is_passable(map, pt)
   local furn = map:get_furn_at(pt):obj()
   if furn:has_flag("IMPASSABLE") then return false end
   return true
+end
+
+---@param who Character
+local function is_wielding_mop(who)
+  for _, it in pairs(who:all_items(false)) do
+    if who:is_wielding(it) then
+      local itype = it:get_type():obj()
+      if itype and itype:can_use("MOP") then return true end
+    end
+  end
+  return false
+end
+
+---@param here Map
+---@param center Tripoint
+local function auto_mop_surrounding(here, center)
+  local mopped_tiles = 0
+  for _, pt in ipairs(here:points_in_radius(center, 1)) do
+    local mopped_tile = false
+    for _, field_id in ipairs(moppable_field_ids) do
+      if here:has_field_at(pt, field_id) then
+        here:remove_field_at(pt, field_id)
+        mopped_tile = true
+      end
+    end
+    if mopped_tile then mopped_tiles = mopped_tiles + 1 end
+  end
+  return mopped_tiles
 end
 
 ---@param who Character
@@ -260,20 +301,21 @@ local function tick_clutter_intolerant()
   end
 end
 
----@param params table
----@return boolean
+---@param params OnCharacterTryMoveParams
 local function on_character_try_move(params)
   ---@type Character
   local ch = params.char
   if not ch then return true end
+
+  local here = gapi.get_map()
+  local dest = params.to
+
   if not ch:has_trait(trait_nyctophobia) then return true end
   if ch:get_effect_int(effect_depressants) > 3 then return true end
   if params.movement_mode == CharacterMoveMode.run then return true end
 
-  local dest = params.to
   if not dest then return true end
 
-  local here = gapi.get_map()
   local threshold = nyctophobia_threshold()
   if here:ambient_light_at(dest) >= threshold then return true end
 
@@ -288,9 +330,30 @@ local function on_character_try_move(params)
   return false
 end
 
+---@param params OnCharacterTryMoveParams
+local function on_character_try_move_with_auto_mop(params)
+  local allowed = on_character_try_move(params)
+  if not allowed then return false end
+
+  ---@type Character
+  local ch = params.char
+  if not ch then return true end
+  if params.movement_mode ~= CharacterMoveMode.walk then return true end
+
+  local dest = params.to
+  if not dest then return true end
+
+  local here = gapi.get_map()
+  if not is_wielding_mop(ch) then return true end
+
+  local mopped_tiles = auto_mop_surrounding(here, dest)
+  if mopped_tiles > 0 then ch:mod_moves(-150 * mopped_tiles) end
+  return true
+end
+
 ---@param mod table
 function lua_traits.register(mod)
-  mod.on_character_try_move = on_character_try_move
+  mod.on_character_try_move = on_character_try_move_with_auto_mop
   mod.on_nyctophobia_tick = tick_nyctophobia
   mod.on_morale_traits_tick = tick_morale_traits
   mod.on_clutter_intolerant_tick = tick_clutter_intolerant

--- a/data/raw/generate_types.lua
+++ b/data/raw/generate_types.lua
@@ -293,6 +293,16 @@ on_npc_try_move = {}
 ---@field force boolean
 on_monster_try_move = {}
 
+---@class OnCharacterTryMoveParams
+---@field char Character
+---@field from Tripoint
+---@field to Tripoint
+---@field movement_mode CharacterMoveMode
+---@field via_ramp boolean
+---@field mounted boolean
+---@field mount Creature?
+on_character_try_move = {}
+
 ---@class OnCharacterResetStatsParams
 ---@field character Character
 on_character_reset_stats = {}


### PR DESCRIPTION


## Purpose of change (The Why)

why many mop when wield do the trick
or in technical terms: haha cleaning go brrrrrrrrrrrrrrrrrrrrrr

## Describe the solution (The How)

add check for holding mop, and auto-mop nearby when walking

## Describe alternatives you've considered

could be made more performant i guess by caching or adding C++ querying method
but it's simple and it works yeeeeeeee

## Testing

https://github.com/user-attachments/assets/fab822e5-d76e-4c73-8e0e-94694826a901

## Additional context


## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

- [x] This PR modifies lua scripts or the lua API.
  - [x] I have added [`lua` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#lua%3A-changes-to-lua-api) to the PR title.
  - [x] I have added [type annotations](https://emmylua.github.io/annotation.html) to functions so that it's safe and easy to maintain.
