### PR TITLE
perf: Lua mapgen lag fix

### DIFF
--- a/src/catalua.cpp
+++ b/src/catalua.cpp
@@ -913,6 +913,71 @@ void run_on_mapgen_postprocess_hooks( lua_state &state, map &m, const tripoint &
     }, { .state = &state } );
 }
 
+void run_on_mapgen_postprocess_hooks_batch( lua_state &state, tinymap &tmp,
+                                             std::span<const mapgen_hook_batch_item> items )
+{
+    if( items.empty() ) {
+        return;
+    }
+
+    auto &lua = state.lua;
+    const auto maybe_hooks = lua.globals()["game"]["hooks"]["on_mapgen_postprocess"]
+                             .get<sol::optional<sol::table>>();
+    if( !maybe_hooks ) {
+        return;
+    }
+
+    const auto &hooks   = *maybe_hooks;
+    const auto &entries = get_hook_entries( lua, "on_mapgen_postprocess", hooks );
+    if( entries.empty() ) {
+        return;
+    }
+
+    // Create the params table once for the whole batch.
+    // params["map"] holds a pointer to tmp; bind_submaps_for_hook() rebinds the
+    // underlying submap grid in-place, so the Lua side always sees current data
+    // without us needing to reassign params["map"] per item.
+    // The results table is intentionally omitted — on_mapgen_postprocess callers
+    // discard the return value, so tracking per-hook results is pure overhead.
+    auto params = lua.create_table();
+    params["map"] = static_cast<map *>( &tmp );
+
+    std::ranges::for_each( items, [&]( const mapgen_hook_batch_item & item ) {
+        tmp.bind_submaps_for_hook( item.sm_base );
+        params["prev"] = sol::lua_nil;
+        params["omt"]  = item.omt_pos;
+        params["when"] = item.when;
+
+        std::ranges::for_each( entries, [&]( const hook_entry & e ) {
+            try {
+                const sol::object obj = hooks.get_or<sol::object>( e.index, sol::lua_nil );
+                if( obj == sol::lua_nil ) {
+                    return;
+                }
+
+                sol::protected_function func;
+                if( e.is_table ) {
+                    func = obj.as<sol::table>()
+                               .get_or<sol::object>( "fn", sol::lua_nil )
+                               .as<sol::protected_function>();
+                } else {
+                    func = obj.as<sol::protected_function>();
+                }
+
+                sol::protected_function_result res = func( params );
+                check_func_result( res );
+
+                if( res.valid() ) {
+                    params["prev"] = res.get<sol::object>();
+                }
+            } catch( const std::runtime_error & err ) {
+                debugmsg( "Failed to run hook on_mapgen_postprocess[%d]: %s",
+                          e.index, err.what() );
+            }
+        } );
+    } );
+}
+
 bool has_mapgen_postprocess_hooks( lua_state &state )
 {
     const auto maybe_hooks = state.lua.globals()["game"]["hooks"]["on_mapgen_postprocess"]

--- a/src/catalua.cpp
+++ b/src/catalua.cpp
@@ -914,7 +914,7 @@ void run_on_mapgen_postprocess_hooks( lua_state &state, map &m, const tripoint &
 }
 
 void run_on_mapgen_postprocess_hooks_batch( lua_state &state, tinymap &tmp,
-                                             std::span<const mapgen_hook_batch_item> items )
+        std::span<const mapgen_hook_batch_item> items )
 {
     if( items.empty() ) {
         return;
@@ -958,8 +958,8 @@ void run_on_mapgen_postprocess_hooks_batch( lua_state &state, tinymap &tmp,
                 sol::protected_function func;
                 if( e.is_table ) {
                     func = obj.as<sol::table>()
-                               .get_or<sol::object>( "fn", sol::lua_nil )
-                               .as<sol::protected_function>();
+                           .get_or<sol::object>( "fn", sol::lua_nil )
+                           .as<sol::protected_function>();
                 } else {
                     func = obj.as<sol::protected_function>();
                 }
@@ -970,7 +970,7 @@ void run_on_mapgen_postprocess_hooks_batch( lua_state &state, tinymap &tmp,
                 if( res.valid() ) {
                     params["prev"] = res.get<sol::object>();
                 }
-            } catch( const std::runtime_error & err ) {
+            } catch( const std::runtime_error &err ) {
                 debugmsg( "Failed to run hook on_mapgen_postprocess[%d]: %s",
                           e.index, err.what() );
             }

--- a/src/catalua.h
+++ b/src/catalua.h
@@ -1,14 +1,16 @@
 #pragma once
 
-#include "type_id.h"
+#include "calendar.h"
 #include "character.h"
+#include "point.h"
+#include "type_id.h"
 #include <memory>
 #include <filesystem>
+#include <span>
 
 class Item_factory;
 class map;
-class time_point;
-struct tripoint;
+class tinymap;
 class world;
 
 namespace cata
@@ -44,6 +46,28 @@ void run_on_game_save_hooks( lua_state &state );
 void run_on_every_x_hooks( lua_state &state );
 void run_on_mapgen_postprocess_hooks( lua_state &state, map &m, const tripoint &p,
                                       const time_point &when );
+
+/** Single item passed to run_on_mapgen_postprocess_hooks_batch(). */
+struct mapgen_hook_batch_item {
+    tripoint   sm_base;  // submap coords — passed to tinymap::bind_submaps_for_hook
+    tripoint   omt_pos;  // raw OmT position — forwarded to params["omt"]
+    time_point when;
+};
+
+/**
+ * Batch variant of run_on_mapgen_postprocess_hooks().
+ *
+ * Amortises Lua table allocation and hook-table lookup over the whole batch:
+ * the params table is created once, params["map"] is set once (the pointer
+ * remains valid while bind_submaps_for_hook() rebinds the underlying data),
+ * and the hook table is resolved once.  The results table is omitted entirely
+ * because on_mapgen_postprocess callers discard the return value.
+ *
+ * All items must belong to the same bound dimension of tmp.
+ */
+void run_on_mapgen_postprocess_hooks_batch( lua_state &state, tinymap &tmp,
+                                            std::span<const mapgen_hook_batch_item> items );
+
 /** Return true if at least one on_mapgen_postprocess hook is registered. */
 bool has_mapgen_postprocess_hooks( lua_state &state );
 void reg_lua_icallback_actors( lua_state &state, Item_factory &ifactory );

--- a/src/catalua.h
+++ b/src/catalua.h
@@ -66,7 +66,7 @@ struct mapgen_hook_batch_item {
  * All items must belong to the same bound dimension of tmp.
  */
 void run_on_mapgen_postprocess_hooks_batch( lua_state &state, tinymap &tmp,
-                                            std::span<const mapgen_hook_batch_item> items );
+        std::span<const mapgen_hook_batch_item> items );
 
 /** Return true if at least one on_mapgen_postprocess hook is registered. */
 bool has_mapgen_postprocess_hooks( lua_state &state );

--- a/src/catalua_bindings_map.cpp
+++ b/src/catalua_bindings_map.cpp
@@ -433,6 +433,14 @@ void cata::detail::reg_map( sol::state &lua )
         luna::set_fx( ut, "get_ter_at", sol::resolve<ter_id( const tripoint & )const>( &map::ter ) );
         luna::set_fx( ut, "set_ter_at",
                       sol::resolve<bool( const tripoint &, const ter_id & )>( &map::ter_set ) );
+        DOC( "Coordinate-based variants that avoid allocating a Tripoint object." );
+        luna::set_fx( ut, "get_ter_at_xyz", []( const map & m, int x, int y, int z ) -> ter_id {
+            return m.ter( tripoint( x, y, z ) );
+        } );
+        luna::set_fx( ut, "set_ter_at_xyz", []( map & m, int x, int y, int z,
+        const ter_id & id ) -> bool {
+            return m.ter_set( tripoint( x, y, z ), id );
+        } );
 
         luna::set_fx( ut, "get_furn_at", sol::resolve<furn_id( const tripoint & )const>( &map::furn ) );
         luna::set_fx( ut, "set_furn_at", []( map & m, const tripoint & p, const furn_id & id ) { m.furn_set( p, id ); } );

--- a/src/catalua_mapgen.cpp
+++ b/src/catalua_mapgen.cpp
@@ -5,7 +5,10 @@
 #include "player.h"
 #include "game.h"
 #include "mapgendata.h"
+#include "thread_pool.h"
 #include "sol/sol.hpp"
+
+#include <cassert>
 
 mapgen_function_lua::mapgen_function_lua( const std::string &func,
         int weight ) : mapgen_function( weight )
@@ -20,6 +23,9 @@ mapgen_function_lua::mapgen_function_lua( const std::string &func,
 
 void mapgen_function_lua::generate( mapgendata &dat )
 {
+    // Must not be called from a pool worker thread: generate_quad() detects
+    // Lua-based terrain and defers the whole quad to drain_deferred_lua_quads().
+    assert( !is_pool_worker_thread() );
     if( generate_func.valid() ) {
         sol::protected_function_result res = generate_func( &dat, &dat.m );
         check_func_result( res );

--- a/src/catalua_mapgen.h
+++ b/src/catalua_mapgen.h
@@ -19,6 +19,7 @@ class mapgen_function_lua : public virtual mapgen_function
         mapgen_function_lua( const std::string &func, int weight = 1000 );
 
         void generate( mapgendata &dat ) override;
+        auto is_lua_generator() const -> bool override { return true; }
 
 };
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2027,7 +2027,7 @@ void map::furn_set( const tripoint &p, const furn_id &new_furniture,
     set_memory_seen_cache_dirty( p );
 
     // TODO: Limit to changes that affect move cost, traps and stairs
-    set_pathfinding_cache_dirty( p.z );
+    set_pathfinding_cache_dirty( p );
 
     // Make sure the furniture falls if it needs to
     support_dirty( p );
@@ -2399,7 +2399,7 @@ bool map::ter_set( const tripoint &p, const ter_id &new_terrain )
     set_memory_seen_cache_dirty( p );
 
     // TODO: Limit to changes that affect move cost, traps and stairs
-    set_pathfinding_cache_dirty( p.z );
+    set_pathfinding_cache_dirty( p );
 
     tripoint above( p.xy(), p.z + 1 );
     // Make sure that if we supported something and no longer do so, it falls down
@@ -6556,7 +6556,7 @@ bool map::add_field( const tripoint &p, const field_type_id &type_id, int intens
     }
 
     if( fd_type.is_dangerous() ) {
-        set_pathfinding_cache_dirty( p.z );
+        set_pathfinding_cache_dirty( p );
     }
 
     // Ensure blood type fields don't hang in the air
@@ -6584,7 +6584,7 @@ void map::remove_field( const tripoint &p, const field_type_id &field_to_remove 
             set_seen_cache_dirty( p );
         }
         if( fdata.is_dangerous() ) {
-            set_pathfinding_cache_dirty( p.z );
+            set_pathfinding_cache_dirty( p );
         }
     }
 }
@@ -10511,6 +10511,15 @@ void map::set_pathfinding_cache_dirty( const int zlev )
                 sm->pf_dirty = true;
             }
         }
+    }
+}
+
+void map::set_pathfinding_cache_dirty( const tripoint &p )
+{
+    point l;
+    submap *const sm = get_submap_at( p, l );
+    if( sm ) {
+        sm->pf_dirty = true;
     }
 }
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -9993,12 +9993,18 @@ void tinymap::drain_to_mapbuffer( mapbuffer &dest )
     ( void )dest;
 }
 
