### PR TITLE
feat: let mutations scale characters max stored kcal

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -2945,7 +2945,8 @@
     "description": "Eating rotting, long-dead flesh is good for the struggle, and safe--if still completely unappealing--for you.",
     "prereqs": [ "POISRESIST" ],
     "threshreq": [ "THRESH_CHIMERA", "THRESH_RAT", "THRESH_MOUSE", "THRESH_SERPENT" ],
-    "category": [ "RAT", "CHIMERA", "MOUSE", "SERPENT" ]
+    "category": [ "RAT", "CHIMERA", "MOUSE", "SERPENT" ],
+    "kcal_scale": 0.15
   },
   {
     "type": "mutation",
@@ -2998,7 +2999,7 @@
     "category": [ "CHIMERA" ],
     "valid": false,
     "active": true,
-    "kcal_scale": 0.5
+    "kcal_scale": 0.3
   },
   {
     "type": "mutation",

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -2991,13 +2991,14 @@
     "id": "EATHEALTH",
     "name": { "str": "Hyper-Metabolism" },
     "points": 15,
-    "description": "You metabolize nutrients so rapidly that you can convert food directly into useful tissue.  Excess nutrition will convert to HP, rather than being wasted.  Activate to skip prompt for overeating.",
+    "description": "You metabolize nutrients so rapidly that you can convert food directly into useful tissue.  Excess nutrition will convert to HP, rather than being wasted. You can also store more kcal. Activate to skip prompt for overeating.",
     "prereqs": [ "HUNGER3" ],
     "types": [ "METABOLISM" ],
     "threshreq": [ "THRESH_CHIMERA" ],
     "category": [ "CHIMERA" ],
     "valid": false,
-    "active": true
+    "active": true,
+    "kcal_scale": 0.5
   },
   {
     "type": "mutation",

--- a/docs/en/mod/json/reference/creatures/mutations.md
+++ b/docs/en/mod/json/reference/creatures/mutations.md
@@ -114,6 +114,7 @@
 "no_cbm_on_bp": [ "TORSO", "HEAD", "EYES", "MOUTH", "ARM_L" ], // List of body parts that can't receive cbms. (default: empty)
 "body_size": "LARGE", // Increase or decrease size, only one size mutation at a time will be valid. Allowed values are: `TINY`, `SMALL`, `LARGE`, `HUGE`. `MEDIUM` can be specified but has no effect, as this is the default size for players and NPCs.
 "lumination": [ [ "HEAD", 20 ], [ "ARM_L", 10 ] ], // List of glowing bodypart and the intensity of the glow as a float. (default: empty)
+"kcal_scale" : 0.5, //Scales maximum kcal storage. 1.0 doubles, -0.5 halves.
 "metabolism_modifier": 0.333, // Extra metabolism rate multiplier. 1.0 doubles usage, -0.5 halves.
 "fatigue_modifier": 0.5, // Extra fatigue rate multiplier. 1.0 doubles usage, -0.5 halves.
 "fatigue_regen_modifier": 0.333, // Modifier for the rate at which fatigue and sleep deprivation drops when resting.

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -5110,7 +5110,7 @@ void Character::set_stored_kcal( int kcal )
 
 int Character::max_stored_kcal() const
 {
-    return 2500 * 7;
+    return 2500 * 7 * (1.0f + mutation_value( "kcal_scale" ));
 }
 
 float Character::get_kcal_percent() const
@@ -5154,7 +5154,7 @@ std::pair<std::string, nc_color> Character::get_thirst_description() const
 
 std::pair<std::string, nc_color> Character::get_hunger_description() const
 {
-    int total_kcal = stored_calories + stomach.get_calories();
+    int total_kcal = stored_calories + stomach.get_calories(); //zz
     int max_kcal = max_stored_kcal();
     float days_left = static_cast<float>( total_kcal ) / bmr();
     float days_max = static_cast<float>( max_kcal ) / bmr();
@@ -7479,6 +7479,7 @@ mutation_value_map = {
     { "hp_modifier_secondary", calc_mutation_value<&mutation_branch::hp_modifier_secondary> },
     { "hp_adjustment", calc_mutation_value<&mutation_branch::hp_adjustment> },
     { "temperature_speed_modifier", calc_mutation_value<&mutation_branch::temperature_speed_modifier> },
+    { "kcal_scale", calc_mutation_value<&mutation_branch::kcal_scale> },
     { "metabolism_modifier", calc_mutation_value<&mutation_branch::metabolism_modifier> },
     { "thirst_modifier", calc_mutation_value<&mutation_branch::thirst_modifier> },
     { "fatigue_regen_modifier", calc_mutation_value<&mutation_branch::fatigue_regen_modifier> },

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -5154,7 +5154,7 @@ std::pair<std::string, nc_color> Character::get_thirst_description() const
 
 std::pair<std::string, nc_color> Character::get_hunger_description() const
 {
-    int total_kcal = stored_calories + stomach.get_calories(); //zz
+    int total_kcal = stored_calories + stomach.get_calories();
     int max_kcal = max_stored_kcal();
     float days_left = static_cast<float>( total_kcal ) / bmr();
     float days_max = static_cast<float>( max_kcal ) / bmr();

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -5110,7 +5110,7 @@ void Character::set_stored_kcal( int kcal )
 
 int Character::max_stored_kcal() const
 {
-    return 2500 * 7 * (1.0f + mutation_value( "kcal_scale" ));
+    return 2500 * 7 * ( 1.0f + mutation_value( "kcal_scale" ) );
 }
 
 float Character::get_kcal_percent() const

--- a/src/mutation.h
+++ b/src/mutation.h
@@ -190,6 +190,8 @@ struct mutation_branch {
 
         // Speed lowers--or raises--for every X F (X C) degrees below or above 65 F (18.3 C)
         float temperature_speed_modifier = 0.0f;
+        // Scales total kcal character can hold. 1.0 doubles, -0.5 halves.
+        float kcal_scale = 0.0f;
         // Extra metabolism rate multiplier. 1.0 doubles usage, -0.5 halves.
         float metabolism_modifier = 0.0f;
         // As above but for thirst.

--- a/src/mutation_data.cpp
+++ b/src/mutation_data.cpp
@@ -402,6 +402,7 @@ void mutation_branch::load( const JsonObject &jo, const std::string & )
     optional( jo, was_loaded, "noise_modifier", noise_modifier, 1.0f );
     optional( jo, was_loaded, "temperature_speed_modifier", temperature_speed_modifier, 0.0f );
     optional( jo, was_loaded, "metabolism_modifier", metabolism_modifier, 0.0f );
+    optional( jo, was_loaded, "kcal_scale", kcal_scale, 0.0f );
     optional( jo, was_loaded, "thirst_modifier", thirst_modifier, 0.0f );
     optional( jo, was_loaded, "fatigue_modifier", fatigue_modifier, 0.0f );
     optional( jo, was_loaded, "fatigue_regen_modifier", fatigue_regen_modifier, 0.0f );


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

someone asked for it and I thought it might be neat

does add some options for modders or a possible future mutation rebalance

also just would be thematic to have larger mutations able to eat more and smaller mutations unable to eat as much

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)

add kcal_scale mutation modifier, which scales the value max_stored_kcal() returns

note that modifying max_stored_kcal() does not influence the amount of kcal burned by any action or gained by food,
but does influence things that use a percentage check (jittery, hibernation, starvation thresholds)

so halving the max_stored_kcal moves the speed starvation penalty threshold from 8750 to 4375, jittery from 16625 to 8312 etc

## Describe alternatives you've considered

- not doing this

- giving kcal scale to the size mutations
might require removing some of the metabolism mutations from some paths
also generally dont know what the ideal mutation balance is considering they are poorly balanced as it is

## Testing

gave freakishly huge "kcal_scale:" 1.0
gave a character freakishly huge and ate food until the character was full
verified that hibernation and jittery worked, set stored kcal to 16000 and verified the starving speed reduction is working
crafted some items and chopped down a tree and nothing seemed to explode

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

- [x] This is a C++ PR that modifies JSON loading or behavior.
  - [x] I have documented the changes in the appropriate location in the `docs/` folder.
