### PR TITLE
feat(balance): make jet/hover parts reversible and add `decomp_learn`, remove autolearn

### DIFF
--- a/data/json/recipes/other/vehicles.json
+++ b/data/json/recipes/other/vehicles.json
@@ -2515,7 +2515,8 @@
     "skill_used": "mechanics",
     "difficulty": 9,
     "time": "4 h",
-    "autolearn": true,
+    "reversible": true,
+    "decomp_learn": 9,
     "using": [ [ "welding_standard", 20 ], [ "adhesive", 5 ] ],
     "components": [
       [ [ "amplifier", 2 ] ],
@@ -2540,7 +2541,8 @@
     "skill_used": "mechanics",
     "difficulty": 8,
     "time": "8 h",
-    "autolearn": true,
+    "reversible": true,
+    "decomp_learn": 8,
     "using": [ [ "welding_standard", 20 ], [ "adhesive", 5 ] ],
     "components": [
       [ [ "amplifier", 2 ] ],
@@ -2565,7 +2567,8 @@
     "skill_used": "mechanics",
     "difficulty": 9,
     "time": "8 h",
-    "autolearn": true,
+    "reversible": true,
+    "decomp_learn": 9,
     "using": [ [ "welding_standard", 20 ], [ "adhesive", 5 ] ],
     "components": [
       [ [ "amplifier", 2 ] ],


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

Smol followup to https://github.com/cataclysmbn/Cataclysm-BN/pull/8485 which I merged early so I didn't have to keep messing with merge conflicts for PRs touching sprite stuff.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

Removed autolearn from the new jet propulsion parts, in exchange for making them reversible and adding decomp learns like several other aero and heli parts already have.

## Describe alternatives you've considered

Submitting to the eepy.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

Checked affected file for syntax and lint errors.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

Turns out they already had booklearns like I requested, I just didn't spot them because derg am dumb

I still need some delicious _I M P L E M E N T A T I O N_ but maybe I'll add vehicles using them tomorrow...

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