-void tinymap::load_from_mapbuffer( const tripoint &sm_base )
+void tinymap::bind_submaps_for_hook( const tripoint &sm_base )
 {
+    // Directly wire the four 2×2 grid slots to the already-resident submaps.
+    // Does NOT call loadn()/actualize() — freshly generated submaps need no
+    // time-advance, and this tinymap is never rendered, simulated, or saved.
     set_abs_sub( sm_base );
-    for( auto di : std::views::iota( 0, 2 ) ) {
-        for( auto dj : std::views::iota( 0, 2 ) ) {
-            loadn( tripoint( di, dj, sm_base.z ), false );
+    mapbuffer &mb = MAPBUFFER_REGISTRY.get( get_bound_dimension() );
+    for( int di = 0; di < 2; ++di ) {
+        for( int dj = 0; dj < 2; ++dj ) {
+            const tripoint abs( sm_base.x + di, sm_base.y + dj, sm_base.z );
+            setsubmap( get_nonant( { di, dj, sm_base.z } ),
+                       mb.lookup_submap_in_memory( abs ) );
         }
     }
 }

--- a/src/map.h
+++ b/src/map.h
@@ -2377,13 +2377,17 @@ class tinymap : public map
         void drain_to_mapbuffer( mapbuffer &dest );
 
         /**
-         * Position this tinymap at @p sm_base (submap coordinates) and load
-         * its 2×2 submaps from the mapbuffer.  The submaps must already be
-         * present in the mapbuffer (e.g. after saven() was called during
-         * generation).  Used by run_deferred_mapgen_hooks() to reconstruct a
-         * live map reference on the main thread.
+         * Position this tinymap at @p sm_base (submap coordinates) and wire up
+         * its 2×2 grid slots directly from the mapbuffer without going through
+         * loadn().  The submaps must already be present in the mapbuffer.
+         *
+         * Unlike the old load_from_mapbuffer, this skips loadn()/actualize(),
+         * vehicle-cache setup, and render-cache invalidation.  This is correct
+         * for Lua on_mapgen_postprocess hooks: the submaps are freshly generated
+         * (no time-advance processing needed) and the tinymap is short-lived,
+         * never rendered or simulated.
          */
-        void load_from_mapbuffer( const tripoint &sm_base );
+        void bind_submaps_for_hook( const tripoint &sm_base );
 };
 
 class fake_map : public tinymap

--- a/src/map.h
+++ b/src/map.h
@@ -548,8 +548,11 @@ class map : public submap_load_listener
 
         void set_suspension_cache_dirty( const int zlev );
 
-        /// Mark the per-submap pf_cache dirty for the submap containing p.
+        /// Mark the per-submap pf_cache dirty for all submaps on zlev.
+        /// Use the tripoint overload for single-tile changes.
         void set_pathfinding_cache_dirty( int zlev );
+        /// Mark the per-submap pf_cache dirty for the single submap containing p.
+        void set_pathfinding_cache_dirty( const tripoint &p );
         /*@}*/
 
         void set_memory_seen_cache_dirty( const tripoint &p );

--- a/src/mapbuffer.cpp
+++ b/src/mapbuffer.cpp
@@ -643,7 +643,7 @@ auto mapbuffer::drain_deferred_lua_quads() -> std::vector<tripoint>
     }
 
     std::vector<tripoint> generated;
