### PR TITLE
fix: replace obseleted crows on aircraft carrier with medium turrets

### DIFF
--- a/data/json/mapgen/aircraft_carrier/aircraft_carrier_z3.json
+++ b/data/json/mapgen/aircraft_carrier/aircraft_carrier_z3.json
@@ -57,9 +57,9 @@
       ],
       "palettes": [ "aircraft_carrier_palette" ],
       "place_monster": [
-        { "monster": "mon_turret_rifle", "x": 5, "y": 34 },
-        { "monster": "mon_turret_rifle", "x": 3, "y": 35 },
-        { "monster": "mon_turret_rifle", "x": 3, "y": 37 }
+        { "monster": "mon_turret_medium", "x": 5, "y": 34 },
+        { "monster": "mon_turret_medium", "x": 3, "y": 35 },
+        { "monster": "mon_turret_medium", "x": 3, "y": 37 }
       ]
     }
   }


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
the m249 crows is marked as obsolete, but it still spawns on the aircraft carrier
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
changes the crows to medium turrets instead
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
n/a
## Testing
loaded game
debug teleported to carrier
looked at turrets
turrets shot zombies
success
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [ check] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ check] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [ check] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [ check] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
