### PR TITLE
fix: save dynamic monster flags

### DIFF
--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -2097,6 +2097,7 @@ void monster::load( const JsonObject &data )
     data.read( "dimension_id", dimension_id_ );
     data.read( "mounted_player_id", mounted_player_id );
     data.read( "path", path );
+    data.read( "monster_flags", monster_flags );
 }
 
 /*
@@ -2187,6 +2188,7 @@ void monster::store( JsonOut &json ) const
     // storing the rider
     json.member( "mounted_player_id", mounted_player_id );
     json.member( "path", path );
+    json.member( "monster_flags", monster_flags );
 }
 
 void mon_special_attack::serialize( JsonOut &json ) const


### PR DESCRIPTION
## Purpose of change (The Why)
Somehow missed saving it in #8407 

## Describe the solution (The How)
Add saving

## Describe alternatives you've considered
Screaming

## Testing
Loaded game
Trained horse
Saved game
Loaded Game
Horse still trained

## Additional context
I screm

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.