-    std::ranges::for_each( pending, [&]( const tripoint &om_addr ) {
+    std::ranges::for_each( pending, [&]( const tripoint & om_addr ) {
         if( generate_quad( om_addr ) ) {
             generated.push_back( om_addr );
         }

--- a/src/mapbuffer.cpp
+++ b/src/mapbuffer.cpp
@@ -15,6 +15,7 @@
 #include "calendar.h"
 #include "cata_utility.h"
 #include "coordinate_conversions.h"
+#include "mapgen_functions.h"
 #include "debug.h"
 #include "distribution_grid.h"
 #include "filesystem.h"
@@ -618,10 +619,36 @@ bool mapbuffer::generate_quad( const tripoint &om_addr )
     if( all_loaded ) {
         return false;
     }
+    // Lua mapgen is not reentrant: if the terrain at this quad uses a Lua-based
+    // generator and we are on a worker thread, defer the entire generate_quad()
+    // call to the main thread rather than allocating blank submaps and bailing
+    // partway through map::generate().
+    if( is_pool_worker_thread() && omt_mapgen_uses_lua( dimension_id_, om_addr ) ) {
+        std::lock_guard<std::mutex> lk( deferred_lua_quads_mutex_ );
+        deferred_lua_quads_.push_back( om_addr );
+        return false;
+    }
     tinymap tmp_map;
     tmp_map.bind_dimension( dimension_id_ );
     tmp_map.generate( base, calendar::turn );
     return true;
+}
+
+auto mapbuffer::drain_deferred_lua_quads() -> std::vector<tripoint>
+{
+    std::vector<tripoint> pending;
+    {
+        std::lock_guard<std::mutex> lk( deferred_lua_quads_mutex_ );
+        pending.swap( deferred_lua_quads_ );
+    }
+
+    std::vector<tripoint> generated;
+    std::ranges::for_each( pending, [&]( const tripoint &om_addr ) {
+        if( generate_quad( om_addr ) ) {
+            generated.push_back( om_addr );
+        }
+    } );
+    return generated;
 }
 
 bool mapbuffer::load_or_generate_quad( const tripoint &om_addr )

--- a/src/mapbuffer.h
+++ b/src/mapbuffer.h
@@ -172,6 +172,18 @@ class mapbuffer
         auto drain_pending_submap_destroy() -> void;
 
         /**
+         * Generate all quads that were deferred from worker threads because their
+         * overmap terrain has a Lua-based mapgen function (Lua is not reentrant).
+         *
+         * Runs generate_quad() for each deferred entry synchronously on the calling
+         * thread.  Must be called on the main thread only.
+         *
+         * Returns the om_addr of every quad that was actually generated (i.e. was
+         * not already resident in memory).  Callers should mark these dirty.
+         */
+        auto drain_deferred_lua_quads() -> std::vector<tripoint>;
+
+        /**
          * Conditionally save and then remove the submap at @p pos from the buffer.
          * The containing OMT quad is saved to disk first (unless it is fully uniform),
          * then the submap is erased from memory.  Does nothing if @p pos is not loaded.
@@ -225,6 +237,12 @@ class mapbuffer
         /// the player can revert to the pre-session state by quitting without saving.
         mutable std::mutex pending_writes_mutex_;
         std::map<tripoint, std::string> pending_writes_;
+
+        /// Quads whose overmap terrain has a Lua-based mapgen function.
+        /// generate_quad() pushes here instead of generating on the worker (Lua is not
+        /// reentrant).  Drained by drain_deferred_lua_quads() on the main thread.
+        mutable std::mutex deferred_lua_quads_mutex_;
+        std::vector<tripoint> deferred_lua_quads_;
 
     public:
         submap_map_t::iterator begin() {

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -293,6 +293,16 @@ class mapgen_basic_container
             ( *ptr )->generate( dat );
             return true;
         }
+        /** Returns true if any generator in the weighted pool is Lua-based. */
+        auto any_lua() const -> bool {
+            bool found = false;
+            weights_.apply( [&]( const std::shared_ptr<mapgen_function> &ptr ) {
+                if( ptr && ptr->is_lua_generator() ) {
+                    found = true;
+                }
+            } );
+            return found;
+        }
         /**
          * Calls @ref mapgen_function::setup and sets up the internal weighted list using
          * the **current** value of @ref mapgen_function::weight. This value may have
@@ -405,6 +415,14 @@ class mapgen_factory
                 return false;
             }
             return iter->second.generate( dat, hardcoded_weight );
+        }
+        /// Returns true if any generator registered under @p key is Lua-based.
+        auto has_lua_generator( const std::string &key ) const -> bool {
+            const auto iter = mapgens_.find( key );
+            if( iter == mapgens_.end() ) {
+                return false;
+            }
+            return iter->second.any_lua();
         }
 
         mapgen_parameters get_map_special_params( const std::string &key ) const {
@@ -7583,6 +7601,13 @@ std::pair<std::map<ter_id, int>, std::map<furn_id, int>> get_changed_ids_from_up
 bool run_mapgen_func( const std::string &mapgen_id, mapgendata &dat )
 {
     return oter_mapgen.generate( dat, mapgen_id );
+}
+
+auto omt_mapgen_uses_lua( const std::string &dim_id, const tripoint &om_addr ) -> bool
+{
+    overmapbuffer &omap = get_overmapbuffer( dim_id );
+    const oter_id terrain_type = omap.ter( tripoint_abs_omt( om_addr ) );
+    return oter_mapgen.has_lua_generator( terrain_type->get_mapgen_id() );
 }
 
 mapgen_parameters get_map_special_params( const std::string &mapgen_id )

--- a/src/mapgen.h
+++ b/src/mapgen.h
@@ -47,6 +47,7 @@ class mapgen_function
         virtual void check( const std::string & /*oter_name*/ ) const { }
 
         virtual void generate( mapgendata & ) = 0;
+        virtual auto is_lua_generator() const -> bool { return false; }
         virtual mapgen_parameters get_mapgen_params( mapgen_parameter_scope ) const {
             return {};
         }

--- a/src/mapgen_async.cpp
+++ b/src/mapgen_async.cpp
@@ -55,6 +55,11 @@ void refresh_mapgen_postprocess_hook_presence( cata::lua_state &state )
         std::memory_order_relaxed );
 }
 
