### PR TITLE
fix: Vehicle Lockup Fix

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -12200,6 +12200,7 @@ void game::resize_reality_bubble_to( int new_size )
     // Discard pathfinding objects sized for the old bubble.
     Pathfinding::clear_pool();
 
+
 #if defined(TILES)
     if( tilecontext ) {
         tilecontext->reset_minimap();

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1698,6 +1698,16 @@ void map::unboard_vehicle( const tripoint &p, bool dead_passenger )
 
 bool map::displace_vehicle( vehicle &veh, const tripoint &dp )
 {
+    // abs_sm_pos is always authoritative.  A tinymap (e.g. fire-spread loader) that
+    // loads the same submap sets veh.sm_pos to its own local grid coordinates, which
+    // are meaningless to the main map and corrupt the position lookup.  Recompute
+    // sm_pos from abs_sm_pos before any position-dependent call so the correction
+    // applies regardless of which code path caused the staleness.
+    veh.sm_pos = tripoint(
+                     veh.abs_sm_pos.x() - abs_sub.x,
+                     veh.abs_sm_pos.y() - abs_sub.y,
+                     veh.abs_sm_pos.z() );
+
     const tripoint src = veh.global_pos3();
     tripoint dst = src + dp;
 
@@ -1708,8 +1718,8 @@ bool map::displace_vehicle( vehicle &veh, const tripoint &dp )
     std::set<int> smzs;
 
     if( src_submap == nullptr ) {
-        add_msg( m_debug, "map::displace_vehicle: src submap not loaded %d,%d,%d->%d,%d,%d",
-                 src.x, src.y, src.z, dst.x, dst.y, dst.z );
+        debugmsg( "displace_vehicle: src submap null for '%s' at %d,%d,%d",
+                  veh.name, src.x, src.y, src.z );
         return false;
     }
 
@@ -1846,10 +1856,8 @@ bool map::displace_vehicle( vehicle &veh, const tripoint &dp )
     }
     if( need_update ) {
         g->update_map( g->u );
-        // update_map shifts abs_sub but loadn may place this vehicle at slot (0,0,z)
-        // without later updating sm_pos when a subsequent shift makes that slot stale.
-        // abs_sm_pos is always set correctly; recompute sm_pos from it so the cache
-        // lookup lands in the right grid slot.
+        // update_map shifts abs_sub; recompute sm_pos so the cache lookup
+        // lands in the right grid slot after the shift.
         veh.sm_pos = tripoint(
                          veh.abs_sm_pos.x() - abs_sub.x,
                          veh.abs_sm_pos.y() - abs_sub.y,

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1837,6 +1837,14 @@ bool map::displace_vehicle( vehicle &veh, const tripoint &dp )
     }
     if( need_update ) {
         g->update_map( g->u );
+        // update_map shifts abs_sub but loadn may place this vehicle at slot (0,0,z)
+        // without later updating sm_pos when a subsequent shift makes that slot stale.
+        // abs_sm_pos is always set correctly; recompute sm_pos from it so the cache
+        // lookup lands in the right grid slot.
+        veh.sm_pos = tripoint(
+                         veh.abs_sm_pos.x() - abs_sub.x,
+                         veh.abs_sm_pos.y() - abs_sub.y,
+                         veh.abs_sm_pos.z() );
     }
     add_vehicle_to_cache( &veh );
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -604,6 +604,15 @@ void map::reset_vehicle_cache( )
     for( int zlev = zmin; zlev <= zmax; zlev++ ) {
         auto &ch = get_cache( zlev );
         for( const auto &elem : ch.vehicle_list ) {
+            // abs_sm_pos is always the authoritative absolute position.
+            // sm_pos can be stale when loadn fires during a shift and abs_sub
+            // subsequently changes (e.g. the vehicle's submap enters the grid
+            // from the fire-spread loader, or the reality bubble resizes).
+            // Recompute sm_pos here so the tile-level cache uses the right slot.
+            elem->sm_pos = tripoint(
+                               elem->abs_sm_pos.x() - abs_sub.x,
+                               elem->abs_sm_pos.y() - abs_sub.y,
+                               elem->abs_sm_pos.z() );
             elem->adjust_zlevel( 0, tripoint_zero );
             add_vehicle_to_cache( elem );
         }


### PR DESCRIPTION
## Purpose of change (The Why)

resolves #8497
resolves #8477
Map updates were not setting vehicle position correctly.
Both were the same bug experienced differently.

## Describe the solution (The How)

Update sm_pos using abs_sm_pos since it's always correct.

## Testing

Fly over a fire in a blimp, and you don't freeze midair.
This was a consistent break when fire-loading was enabled, but it was really unrelated. Just a canary.

## Additional context

I got a duplicate of the vehicle to spawn in the top left at bubble size 2 or 3. Weird.