### PR TITLE
fix: Make Windows crash logs better

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -318,17 +318,13 @@ jobs:
 
       - name: Locate PDB (windows msvc)
         if: runner.os == 'Windows'
-        run: |
-          Write-Host "=== Searching for PDB files ==="
-          Get-ChildItem -Path "${{ github.workspace }}/out/build/windows-tiles-sounds-x64-msvc" -Filter "*.pdb" -Recurse | Select-Object FullName, Length
-          Write-Host "=== Build directory root contents ==="
-          Get-ChildItem -Path "${{ github.workspace }}/out/build/windows-tiles-sounds-x64-msvc" | Select-Object Name, Length, LastWriteTime
+        run: Get-ChildItem -Path "${{ github.workspace }}/out/build/windows-tiles-sounds-x64-msvc" -Filter "*.pdb" -Recurse | Select-Object -ExpandProperty FullName
 
       - name: Archive PDB (windows msvc)
         if: runner.os == 'Windows'
         run: |
           Compress-Archive -Force `
-            -Path "${{ github.workspace }}/out/build/windows-tiles-sounds-x64-msvc/cataclysm-bn-tiles.pdb" `
+            -Path "${{ github.workspace }}/out/build/windows-tiles-sounds-x64-msvc/src/cataclysm-bn-tiles.pdb" `
             -DestinationPath "cbn-${{ matrix.artifact }}-${{ inputs.version-label }}-pdb.zip"
 
       # Build with Make (macOS) - TODO: migrate to CMake once dmgdist target is implemented

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -318,7 +318,11 @@ jobs:
 
       - name: Locate PDB (windows msvc)
         if: runner.os == 'Windows'
-        run: Get-ChildItem -Path "${{ github.workspace }}/out/build/windows-tiles-sounds-x64-msvc" -Filter "*.pdb"
+        run: |
+          Write-Host "=== Searching for PDB files ==="
+          Get-ChildItem -Path "${{ github.workspace }}/out/build/windows-tiles-sounds-x64-msvc" -Filter "*.pdb" -Recurse | Select-Object FullName, Length
+          Write-Host "=== Build directory root contents ==="
+          Get-ChildItem -Path "${{ github.workspace }}/out/build/windows-tiles-sounds-x64-msvc" | Select-Object Name, Length, LastWriteTime
 
       - name: Archive PDB (windows msvc)
         if: runner.os == 'Windows'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -316,6 +316,17 @@ jobs:
           cmake --install out/build/windows-tiles-sounds-x64-msvc --prefix cataclysmbn-${{ inputs.version-label }} --config Release
           Compress-Archive -Force -Path cataclysmbn-${{ inputs.version-label }}/* -DestinationPath cbn-${{ matrix.artifact }}-${{ inputs.version-label }}.zip
 
+      - name: Locate PDB (windows msvc)
+        if: runner.os == 'Windows'
+        run: Get-ChildItem -Path "${{ github.workspace }}/out/build/windows-tiles-sounds-x64-msvc" -Filter "*.pdb"
+
+      - name: Archive PDB (windows msvc)
+        if: runner.os == 'Windows'
+        run: |
+          Compress-Archive -Force `
+            -Path "${{ github.workspace }}/out/build/windows-tiles-sounds-x64-msvc/cataclysm-bn-tiles.pdb" `
+            -DestinationPath "cbn-${{ matrix.artifact }}-${{ inputs.version-label }}-pdb.zip"
+
       # Build with Make (macOS) - TODO: migrate to CMake once dmgdist target is implemented
       - name: Build CBN (osx)
         if: runner.os == 'macOS'
@@ -395,6 +406,18 @@ jobs:
             gh release edit experimental --title "Experimental @ $TIMESTAMP ($SHA_SHORT)" --notes "Experimental build for commit $SHA_SHORT on $TIMESTAMP"
           else
             gh release upload ${{ inputs.release-tag }} --clobber cbn-${{ matrix.artifact }}-${{ inputs.version-label }}.${{ matrix.ext }}
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+
+      - name: Upload PDB to release (windows msvc)
+        if: runner.os == 'Windows' && inputs.upload-to-release
+        run: |
+          if [ "${{ inputs.version-label }}" = "experimental" ]; then
+            gh release upload experimental --clobber "cbn-${{ matrix.artifact }}-${{ inputs.version-label }}-pdb.zip"
+          else
+            gh release upload ${{ inputs.release-tag }} --clobber "cbn-${{ matrix.artifact }}-${{ inputs.version-label }}-pdb.zip"
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src/crash.cpp
+++ b/src/crash.cpp
@@ -236,9 +236,6 @@ static LONG WINAPI windows_exception_filter( EXCEPTION_POINTERS *exception_info 
 
 void init_crash_handlers()
 {
-#if defined(_WIN32)
-    SetUnhandledExceptionFilter( windows_exception_filter );
-#endif
     for( auto sig : {
              SIGSEGV, SIGILL, SIGABRT, SIGFPE
          } ) {
@@ -246,6 +243,11 @@ void init_crash_handlers()
         std::signal( sig, signal_handler );
     }
     std::set_terminate( crash_terminate_handler );
+#if defined(_WIN32)
+    // Registered last so any SetUnhandledExceptionFilter call made internally
+    // by the CRT's signal() machinery does not overwrite ours.
+    SetUnhandledExceptionFilter( windows_exception_filter );
+#endif
 }
 
 #else // !BACKTRACE

--- a/src/crash.cpp
+++ b/src/crash.cpp
@@ -3,6 +3,7 @@
 
 #if defined(BACKTRACE)
 
+#include <atomic>
 #include <csignal>
 #include <cstdio>
 #include <cstdlib>
@@ -26,6 +27,14 @@
 
 // signal handlers are expected to have C linkage, and only use the
 // common subset of C & C++
+
+#if defined(_WIN32)
+// Ensures only the first crash path (exception filter or signal handler) logs and dumps.
+static std::atomic_flag g_crash_logged{};
+// Set by windows_exception_filter; used by dump_to() and debug_write_backtrace().
+static EXCEPTION_POINTERS *g_exception_info = nullptr;
+#endif
+
 extern "C" {
 
 #if defined(_WIN32)
@@ -33,13 +42,19 @@ extern "C" {
     {
         HANDLE handle = CreateFile( file, GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS,
                                     FILE_ATTRIBUTE_NORMAL, nullptr );
-        // TODO: call from a separate process as suggested by the documentation
-        // TODO: capture stack trace and pass as parameter as suggested by the documentation
+        MINIDUMP_EXCEPTION_INFORMATION mdei = {};
+        MINIDUMP_EXCEPTION_INFORMATION *mdei_ptr = nullptr;
+        if( g_exception_info ) {
+            mdei.ThreadId          = GetCurrentThreadId();
+            mdei.ExceptionPointers = g_exception_info;
+            mdei.ClientPointers    = FALSE;
+            mdei_ptr               = &mdei;
+        }
         MiniDumpWriteDump( GetCurrentProcess(),
                            GetCurrentProcessId(),
                            handle,
-                           MiniDumpNormal,
-                           nullptr, nullptr, nullptr );
+                           static_cast<MINIDUMP_TYPE>( MiniDumpNormal | MiniDumpWithUnloadedModules ),
+                           mdei_ptr, nullptr, nullptr );
         CloseHandle( handle );
     }
 #endif
@@ -112,6 +127,12 @@ extern "C" {
 #pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
         signal( sig, SIG_DFL );
 #pragma GCC diagnostic pop
+#if defined(_WIN32)
+        if( g_crash_logged.test_and_set() ) {
+            raise( sig );
+            return;
+        }
+#endif
         const char *msg;
         switch( sig ) {
             case SIGSEGV:
@@ -139,6 +160,41 @@ extern "C" {
         abort();
     }
 } // extern "C"
+
+#if defined(_WIN32)
+static LONG WINAPI windows_exception_filter( EXCEPTION_POINTERS *exception_info )
+{
+    if( g_crash_logged.test_and_set() ) {
+        return EXCEPTION_CONTINUE_SEARCH;
+    }
+    g_exception_info = exception_info;
+    set_crash_exception_context( exception_info ? exception_info->ContextRecord : nullptr );
+    const char *msg = "Unknown exception";
+    if( exception_info && exception_info->ExceptionRecord ) {
+        switch( exception_info->ExceptionRecord->ExceptionCode ) {
+            case EXCEPTION_ACCESS_VIOLATION:
+                msg = "EXCEPTION_ACCESS_VIOLATION: Access violation";
+                break;
+            case EXCEPTION_ILLEGAL_INSTRUCTION:
+                msg = "EXCEPTION_ILLEGAL_INSTRUCTION: Illegal instruction";
+                break;
+            case EXCEPTION_STACK_OVERFLOW:
+                msg = "EXCEPTION_STACK_OVERFLOW: Stack overflow";
+                break;
+            case EXCEPTION_INT_DIVIDE_BY_ZERO:
+                msg = "EXCEPTION_INT_DIVIDE_BY_ZERO: Integer divide by zero";
+                break;
+            case EXCEPTION_FLT_DIVIDE_BY_ZERO:
+                msg = "EXCEPTION_FLT_DIVIDE_BY_ZERO: Float divide by zero";
+                break;
+            default:
+                break;
+        }
+    }
+    log_crash( "Signal", msg );
+    return EXCEPTION_CONTINUE_SEARCH;
+}
+#endif
 
 [[noreturn]] static void crash_terminate_handler()
 {
@@ -180,6 +236,9 @@ extern "C" {
 
 void init_crash_handlers()
 {
+#if defined(_WIN32)
+    SetUnhandledExceptionFilter( windows_exception_filter );
+#endif
     for( auto sig : {
              SIGSEGV, SIGILL, SIGABRT, SIGFPE
          } ) {

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -1054,6 +1054,12 @@ struct backtrace_module_info_t {
 };
 static std::map<DWORD64, backtrace_module_info_t> bt_module_info_map;
 #endif
+static CONTEXT *g_crash_context = nullptr;
+
+void set_crash_exception_context( void *context )
+{
+    g_crash_context = static_cast<CONTEXT *>( context );
+}
 #elif !defined(__ANDROID__) && !defined(LIBBACKTRACE)
 constexpr int bt_cnt = 20;
 static void *bt[bt_cnt];
@@ -1137,9 +1143,110 @@ void debug_write_backtrace( std::ostream &out )
     } );
     sym.SizeOfStruct = sizeof( SYMBOL_INFO );
     sym.MaxNameLen = max_name_len;
+    const HANDLE proc = GetCurrentProcess();
+#ifdef _WIN64
+    if( g_crash_context ) {
+        // Walk the stack from the exception context so frames reflect the actual crash
+        // site rather than the signal/exception handler.
+        CONTEXT ctx = *g_crash_context;
+        STACKFRAME64 frame = {};
+        frame.AddrPC.Offset    = ctx.Rip;
+        frame.AddrPC.Mode      = AddrModeFlat;
+        frame.AddrFrame.Offset = ctx.Rbp;
+        frame.AddrFrame.Mode   = AddrModeFlat;
+        frame.AddrStack.Offset = ctx.Rsp;
+        frame.AddrStack.Mode   = AddrModeFlat;
+        for( int i = 0;
+             StackWalk64( IMAGE_FILE_MACHINE_AMD64, proc, GetCurrentThread(),
+                          &frame, &ctx, nullptr,
+                          SymFunctionTableAccess64, SymGetModuleBase64, nullptr )
+             && i < bt_cnt; ++i ) {
+            const DWORD64 addr = frame.AddrPC.Offset;
+            DWORD64 off = 0;
+            out << "\n  #" << i;
+            out << "\n    (dbghelp: ";
+            if( SymFromAddr( proc, addr, &off, &sym ) ) {
+                out << demangle( sym.Name ) << "+0x" << std::hex << off << std::dec;
+            }
+            out << "@" << reinterpret_cast<void *>( static_cast<uintptr_t>( addr ) );
+            const DWORD64 mod_base = SymGetModuleBase64( proc, addr );
+            if( mod_base ) {
+                out << "[";
+                const DWORD mod_len = GetModuleFileName( reinterpret_cast<HMODULE>( mod_base ),
+                                      mod_path, module_path_len );
+                // mod_len == module_path_len means insufficient buffer
+                if( mod_len > 0 && mod_len < module_path_len ) {
+                    const char *mod_name = mod_path + mod_len;
+                    for( ; mod_name > mod_path && *( mod_name - 1 ) != '\\'; --mod_name ) {
+                    }
+                    out << mod_name;
+                } else {
+                    out << "0x" << std::hex << mod_base << std::dec;
+                }
+                out << "+0x" << std::hex << static_cast<uintptr_t>( addr ) - mod_base
+                    << std::dec << "]";
+            }
+            out << "), ";
+#if defined(LIBBACKTRACE)
+            backtrace_module_info_t bt_module_info;
+            if( mod_base ) {
+                const auto it = bt_module_info_map.find( mod_base );
+                if( it != bt_module_info_map.end() ) {
+                    bt_module_info = it->second;
+                } else {
+                    const DWORD mod_len2 = GetModuleFileName( reinterpret_cast<HMODULE>( mod_base ),
+                                           mod_path, module_path_len );
+                    if( mod_len2 > 0 && mod_len2 < module_path_len ) {
+                        bt_module_info.state = bt_create_state( mod_path, 0,
+                        // error callback
+                        [&out]( const char *const msg, const int errnum ) {
+                            out << "\n    (backtrace_create_state failed: errno = " << errnum
+                                << ", msg = " << ( msg ? msg : "[no msg]" ) << "),";
+                        } );
+                        bt_module_info.image_base = get_image_base( mod_path );
+                        if( bt_module_info.image_base == 0 ) {
+                            out << "\n    (cannot locate image base),";
+                        }
+                    } else {
+                        out << "\n    (executable path exceeds " << module_path_len << " chars),";
+                    }
+                    bt_module_info_map.emplace( mod_base, bt_module_info );
+                }
+            } else {
+                out << "\n    (unable to get module base address),";
+            }
+            if( bt_module_info.state && bt_module_info.image_base != 0 ) {
+                const uintptr_t de_aslr_pc = static_cast<uintptr_t>( addr ) - mod_base +
+                                             bt_module_info.image_base;
+                bt_syminfo( bt_module_info.state, de_aslr_pc,
+                            // syminfo callback
+                            [&out]( const uintptr_t pc, const char *const symname,
+                const uintptr_t symval, const uintptr_t ) {
+                    out << "\n    (libbacktrace: " << ( symname ? symname : "[unknown symbol]" )
+                        << "+0x" << std::hex << pc - symval << std::dec
+                        << "@0x" << std::hex << pc << std::dec
+                        << "),";
+                },
+                // error callback
+                [&out]( const char *const msg, const int errnum ) {
+                    out << "\n    (backtrace_syminfo failed: errno = " << errnum
+                        << ", msg = " << ( msg ? msg : "[no msg]" )
+                        << "),";
+                } );
+                bt_pcinfo( bt_module_info.state, de_aslr_pc, bt_full_print,
+                           // error callback
+                [&out]( const char *const msg, const int errnum ) {
+                    out << "\n    (backtrace_pcinfo failed: errno = " << errnum
+                        << ", msg = " << ( msg ? msg : "[no msg]" )
+                        << "),";
+                } );
+            }
+#endif
+        }
+    } else {
+#endif
     // libbacktrace's own backtrace capturing doesn't seem to work on Windows
     const USHORT num_bt = CaptureStackBackTrace( 0, bt_cnt, bt, nullptr );
-    const HANDLE proc = GetCurrentProcess();
     for( USHORT i = 0; i < num_bt; ++i ) {
         DWORD64 off;
         out << "\n  #" << i;
@@ -1222,6 +1329,9 @@ void debug_write_backtrace( std::ostream &out )
         }
 #endif
     }
+#ifdef _WIN64
+    }
+#endif
     out << "\n";
 #else
 #   if defined(LIBBACKTRACE)

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -1198,7 +1198,7 @@ void debug_write_backtrace( std::ostream &out )
                                            mod_path, module_path_len );
                     if( mod_len2 > 0 && mod_len2 < module_path_len ) {
                         bt_module_info.state = bt_create_state( mod_path, 0,
-                        // error callback
+                                                                // error callback
                         [&out]( const char *const msg, const int errnum ) {
                             out << "\n    (backtrace_create_state failed: errno = " << errnum
                                 << ", msg = " << ( msg ? msg : "[no msg]" ) << "),";
@@ -1245,90 +1245,90 @@ void debug_write_backtrace( std::ostream &out )
         }
     } else {
 #endif
-    // libbacktrace's own backtrace capturing doesn't seem to work on Windows
-    const USHORT num_bt = CaptureStackBackTrace( 0, bt_cnt, bt, nullptr );
-    for( USHORT i = 0; i < num_bt; ++i ) {
-        DWORD64 off;
-        out << "\n  #" << i;
-        out << "\n    (dbghelp: ";
-        if( SymFromAddr( proc, reinterpret_cast<DWORD64>( bt[i] ), &off, &sym ) ) {
-            out << demangle( sym.Name ) << "+0x" << std::hex << off << std::dec;
-        }
-        out << "@" << bt[i];
-        const DWORD64 mod_base = SymGetModuleBase64( proc, reinterpret_cast<DWORD64>( bt[i] ) );
-        if( mod_base ) {
-            out << "[";
-            const DWORD mod_len = GetModuleFileName( reinterpret_cast<HMODULE>( mod_base ), mod_path,
-                                  module_path_len );
-            // mod_len == module_path_len means insufficient buffer
-            if( mod_len > 0 && mod_len < module_path_len ) {
-                const char *mod_name = mod_path + mod_len;
-                for( ; mod_name > mod_path && *( mod_name - 1 ) != '\\'; --mod_name ) {
-                }
-                out << mod_name;
-            } else {
-                out << "0x" << std::hex << mod_base << std::dec;
+        // libbacktrace's own backtrace capturing doesn't seem to work on Windows
+        const USHORT num_bt = CaptureStackBackTrace( 0, bt_cnt, bt, nullptr );
+        for( USHORT i = 0; i < num_bt; ++i ) {
+            DWORD64 off;
+            out << "\n  #" << i;
+            out << "\n    (dbghelp: ";
+            if( SymFromAddr( proc, reinterpret_cast<DWORD64>( bt[i] ), &off, &sym ) ) {
+                out << demangle( sym.Name ) << "+0x" << std::hex << off << std::dec;
             }
-            out << "+0x" << std::hex << reinterpret_cast<uintptr_t>( bt[i] ) - mod_base <<
-                std::dec << "]";
-        }
-        out << "), ";
-#if defined(LIBBACKTRACE)
-        backtrace_module_info_t bt_module_info;
-        if( mod_base ) {
-            const auto it = bt_module_info_map.find( mod_base );
-            if( it != bt_module_info_map.end() ) {
-                bt_module_info = it->second;
-            } else {
+            out << "@" << bt[i];
+            const DWORD64 mod_base = SymGetModuleBase64( proc, reinterpret_cast<DWORD64>( bt[i] ) );
+            if( mod_base ) {
+                out << "[";
                 const DWORD mod_len = GetModuleFileName( reinterpret_cast<HMODULE>( mod_base ), mod_path,
                                       module_path_len );
+                // mod_len == module_path_len means insufficient buffer
                 if( mod_len > 0 && mod_len < module_path_len ) {
-                    bt_module_info.state = bt_create_state( mod_path, 0,
-                                                            // error callback
-                    [&out]( const char *const msg, const int errnum ) {
-                        out << "\n    (backtrace_create_state failed: errno = " << errnum
-                            << ", msg = " << ( msg ? msg : "[no msg]" ) << "),";
-                    } );
-                    bt_module_info.image_base = get_image_base( mod_path );
-                    if( bt_module_info.image_base == 0 ) {
-                        out << "\n    (cannot locate image base),";
+                    const char *mod_name = mod_path + mod_len;
+                    for( ; mod_name > mod_path && *( mod_name - 1 ) != '\\'; --mod_name ) {
                     }
+                    out << mod_name;
                 } else {
-                    out << "\n    (executable path exceeds " << module_path_len << " chars),";
+                    out << "0x" << std::hex << mod_base << std::dec;
                 }
-                bt_module_info_map.emplace( mod_base, bt_module_info );
+                out << "+0x" << std::hex << reinterpret_cast<uintptr_t>( bt[i] ) - mod_base <<
+                    std::dec << "]";
             }
-        } else {
-            out << "\n    (unable to get module base address),";
-        }
-        if( bt_module_info.state && bt_module_info.image_base != 0 ) {
-            const uintptr_t de_aslr_pc = reinterpret_cast<uintptr_t>( bt[i] ) - mod_base +
-                                         bt_module_info.image_base;
-            bt_syminfo( bt_module_info.state, de_aslr_pc,
-                        // syminfo callback
-                        [&out]( const uintptr_t pc, const char *const symname,
-            const uintptr_t symval, const uintptr_t ) {
-                out << "\n    (libbacktrace: " << ( symname ? symname : "[unknown symbol]" )
-                    << "+0x" << std::hex << pc - symval << std::dec
-                    << "@0x" << std::hex << pc << std::dec
-                    << "),";
-            },
-            // error callback
-            [&out]( const char *const msg, const int errnum ) {
-                out << "\n    (backtrace_syminfo failed: errno = " << errnum
-                    << ", msg = " << ( msg ? msg : "[no msg]" )
-                    << "),";
-            } );
-            bt_pcinfo( bt_module_info.state, de_aslr_pc, bt_full_print,
-                       // error callback
-            [&out]( const char *const msg, const int errnum ) {
-                out << "\n    (backtrace_pcinfo failed: errno = " << errnum
-                    << ", msg = " << ( msg ? msg : "[no msg]" )
-                    << "),";
-            } );
-        }
+            out << "), ";
+#if defined(LIBBACKTRACE)
+            backtrace_module_info_t bt_module_info;
+            if( mod_base ) {
+                const auto it = bt_module_info_map.find( mod_base );
+                if( it != bt_module_info_map.end() ) {
+                    bt_module_info = it->second;
+                } else {
+                    const DWORD mod_len = GetModuleFileName( reinterpret_cast<HMODULE>( mod_base ), mod_path,
+                                          module_path_len );
+                    if( mod_len > 0 && mod_len < module_path_len ) {
+                        bt_module_info.state = bt_create_state( mod_path, 0,
+                                                                // error callback
+                        [&out]( const char *const msg, const int errnum ) {
+                            out << "\n    (backtrace_create_state failed: errno = " << errnum
+                                << ", msg = " << ( msg ? msg : "[no msg]" ) << "),";
+                        } );
+                        bt_module_info.image_base = get_image_base( mod_path );
+                        if( bt_module_info.image_base == 0 ) {
+                            out << "\n    (cannot locate image base),";
+                        }
+                    } else {
+                        out << "\n    (executable path exceeds " << module_path_len << " chars),";
+                    }
+                    bt_module_info_map.emplace( mod_base, bt_module_info );
+                }
+            } else {
+                out << "\n    (unable to get module base address),";
+            }
+            if( bt_module_info.state && bt_module_info.image_base != 0 ) {
+                const uintptr_t de_aslr_pc = reinterpret_cast<uintptr_t>( bt[i] ) - mod_base +
+                                             bt_module_info.image_base;
+                bt_syminfo( bt_module_info.state, de_aslr_pc,
+                            // syminfo callback
+                            [&out]( const uintptr_t pc, const char *const symname,
+                const uintptr_t symval, const uintptr_t ) {
+                    out << "\n    (libbacktrace: " << ( symname ? symname : "[unknown symbol]" )
+                        << "+0x" << std::hex << pc - symval << std::dec
+                        << "@0x" << std::hex << pc << std::dec
+                        << "),";
+                },
+                // error callback
+                [&out]( const char *const msg, const int errnum ) {
+                    out << "\n    (backtrace_syminfo failed: errno = " << errnum
+                        << ", msg = " << ( msg ? msg : "[no msg]" )
+                        << "),";
+                } );
+                bt_pcinfo( bt_module_info.state, de_aslr_pc, bt_full_print,
+                           // error callback
+                [&out]( const char *const msg, const int errnum ) {
+                    out << "\n    (backtrace_pcinfo failed: errno = " << errnum
+                        << ", msg = " << ( msg ? msg : "[no msg]" )
+                        << "),";
+                } );
+            }
 #endif
-    }
+        }
 #ifdef _WIN64
     }
 #endif

--- a/src/debug.h
+++ b/src/debug.h
@@ -287,6 +287,13 @@ DebugLogGuard realDebugLog( DL lev, DC cl, const char *filename,
  * Write a stack backtrace to the given ostream
  */
 void debug_write_backtrace( std::ostream &out );
+#if defined(_WIN32)
+/**
+ * Sets the CONTEXT* from the crash's EXCEPTION_POINTERS for accurate stack
+ * walking. Pass nullptr to clear. Must be called before debug_write_backtrace.
+ */
+void set_crash_exception_context( void *context );
+#endif
 #endif
 
 // vim:tw=72:sw=4:fdm=marker:fdl=0:


### PR DESCRIPTION
## Purpose of change (The Why)

Minidumps weren't useful because they were scoped incorrectly.
The logs were also giving raw pointer info.

## Describe the solution (The How)

Scoped to WIndows only, add filtering to intercept the exceptions.
Use that for minidump and the log stack.
Gotta be honest, I'm out of my depth on a lot of this. I used AI for more of this than I do for most anything, and that makes me very uncomfortable.
Save the PDB in another zip file for builds

## Testing

Tested with test crash, got symbols.
Tested the full build and acquired the PDB.