+bool mapgen_hooks_registered()
+{
+    return g_has_mapgen_hooks.load( std::memory_order_relaxed );
+}
+
 void push_deferred_autonote( deferred_autonote entry )
 {
     std::lock_guard<std::mutex> lk( g_autonote_mutex );

--- a/src/mapgen_async.cpp
+++ b/src/mapgen_async.cpp
@@ -109,30 +109,45 @@ void run_deferred_mapgen_hooks()
         pending.swap( g_hooks );
     }
 
-    // Skip the expensive tinymap construction when no hooks are registered.
-    // Worker threads always push a deferred entry when generating on a worker
-    // thread, regardless of hook registration.  Checking here (on the main
-    // thread, where Lua access is safe) avoids building O(n) tinymaps per turn
-    // just to call a no-op hook loop.
-    if( !cata::has_mapgen_postprocess_hooks( *DynamicDataLoader::get_instance().lua ) ) {
+    // Fast path: nothing queued.  Skip the Lua state access entirely.
+    if( pending.empty() ) {
         return;
     }
 
-    for( auto &h : pending ) {
-        // The submaps are already in the mapbuffer (saven() was called before
-        // the hook was deferred).  Load them into a temporary tinymap so the
-        // Lua hook receives a live map reference identical in content to what
-        // it would have seen on the main thread.  Modifications to the tinymap
-        // go directly to the mapbuffer-owned submap objects.
-        const tripoint sm_base = omt_to_sm_copy( h.omt_pos.raw() );
-        tinymap tmp;
-        tmp.bind_dimension( h.dim );
-        tmp.load_from_mapbuffer( sm_base );
-        cata::run_on_mapgen_postprocess_hooks(
-            *DynamicDataLoader::get_instance().lua,
-            tmp,
-            h.omt_pos.raw(),
-            h.when
-        );
-    }
+    // Sort by dimension so bind_dimension() is only called when it changes
+    // (in practice almost all quads share the overworld dimension).
+    std::ranges::sort( pending, []( const auto & a, const auto & b ) {
+        return a.dim < b.dim;
+    } );
+
+    // Reuse one tinymap across the entire batch.  Accumulate items per
+    // dimension group and dispatch them together so the batch function can
+    // amortise Lua table allocation and hook-table lookup over all quads.
+    tinymap tmp;
+    std::string cur_dim;
+    std::vector<cata::mapgen_hook_batch_item> batch;
+    batch.reserve( pending.size() );
+
+    const auto flush = [&]() {
+        if( batch.empty() ) {
+            return;
+        }
+        cata::run_on_mapgen_postprocess_hooks_batch(
+            *DynamicDataLoader::get_instance().lua, tmp, batch );
+        batch.clear();
+    };
+
+    std::ranges::for_each( pending, [&]( const auto & h ) {
+        if( h.dim != cur_dim ) {
+            flush();
+            cur_dim = h.dim;
+            tmp.bind_dimension( cur_dim );
+        }
+        batch.push_back( {
+            .sm_base = omt_to_sm_copy( h.omt_pos.raw() ),
+            .omt_pos = h.omt_pos.raw(),
+            .when    = h.when,
+        } );
+    } );
+    flush();
 }

