### PR TITLE
feat(balance): adjust jittery threshold to be more intuitive

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -1154,7 +1154,7 @@
     "id": "JITTERY",
     "name": { "str": "Jittery" },
     "points": -3,
-    "description": "When very hungry or under the effects of stimulants, you may find your hands shaking uncontrollably, severely reducing your Dexterity.",
+    "description": "When hungry or under the effects of stimulants, you may find your hands shaking uncontrollably, severely reducing your Dexterity.",
     "starting_trait": true,
     "valid": false,
     "category": [ "MEDICAL", "MOUSE", "RABBIT" ]

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -337,10 +337,16 @@ void Character::suffer_while_awake( const int current_stim )
     }
 
     if( has_trait( trait_JITTERY ) && !has_effect( effect_shakes ) ) {
+
+        int total_kcal = get_stored_kcal() + stomach.get_calories();
+        int max_kcal = max_stored_kcal();
+        float days_left = static_cast<float>( total_kcal ) / bmr();
+        float days_max = static_cast<float>( max_kcal ) / bmr();
+
         if( current_stim > 50 && one_in( to_turns<int>( 30_minutes ) - ( current_stim * 6 ) ) ) {
             add_effect( effect_shakes, 30_minutes + 1_turns * current_stim );
-        } else if( ( get_kcal_percent() < 0.95f ) &&
-                   one_turn_in( 60_minutes - 1_seconds * ( max_stored_kcal() - get_stored_kcal() ) ) ) {
+        } else if ( days_max - days_left >= 0.5f ) { //matches hunger state in get_hunger_description
+                   one_turn_in( 60_minutes - 1_seconds * ( max_kcal - total_kcal ) ) ) {
             add_effect( effect_shakes, 40_minutes );
         }
     }

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -345,7 +345,7 @@ void Character::suffer_while_awake( const int current_stim )
 
         if( current_stim > 50 && one_in( to_turns<int>( 30_minutes ) - ( current_stim * 6 ) ) ) {
             add_effect( effect_shakes, 30_minutes + 1_turns * current_stim );
-        } else if (( days_max - days_left >= 0.5f ) && //matches hunger state in get_hunger_description
+        } else if( ( days_max - days_left >= 0.5f ) && //matches hunger state in get_hunger_description
                    one_turn_in( 60_minutes - 1_seconds * ( max_kcal - total_kcal ) ) ) {
             add_effect( effect_shakes, 40_minutes );
         }

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -345,7 +345,7 @@ void Character::suffer_while_awake( const int current_stim )
 
         if( current_stim > 50 && one_in( to_turns<int>( 30_minutes ) - ( current_stim * 6 ) ) ) {
             add_effect( effect_shakes, 30_minutes + 1_turns * current_stim );
-        } else if ( days_max - days_left >= 0.5f ) { //matches hunger state in get_hunger_description
+        } else if (( days_max - days_left >= 0.5f ) && //matches hunger state in get_hunger_description
                    one_turn_in( 60_minutes - 1_seconds * ( max_kcal - total_kcal ) ) ) {
             add_effect( effect_shakes, 40_minutes );
         }


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

Currently the threshold to trigger the shakey effect is your stored_kcal being below 16625kcal

Despite what the description of the mutation might claim, this is well within the sated threshold, 
and no starvation penalty exists until 14000kcal at which point you lose 0.1 str and 0.05 dex/int

This leads to the jittery mutation feeling like its just straight broken, unless you decide to dive into the code and find out whats really going on

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)

Set the threshold to trigger the shakey effect to the point at which the sidebar displays the hungry threshold/turns yellow
Which at default metabolism rates makes the jittery effect trigger below 16250kcal

As a side effect the threshold at which jittery triggers scales down the higher the players metabolic rate is increased
(aprox 15500kcal with fast metabolism and 15000kcal with very fast metabolism)

<!-- e.g nerfs monster A -->

## Describe alternatives you've considered

- not doing this

- making the jittery debuff stronger to compensate for this change?

- or making the jittery debuff last longer to compensate for this change?

- change the points value??

idk

## Testing

Booted up the game, gave my character jittery and observed it does not give the shakey status effect above 16250kcal and does below 16250kcal

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
