### PR TITLE
fix: EXTENDABLE parts no longer support installation of other parts

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1669,6 +1669,12 @@ bool vehicle::can_mount( point dp, const vpart_id &id ) const
     if( !parts_in_square.empty() && part_info( parts_in_square[0] ).has_flag( "NOCOLLIDE" ) ) {
         return false;
     }
+    // EXTENDABLE parts can not have other parts on the same tile
+    // Todo: let there be an exception for mount points when added
+    // Like turret mount points
+    if( !parts_in_square.empty() && part_info( parts_in_square[0] ).has_flag( "EXTENDABLE" ) ) {
+        return false;
+    }
 
     //No part type can stack with itself, or any other part in the same slot
     for( const auto &elem : parts_in_square ) {


### PR DESCRIPTION
## Purpose of change (The Why)
This was suppost to be the difference between EXTENDABLE and structural parts

## Describe the solution (The How)
Check for extendable and make it so they cant install things on them

## Describe alternatives you've considered
Wait a few months until I devise the better vehicle mountpoint system
So that things like guns and propellers can be put on wings themselves

## Testing
No more installs on wings

## Additional context
I screm

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.