--- a/src/mapgen_async.h
+++ b/src/mapgen_async.h
@@ -71,6 +71,10 @@ void refresh_mapgen_postprocess_hook_presence( cata::lua_state &state );
  */
 void run_deferred_mapgen_hooks();
 
+/** Returns true if any on_mapgen_postprocess Lua hooks are registered.
+ *  Safe to call from any thread (relaxed atomic load). */
+bool mapgen_hooks_registered();
+
 /** Push an autonote entry from a worker thread (thread-safe). */
 void push_deferred_autonote( deferred_autonote entry );
 

--- a/src/mapgen_functions.h
+++ b/src/mapgen_functions.h
@@ -79,6 +79,14 @@ bool run_mapgen_update_func( const std::string &update_mapgen_id, const tripoint
 bool run_mapgen_update_func( const std::string &update_mapgen_id, mapgendata &dat,
                              bool cancel_on_collision = true );
 bool run_mapgen_func( const std::string &mapgen_id, mapgendata &dat );
+/**
+ * Returns true if the overmap terrain at @p om_addr in dimension @p dim_id
+ * has at least one Lua-based mapgen function in its weighted pool.
+ *
+ * Used by mapbuffer::generate_quad() to detect whether a quad must be
+ * deferred to the main thread (Lua is not reentrant on worker threads).
+ */
+auto omt_mapgen_uses_lua( const std::string &dim_id, const tripoint &om_addr ) -> bool;
 std::pair<std::map<ter_id, int>, std::map<furn_id, int>> get_changed_ids_from_update(
             const std::string &update_mapgen_id );
 mapgen_parameters get_map_special_params( const std::string &mapgen_id );

--- a/src/submap_load_manager.cpp
+++ b/src/submap_load_manager.cpp
@@ -232,7 +232,7 @@ void submap_load_manager::update()
         // Runs after drain_pending_submap_destroy() so any competing duplicate submaps
         // from the same turn have already been queued for main-thread cleanup.
         std::ranges::for_each( dims_to_drain, [this]( const std::string & dim_id ) {
-            for( const tripoint & om_addr :
+            for( const tripoint &om_addr :
                  MAPBUFFER_REGISTRY.get( dim_id ).drain_deferred_lua_quads() ) {
                 dirty_quads_.insert( { dim_id, om_addr } );
             }
@@ -363,7 +363,7 @@ void submap_load_manager::update()
     // only adds entries for quads that were NOT in new_quads (e.g. deferred
     // lazy-border quads whose futures completed this turn).
     std::ranges::for_each( drained_dims, [this]( const std::string & dim_id ) {
-        for( const tripoint & om_addr :
+        for( const tripoint &om_addr :
              MAPBUFFER_REGISTRY.get( dim_id ).drain_deferred_lua_quads() ) {
             dirty_quads_.insert( { dim_id, om_addr } );
         }

--- a/src/submap_load_manager.cpp
+++ b/src/submap_load_manager.cpp
@@ -517,6 +517,12 @@ void submap_load_manager::update()
                 if( lazy_futures_.count( qk ) ) {
                     continue;  // already has an in-flight future — don't resubmit
                 }
+                // Skip lazy pre-loading when Lua mapgen hooks are registered.
+                // Pre-loading many quads at once would batch N hook calls into a
+                // single-frame spike; quads will be generated on demand instead.
+                if( mapgen_hooks_registered() ) {
+                    continue;
+                }
                 auto &mb = MAPBUFFER_REGISTRY.get( key.first );
                 if( !mb.lookup_submap_in_memory( key.second ) ) {
                     lazy_futures_.emplace( qk,

--- a/src/submap_load_manager.cpp
+++ b/src/submap_load_manager.cpp
@@ -228,6 +228,15 @@ void submap_load_manager::update()
         std::ranges::for_each( dims_to_drain, []( const std::string & dim_id ) {
             MAPBUFFER_REGISTRY.get( dim_id ).drain_pending_submap_destroy();
         } );
+        // Generate any Lua-based quads that workers skipped (Lua is not reentrant).
+        // Runs after drain_pending_submap_destroy() so any competing duplicate submaps
+        // from the same turn have already been queued for main-thread cleanup.
+        std::ranges::for_each( dims_to_drain, [this]( const std::string & dim_id ) {
+            for( const tripoint & om_addr :
+                 MAPBUFFER_REGISTRY.get( dim_id ).drain_deferred_lua_quads() ) {
+                dirty_quads_.insert( { dim_id, om_addr } );
+            }
+        } );
     }
 
     // Drain any Lua mapgen postprocess hooks queued by completed lazy generation
@@ -348,6 +357,16 @@ void submap_load_manager::update()
     } );
     std::ranges::for_each( drained_dims, []( const std::string & dim_id ) {
         MAPBUFFER_REGISTRY.get( dim_id ).drain_pending_submap_destroy();
+    } );
+    // Generate Lua-based quads that workers deferred to the main thread.
+    // new_quads are already pre-inserted into dirty_quads_ above; this call
+    // only adds entries for quads that were NOT in new_quads (e.g. deferred
+    // lazy-border quads whose futures completed this turn).
+    std::ranges::for_each( drained_dims, [this]( const std::string & dim_id ) {
+        for( const tripoint & om_addr :
+             MAPBUFFER_REGISTRY.get( dim_id ).drain_deferred_lua_quads() ) {
+            dirty_quads_.insert( { dim_id, om_addr } );
+        }
     } );
 
     // Drain Lua postprocess hooks from any async generation above.


### PR DESCRIPTION
## Purpose of change (The Why)

resolves #8493

## Describe the solution (The How)

Adds some basic improvements to mapgen stuff - filters a bit better, iterates on less.
The main thing is that this basically blocks lazy-loading when lua mapgen is active.
This is hopefully a stopgap, but lazy-loading isn't a huge improvement regardless, so it's not so bad.
I also added a potentially cheap (x, y, z) variant of the get and set terrain at functions for Lua. Might help.

## Describe alternatives you've considered

Making Lua support multi-threading.
I'm working on that, but that's so back-burnered, it's not even funny.

## Testing

Tested with https://github.com/shmakota/overgrowth_bn installed.
Before, near full second hitches every 12 tiles.
After (but before final fix)
I got it to a full second every 24 tiles.
After the final fix, the additional lag was gone entirely.

## Additional context

Lua multi-threading really is a ways off. I'm piling it in the "after SDL3 by a large margin" category.
An important thing for testers: Is this PR better than just disabling the lazy-loaded border setting?