### PR TITLE
fix: Light update every player move + 3D sunlight shadows

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -3289,6 +3289,7 @@ void cata_tiles::draw( point dest, const tripoint &center, int width, int height
             int last_vis = center.z + 1;
             lit_level last_vis_ll = lit_level::BLANK;
             bool drew_occluded_overlay = false;
+            bool had_visible_open_air = false;
             const int &x = temp_x;
             const int &y = temp_y;
 
@@ -3309,9 +3310,13 @@ void cata_tiles::draw( point dest, const tripoint &center, int width, int height
                 ll = ch.inbounds( {x, y} ) ? ch.visibility_cache[ch.idx( x, y )] : lit_level::BLANK;
                 const auto visibility = here.get_visibility( ll, cache );
                 if( ( fov_3d || z == center.z ) && in_map_bounds ) {
-                    if( !would_apply_vision_effects( visibility ) && here.ter( pos ) != t_open_air ) {
-                        last_vis = z;
-                        last_vis_ll = ll;
+                    if( !would_apply_vision_effects( visibility ) ) {
+                        if( here.ter( pos ) != t_open_air ) {
+                            last_vis = z;
+                            last_vis_ll = ll;
+                        } else {
+                            had_visible_open_air = true;
+                        }
                     } else if( !has_memory && z < center.z &&
                                visibility == visibility_type::VIS_HIDDEN ) {
                         if( !drew_occluded_overlay ) {
@@ -3389,6 +3394,14 @@ void cata_tiles::draw( point dest, const tripoint &center, int width, int height
                                 draw_points.emplace_back( tripoint( pos.xy(), last_vis ), height_3d,
                                                           last_vis_ll, invisible );
                             }
+                        } else if( had_visible_open_air && in_map_bounds &&
+                                   z < center.z - fov_3d_z_range ) {
+                            // No solid last_vis found, but we passed through visible open air
+                            // and the tile is below the 3D FOV limit (e.g. flying high above
+                            // the map). Render at its own position with a depth tint.
+                            here.set_memory_seen_cache_dirty( pos );
+                            min_z = std::min( pos.z, min_z );
+                            draw_points.emplace_back( pos, height_3d, lit_level::MEMORIZED, invisible );
                         }
 
                     } else {

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -3309,7 +3309,7 @@ void cata_tiles::draw( point dest, const tripoint &center, int width, int height
                 ll = ch.inbounds( {x, y} ) ? ch.visibility_cache[ch.idx( x, y )] : lit_level::BLANK;
                 const auto visibility = here.get_visibility( ll, cache );
                 if( ( fov_3d || z == center.z ) && in_map_bounds ) {
-                    if( !would_apply_vision_effects( visibility ) ) {
+                    if( !would_apply_vision_effects( visibility ) && here.ter( pos ) != t_open_air ) {
                         last_vis = z;
                         last_vis_ll = ll;
                     } else if( !has_memory && z < center.z &&

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -283,8 +283,6 @@ input_context game::get_player_input( std::string &action )
         ctxt = get_default_mode_input_context();
     }
 
-    m.update_visibility_cache( u.posz() );
-
     user_turn current_turn;
 
 

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -607,7 +607,8 @@ void map::generate_lightmap_worker( const int zlev )
     auto &sm = map_cache.sm;
     auto &outside_cache = map_cache.outside_cache;
     auto &prev_floor_cache = get_cache( clamp( zlev + 1, -OVERMAP_DEPTH, OVERMAP_DEPTH ) ).floor_cache;
-    auto &prev_vehicle_floor_cache = get_cache( clamp( zlev + 1, -OVERMAP_DEPTH, OVERMAP_DEPTH ) ).vehicle_floor_cache;
+    auto &prev_vehicle_floor_cache = get_cache( clamp( zlev + 1, -OVERMAP_DEPTH,
+                                     OVERMAP_DEPTH ) ).vehicle_floor_cache;
     bool top_floor = zlev == OVERMAP_DEPTH;
 
     /* Bulk light sources wastefully cast rays into neighbors; a burning hospital can produce

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -337,7 +337,8 @@ void map::build_angled_sunlight_cache( const int zlev )
             // Without this, angled rays jump laterally past the roof tile at step 1.
             if( zlev + 1 <= OVERMAP_HEIGHT ) {
                 const level_cache &above = get_cache_ref( zlev + 1 );
-                if( above.floor_cache[above.idx( x, y )] ) {
+                const auto aidx = above.idx( x, y );
+                if( above.floor_cache[aidx] || above.vehicle_floor_cache[aidx] ) {
                     solar_cache[ch.idx( x, y )] = false;
                     return;
                 }
@@ -358,8 +359,9 @@ void map::build_angled_sunlight_cache( const int zlev )
             } ),
             [&]( const auto & sp ) {
                 const level_cache &uch = get_cache_ref( zlev + sp.first );
-                return static_cast<bool>(
-                           uch.floor_cache[uch.idx( sp.second.x, sp.second.y )] );
+                const auto uidx = uch.idx( sp.second.x, sp.second.y );
+                return static_cast<bool>( uch.floor_cache[uidx] ) ||
+                       static_cast<bool>( uch.vehicle_floor_cache[uidx] );
             }
                                  );
             solar_cache[ch.idx( x, y )] = !blocked;
@@ -477,6 +479,7 @@ void map::build_sunlight_cache( int pzlev )
         const auto &prev_lm = prev_map_cache.lm;
         const auto &prev_transparency_cache = prev_map_cache.transparency_cache;
         const auto &prev_floor_cache = prev_map_cache.floor_cache;
+        const auto &prev_vehicle_floor_cache = prev_map_cache.vehicle_floor_cache;
         const auto &outside_cache = map_cache.outside_cache;
         const float sight_penalty = get_weather().weather_id->sight_penalty;
         // TODO: Replace these with a lookup inside the four_quadrants class.
@@ -520,6 +523,7 @@ void map::build_sunlight_cache( int pzlev )
 
                     if( prev_transparency > LIGHT_TRANSPARENCY_SOLID &&
                         !prev_floor_cache[prev_map_cache.idx( prev_x, prev_y )] &&
+                        !prev_vehicle_floor_cache[prev_map_cache.idx( prev_x, prev_y )] &&
                         ( prev_light_max = prev_lm[prev_map_cache.idx( prev_x, prev_y )].max() ) > 0.0 ) {
                         const float light_level = clamp( prev_light_max * LIGHT_TRANSPARENCY_OPEN_AIR / prev_transparency,
                                                          inside_light_level, prev_light_max );
@@ -603,6 +607,7 @@ void map::generate_lightmap_worker( const int zlev )
     auto &sm = map_cache.sm;
     auto &outside_cache = map_cache.outside_cache;
     auto &prev_floor_cache = get_cache( clamp( zlev + 1, -OVERMAP_DEPTH, OVERMAP_DEPTH ) ).floor_cache;
+    auto &prev_vehicle_floor_cache = get_cache( clamp( zlev + 1, -OVERMAP_DEPTH, OVERMAP_DEPTH ) ).vehicle_floor_cache;
     bool top_floor = zlev == OVERMAP_DEPTH;
 
     /* Bulk light sources wastefully cast rays into neighbors; a burning hospital can produce
@@ -667,15 +672,20 @@ void map::generate_lightmap_worker( const int zlev )
                         const int y = sy + smy * SEEY;
                         const tripoint p( x, y, zlev );
                         // Project light into any openings into buildings.
+                        // Check both terrain floor_cache and vehicle_floor_cache since vehicle
+                        // roofs are no longer written into floor_cache.
+                        auto has_floor_above = [&]( int idx ) {
+                            return prev_floor_cache[idx] || prev_vehicle_floor_cache[idx];
+                        };
                         if( !outside_cache[map_cache.idx( p.x, p.y )] || ( !top_floor &&
-                                prev_floor_cache[map_cache.idx( p.x, p.y )] ) ) {
+                                has_floor_above( map_cache.idx( p.x, p.y ) ) ) ) {
                             // Apply light sources for external/internal divide
                             for( int i = 0; i < 4; ++i ) {
                                 point neighbour = p.xy() + point( dir_x[i], dir_y[i] );
                                 if( neighbour.x >= 0 && neighbour.y >= 0 &&
                                     neighbour.x < map_cache.cache_x && neighbour.y < map_cache.cache_y
                                     && outside_cache[map_cache.idx( neighbour.x, neighbour.y )] &&
-                                    ( top_floor || !prev_floor_cache[map_cache.idx( neighbour.x, neighbour.y )] )
+                                    ( top_floor || !has_floor_above( map_cache.idx( neighbour.x, neighbour.y ) ) )
                                   ) {
                                     const float source_light =
                                         std::min( natural_light, lm[map_cache.idx( neighbour.x, neighbour.y )].max() );

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <ranges>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
@@ -51,6 +52,11 @@
 
 static const efftype_id effect_haslight( "haslight" );
 static const efftype_id effect_onfire( "onfire" );
+
+// Fraction of default_daylight_level() seen by outdoor tiles in shadow (not in direct solar LOS).
+// Must be < LIGHT_SOURCE_BRIGHT / default_daylight_level() = 10/100 = 0.10 so shadow tiles
+// render as LOW (dim, visible) rather than BRIGHT (same as direct sunlight).
+static constexpr float SOLAR_SHADOW_SCATTER = 0.09f;
 
 // Build a runtime bounding rectangle for the loaded tile grid from a level_cache.
 // Replaces the former compile-time `lightmap_boundaries` constant (which used
@@ -262,6 +268,107 @@ void map::apply_character_light( Character &p )
 }
 
 // This function raytraces starting at the upper limit of the simulated area descending
+void map::update_solar_params()
+{
+    const time_point now        = calendar::turn;
+    const time_point sr         = sunrise( now );
+    const time_point ss         = sunset( now );
+    const time_duration day_dur = ss - sr;
+
+    if( day_dur <= 0_turns || now <= sr || now >= ss ) {
+        m_solar.direct_active = false;
+        m_solar.dx_per_z      = 0.f;
+        m_solar.dy_per_z      = 0.f;
+        return;
+    }
+
+    // Map daylight progress [0,1] to theta [0°,180°]: sunrise = 0°, noon = 90°, sunset = 180°.
+    const auto progress  = to_turns<double>( now - sr ) / to_turns<double>( day_dur );
+    const auto theta_deg = static_cast<float>( progress * 180.0 );
+    const auto theta_rad = theta_deg * static_cast<float>( M_PI ) / 180.f;
+    const auto sin_t     = std::sin( theta_rad );
+    const auto cos_t     = std::cos( theta_rad );
+
+    // Active throughout all daylight hours; night is handled by the early return above.
+    m_solar.direct_active = true;
+
+    // Clamp theta before computing cot to keep sin well away from zero near the horizon.
+    // This replaces the old threshold cutoff: instead of disabling shadows at shallow angles,
+    // we hold them at maximum length. Shadows exist from sunrise to sunset with no abrupt
+    // appear/disappear transition; only the day/night boundary itself triggers the change.
+    static constexpr auto SUN_CLAMP_MIN_RAD = 15.f * static_cast<float>( M_PI ) / 180.f;
+    static constexpr auto SUN_CLAMP_MAX_RAD = 165.f * static_cast<float>( M_PI ) / 180.f;
+    const auto theta_clamped = std::clamp( theta_rad, SUN_CLAMP_MIN_RAD, SUN_CLAMP_MAX_RAD );
+    const auto sin_c = std::sin( theta_clamped );
+    const auto cos_c = std::cos( theta_clamped );
+
+    // dx_per_z = SOLAR_SHADOW_SCALE * Z_LEVEL_SCALE * cot(theta_clamped).
+    // SOLAR_SHADOW_SCALE (1.5) is a tuning multiplier; SOLAR_SHADOW_MAX caps extreme values.
+    // Flip SUN_EAST_SIGN to -1 if +x does not map to east in the tileset.
+    static constexpr auto SUN_EAST_SIGN      = 1.f;
+    static constexpr auto SOLAR_SHADOW_SCALE = 1.5f;
+    static constexpr auto SOLAR_SHADOW_MAX   = 6.f;
+    const auto raw = SUN_EAST_SIGN * SOLAR_SHADOW_SCALE * Z_LEVEL_SCALE * cos_c / sin_c;
+    m_solar.dx_per_z = std::clamp( raw, -SOLAR_SHADOW_MAX, SOLAR_SHADOW_MAX );
+    m_solar.dy_per_z = 0.f;  // No latitude tilt modelled.
+}
+
+void map::build_angled_sunlight_cache( const int zlev )
+{
+    level_cache &ch      = get_cache( zlev );
+    auto &solar_cache    = ch.angled_sunlight_cache;
+
+    if( !m_solar.direct_active ) {
+        std::ranges::fill( solar_cache, false );
+        return;
+    }
+
+    const auto step_x  = m_solar.dx_per_z;
+    const auto step_y  = m_solar.dy_per_z;
+    const auto max_step = OVERMAP_HEIGHT - zlev;
+
+    std::ranges::for_each(
+        std::views::iota( 0, ch.cache_x ),
+        [&]( int x ) {
+            std::ranges::for_each(
+                std::views::iota( 0, ch.cache_y ),
+                [&]( int y ) {
+                    // A floor directly overhead always blocks, regardless of sun angle.
+                    // Without this, angled rays jump laterally past the roof tile at step 1.
+                    if( zlev + 1 <= OVERMAP_HEIGHT ) {
+                        const level_cache &above = get_cache_ref( zlev + 1 );
+                        if( above.floor_cache[above.idx( x, y )] ) {
+                            solar_cache[ch.idx( x, y )] = false;
+                            return;
+                        }
+                    }
+                    // Trace the sun ray upward one z-level at a time.
+                    // Solar-lit if the ray exits the map bounds without hitting a floor.
+                    const auto blocked = std::ranges::any_of(
+                        std::views::iota( 1, max_step + 1 )
+                        | std::views::transform( [&]( int step ) {
+                              return std::pair{ step, point{
+                                  x + static_cast<int>( std::roundf( step_x * static_cast<float>( step ) ) ),
+                                  y + static_cast<int>( std::roundf( step_y * static_cast<float>( step ) ) )
+                              } };
+                          } )
+                        | std::views::take_while( [&]( const auto &sp ) {
+                              return sp.second.x >= 0 && sp.second.x < ch.cache_x
+                                     && sp.second.y >= 0 && sp.second.y < ch.cache_y;
+                          } ),
+                        [&]( const auto &sp ) {
+                            const level_cache &uch = get_cache_ref( zlev + sp.first );
+                            return static_cast<bool>(
+                                uch.floor_cache[uch.idx( sp.second.x, sp.second.y )] );
+                        }
+                    );
+                    solar_cache[ch.idx( x, y )] = !blocked;
+                }
+            );
+        }
+    );
+}
+
 // toward the lower limit. Since it's sunlight, the rays are parallel.
 // Each layer consults the next layer up to determine the intensity of the light that reaches it.
 // Once this is complete, additional operations add more dynamic lighting.
@@ -288,6 +395,19 @@ void map::build_sunlight_cache( int pzlev )
     // when first obstacles occur: fully_outside=false, fully_inside=false  (slow quadrant logic)
     //    ↓
     // when fully below ground: fully_outside=false, fully_inside=true  (fast fill)
+
+    // Rebuild the directional sunlight cache once per in-game hour (expensive path only).
+    if( fov_3d_occlusion ) {
+        const auto current_hour = to_hours<int>( time_past_midnight( calendar::turn ) );
+        if( current_hour != m_solar.last_built_hour ) {
+            update_solar_params();
+            std::ranges::for_each(
+                std::views::iota( zlev_min, zlev_max + 1 ),
+                [this]( int z ) { build_angled_sunlight_cache( z ); }
+            );
+            m_solar.last_built_hour = current_hour;
+        }
+    }
 
     // Iterate top to bottom because sunlight cache needs to construct in that order.
     for( int zlev = zlev_max; zlev >= zlev_min; zlev-- ) {
@@ -323,8 +443,11 @@ void map::build_sunlight_cache( int pzlev )
         // If there were no obstacles before this level, just apply weather illumination since there's no opportunity
         // for light to be blocked.
         if( fully_outside ) {
-            //fill with full light
-            std::fill( lm.begin(), lm.end(), four_quadrants( outside_light_level ) );
+            // No floors above: every tile has unobstructed sky, so all get the natural outdoor level.
+            // Shadow dimming (SOLAR_SHADOW_SCATTER) is applied in ambient_light_at / apparent_light_at,
+            // not here, so lm always carries full outdoor brightness for cascade and bleed purposes.
+            const auto sky_level = outside_light_level;
+            std::fill( lm.begin(), lm.end(), four_quadrants( sky_level ) );
 
             const auto &this_floor_cache = map_cache.floor_cache;
             const auto &this_transparency_cache = map_cache.transparency_cache;
@@ -347,10 +470,9 @@ void map::build_sunlight_cache( int pzlev )
             continue;
         }
 
-        // Replace this with a calculated shift based on time of day and date.
-        // At first compress the angle such that it takes no more than one tile of shift per level.
-        // To exceed that, we'll have to handle casting light from the side instead of the top.
-        point offset;
+        // Directional sunlight is handled via angled_sunlight_cache (see build_angled_sunlight_cache).
+        // The cascade here provides indoor bleed and scatter propagation; it samples directly above.
+        const point offset = point_zero;
         const level_cache &prev_map_cache = get_cache_ref( zlev + 1 );
         const auto &prev_lm = prev_map_cache.lm;
         const auto &prev_transparency_cache = prev_map_cache.transparency_cache;
@@ -414,6 +536,23 @@ void map::build_sunlight_cache( int pzlev )
                     }
                 }
             }
+        }
+
+        // Override solar-lit outdoor tiles to full outside_light_level.
+        // Shadow tiles are left at cascade-computed values; scatter dimming is applied
+        // in apparent_light_at (rendering only) so distance decay works correctly.
+        if( fov_3d_occlusion && m_solar.direct_active ) {
+            const auto &solar_cache = map_cache.angled_sunlight_cache;
+            std::ranges::for_each(
+                std::views::iota( 0, map_cache.cache_x * map_cache.cache_y ),
+                [&]( int i ) {
+                    const auto idx = static_cast<size_t>( i );
+                    if( solar_cache[idx] ) {
+                        lm[idx].fill( outside_light_level );
+                        fully_inside = false;
+                    }
+                }
+            );
         }
     }
 }
@@ -765,7 +904,17 @@ float map::ambient_light_at( const tripoint &p ) const
     }
 
     const auto &map_cache = get_cache_ref( p.z );
-    return map_cache.lm[map_cache.idx( p.x, p.y )].max();
+    float light = map_cache.lm[map_cache.idx( p.x, p.y )].max();
+
+    if( fov_3d_occlusion && m_solar.direct_active ) {
+        const auto idx = static_cast<size_t>( map_cache.idx( p.x, p.y ) );
+        if( map_cache.outside_cache[idx] && !map_cache.angled_sunlight_cache[idx] ) {
+            light = std::min( light,
+                              static_cast<float>( default_daylight_level() ) * SOLAR_SHADOW_SCATTER );
+        }
+    }
+
+    return light;
 }
 
 bool map::is_transparent( const tripoint &p ) const
@@ -862,6 +1011,19 @@ lit_level map::apparent_light_at( const tripoint &p, const visibility_variables 
     const auto &map_cache = get_cache_ref( p.z );
     const apparent_light_info a = apparent_light_helper( map_cache, p );
 
+    float apparent_light = a.apparent_light;
+
+    // Shadow cap: outdoor tiles without direct solar LOS are capped at scatter level.
+    // Uses min rather than multiply so distance decay acts on full daylight first —
+    // shadow tiles stay visible at full render distance and only fade at the edge.
+    if( fov_3d_occlusion && m_solar.direct_active && !a.obstructed ) {
+        const auto idx = static_cast<size_t>( map_cache.idx( p.x, p.y ) );
+        if( map_cache.outside_cache[idx] && !map_cache.angled_sunlight_cache[idx] ) {
+            apparent_light = std::min( apparent_light,
+                                       static_cast<float>( default_daylight_level() ) * SOLAR_SHADOW_SCATTER );
+        }
+    }
+
     // Unimpaired range is an override to strictly limit vision range based on various conditions,
     // but the player can still see light sources.
     if( dist > g->u.unimpaired_range() ) {
@@ -872,8 +1034,8 @@ lit_level map::apparent_light_at( const tripoint &p, const visibility_variables 
         }
     }
     if( a.obstructed ) {
-        if( a.apparent_light > LIGHT_AMBIENT_LIT ) {
-            if( a.apparent_light > cache.g_light_level ) {
+        if( apparent_light > LIGHT_AMBIENT_LIT ) {
+            if( apparent_light > cache.g_light_level ) {
                 // This represents too hazy to see detail,
                 // but enough light getting through to illuminate.
                 return lit_level::BRIGHT_ONLY;
@@ -881,7 +1043,7 @@ lit_level map::apparent_light_at( const tripoint &p, const visibility_variables 
                 // If it's not brighter than the surroundings, it just ends up shadowy.
                 return lit_level::LOW;
             }
-        } else if( a.apparent_light >= cache.vision_threshold ) {
+        } else if( apparent_light >= cache.vision_threshold ) {
             // Tile is hazy but still within the player's actual vision capability
             // (e.g. extended night-vision range pushes the perceptible horizon past 60 tiles).
             return lit_level::LOW;
@@ -890,13 +1052,13 @@ lit_level map::apparent_light_at( const tripoint &p, const visibility_variables 
         }
     }
     // Then we just search for the light level in descending order.
-    if( a.apparent_light > LIGHT_SOURCE_BRIGHT || map_cache.sm[map_cache.idx( p.x, p.y )] > 0.0 ) {
+    if( apparent_light > LIGHT_SOURCE_BRIGHT || map_cache.sm[map_cache.idx( p.x, p.y )] > 0.0 ) {
         return lit_level::BRIGHT;
     }
-    if( a.apparent_light > LIGHT_AMBIENT_LIT ) {
+    if( apparent_light > LIGHT_AMBIENT_LIT ) {
         return lit_level::LIT;
     }
-    if( a.apparent_light >= cache.vision_threshold ) {
+    if( apparent_light >= cache.vision_threshold ) {
         return lit_level::LOW;
     } else {
         return lit_level::BLANK;

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -418,7 +418,45 @@ void map::build_sunlight_cache( int pzlev )
     }
 }
 
-void map::generate_lightmap( const int zlev, bool skip_shared_init )
+void map::generate_lightmap( const int zlev )
+{
+    auto &map_cache = get_cache( zlev );
+    auto &lm = map_cache.lm;
+    auto &sm = map_cache.sm;
+    auto &light_source_buffer = map_cache.light_source_buffer;
+
+    std::fill( lm.begin(), lm.end(), four_quadrants( 0.0f ) );
+    std::fill( sm.begin(), sm.end(), 0.0f );
+    std::fill( light_source_buffer.begin(), light_source_buffer.end(), 0.0f );
+
+    build_sunlight_cache( zlev );
+
+    apply_character_light( get_player_character() );
+    for( npc &guy : g->all_npcs() ) {
+        apply_character_light( guy );
+    }
+    for( monster &critter : g->all_monsters() ) {
+        if( critter.is_hallucination() ) {
+            continue;
+        }
+        const tripoint &mp = critter.pos();
+        if( inbounds( mp ) ) {
+            if( critter.has_effect( effect_onfire ) ) {
+                apply_light_source( mp, 8 );
+            }
+            // TODO: [lightmap] Attach natural light brightness to creatures
+            // TODO: [lightmap] Allow creatures to have light attacks (i.e.: eyebot)
+            // TODO: [lightmap] Allow creatures to have facing and arc lights
+            if( critter.type->luminance > 0 ) {
+                apply_light_source( mp, critter.type->luminance );
+            }
+        }
+    }
+
+    generate_lightmap_worker( zlev );
+}
+
+void map::generate_lightmap_worker( const int zlev )
 {
     ZoneScoped;
     auto &map_cache = get_cache( zlev );
@@ -438,27 +476,6 @@ void map::generate_lightmap( const int zlev, bool skip_shared_init )
      * Step 4: Profit!
      */
     auto &light_source_buffer = map_cache.light_source_buffer;
-
-    if( !skip_shared_init ) {
-        // Serial path: this call is responsible for its own initialization.
-        // build_sunlight_cache() writes to all z-levels' lm, so it must not
-        // run concurrently with other generate_lightmap() calls.
-        std::fill( lm.begin(), lm.end(), four_quadrants( 0.0f ) );
-        std::fill( sm.begin(), sm.end(), 0.0f );
-        std::fill( light_source_buffer.begin(), light_source_buffer.end(), 0.0f );
-
-        build_sunlight_cache( zlev );
-
-        apply_character_light( get_player_character() );
-        for( npc &guy : g->all_npcs() ) {
-            apply_character_light( guy );
-        }
-    }
-    // When skip_shared_init is true the caller has already:
-    //   - cleared sm[zlev] and light_source_buffer[zlev]
-    //   - called build_sunlight_cache() once (fills all lm[])
-    //   - applied character/NPC lights
-    // We only collect dynamic sources that belong to this z-level.
 
     constexpr std::array<int, 4> dir_x = { {  0, -1, 1, 0 } };    //    [0]
     constexpr std::array<int, 4> dir_y = { { -1,  0, 0, 1 } };    // [1][X][2]
@@ -605,27 +622,6 @@ void map::generate_lightmap( const int zlev, bool skip_shared_init )
             } );
         } );
 
-        // Skip in parallel mode: build_map_cache has already applied monster lights
-        // serially before the parallel_for to avoid racing on weak_ptr_fast::lock().
-        if( !skip_shared_init ) {
-            for( monster &critter : g->all_monsters() ) {
-                if( critter.is_hallucination() ) {
-                    continue;
-                }
-                const tripoint &mp = critter.pos();
-                if( inbounds( mp ) ) {
-                    if( critter.has_effect( effect_onfire ) ) {
-                        apply_light_source( mp, 8 );
-                    }
-                    // TODO: [lightmap] Attach natural light brightness to creatures
-                    // TODO: [lightmap] Allow creatures to have light attacks (i.e.: eyebot)
-                    // TODO: [lightmap] Allow creatures to have facing and arc lights
-                    if( critter.type->luminance > 0 ) {
-                        apply_light_source( mp, critter.type->luminance );
-                    }
-                }
-            }
-        }
 
         // Apply any vehicle light sources
         VehicleList vehs = get_vehicles();
@@ -653,9 +649,7 @@ void map::generate_lightmap( const int zlev, bool skip_shared_init )
                 if( !inbounds( src ) ) {
                     continue;
                 }
-                // In parallel mode skip parts not on this z-level to avoid
-                // cross-level cache writes.
-                if( skip_shared_init && src.z != zlev ) {
+                if( src.z != zlev ) {
                     continue;
                 }
 
@@ -697,8 +691,7 @@ void map::generate_lightmap( const int zlev, bool skip_shared_init )
                 if( !inbounds( pp ) ) {
                     continue;
                 }
-                // In parallel mode skip parts not on this z-level.
-                if( skip_shared_init && pp.z != zlev ) {
+                if( pp.z != zlev ) {
                     continue;
                 }
                 if( vp.has_feature( VPFLAG_CARGO ) && !vp.has_feature( "COVERED" ) ) {

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -329,43 +329,43 @@ void map::build_angled_sunlight_cache( const int zlev )
 
     std::ranges::for_each(
         std::views::iota( 0, ch.cache_x ),
-        [&]( int x ) {
-            std::ranges::for_each(
-                std::views::iota( 0, ch.cache_y ),
-                [&]( int y ) {
-                    // A floor directly overhead always blocks, regardless of sun angle.
-                    // Without this, angled rays jump laterally past the roof tile at step 1.
-                    if( zlev + 1 <= OVERMAP_HEIGHT ) {
-                        const level_cache &above = get_cache_ref( zlev + 1 );
-                        if( above.floor_cache[above.idx( x, y )] ) {
-                            solar_cache[ch.idx( x, y )] = false;
-                            return;
-                        }
-                    }
-                    // Trace the sun ray upward one z-level at a time.
-                    // Solar-lit if the ray exits the map bounds without hitting a floor.
-                    const auto blocked = std::ranges::any_of(
-                        std::views::iota( 1, max_step + 1 )
-                        | std::views::transform( [&]( int step ) {
-                              return std::pair{ step, point{
-                                  x + static_cast<int>( std::roundf( step_x * static_cast<float>( step ) ) ),
-                                  y + static_cast<int>( std::roundf( step_y * static_cast<float>( step ) ) )
-                              } };
-                          } )
-                        | std::views::take_while( [&]( const auto &sp ) {
-                              return sp.second.x >= 0 && sp.second.x < ch.cache_x
-                                     && sp.second.y >= 0 && sp.second.y < ch.cache_y;
-                          } ),
-                        [&]( const auto &sp ) {
-                            const level_cache &uch = get_cache_ref( zlev + sp.first );
-                            return static_cast<bool>(
-                                uch.floor_cache[uch.idx( sp.second.x, sp.second.y )] );
-                        }
-                    );
-                    solar_cache[ch.idx( x, y )] = !blocked;
+    [&]( int x ) {
+        std::ranges::for_each(
+            std::views::iota( 0, ch.cache_y ),
+        [&]( int y ) {
+            // A floor directly overhead always blocks, regardless of sun angle.
+            // Without this, angled rays jump laterally past the roof tile at step 1.
+            if( zlev + 1 <= OVERMAP_HEIGHT ) {
+                const level_cache &above = get_cache_ref( zlev + 1 );
+                if( above.floor_cache[above.idx( x, y )] ) {
+                    solar_cache[ch.idx( x, y )] = false;
+                    return;
                 }
-            );
+            }
+            // Trace the sun ray upward one z-level at a time.
+            // Solar-lit if the ray exits the map bounds without hitting a floor.
+            const auto blocked = std::ranges::any_of(
+                                     std::views::iota( 1, max_step + 1 )
+            | std::views::transform( [&]( int step ) {
+                return std::pair{ step, point{
+                        x + static_cast<int>( std::roundf( step_x * static_cast<float>( step ) ) ),
+                        y + static_cast<int>( std::roundf( step_y * static_cast<float>( step ) ) )
+                    } };
+            } )
+            | std::views::take_while( [&]( const auto & sp ) {
+                return sp.second.x >= 0 && sp.second.x < ch.cache_x
+                       && sp.second.y >= 0 && sp.second.y < ch.cache_y;
+            } ),
+            [&]( const auto & sp ) {
+                const level_cache &uch = get_cache_ref( zlev + sp.first );
+                return static_cast<bool>(
+                           uch.floor_cache[uch.idx( sp.second.x, sp.second.y )] );
+            }
+                                 );
+            solar_cache[ch.idx( x, y )] = !blocked;
         }
+        );
+    }
     );
 }
 
@@ -403,7 +403,7 @@ void map::build_sunlight_cache( int pzlev )
             update_solar_params();
             std::ranges::for_each(
                 std::views::iota( zlev_min, zlev_max + 1 ),
-                [this]( int z ) { build_angled_sunlight_cache( z ); }
+            [this]( int z ) { build_angled_sunlight_cache( z ); }
             );
             m_solar.last_built_hour = current_hour;
         }
@@ -545,13 +545,13 @@ void map::build_sunlight_cache( int pzlev )
             const auto &solar_cache = map_cache.angled_sunlight_cache;
             std::ranges::for_each(
                 std::views::iota( 0, map_cache.cache_x * map_cache.cache_y ),
-                [&]( int i ) {
-                    const auto idx = static_cast<size_t>( i );
-                    if( solar_cache[idx] ) {
-                        lm[idx].fill( outside_light_level );
-                        fully_inside = false;
-                    }
+            [&]( int i ) {
+                const auto idx = static_cast<size_t>( i );
+                if( solar_cache[idx] ) {
+                    lm[idx].fill( outside_light_level );
+                    fully_inside = false;
                 }
+            }
             );
         }
     }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -9809,12 +9809,10 @@ void map::build_map_cache( const int zlev, bool skip_lightmap )
     if( seen_cache_dirty ) {
         skew_vision_cache.assign( vision_cache_slots, vision_cache_slot{} );
     }
-    // Initial value is illegal player position.
     const tripoint &p = g->u.pos();
-    static tripoint player_prev_pos;
-    if( seen_cache_dirty || player_prev_pos != p ) {
+    if( seen_cache_dirty || m_last_seen_cache_origin != p ) {
         build_seen_cache( p, zlev );
-        player_prev_pos = p;
+        m_last_seen_cache_origin = p;
         // seen_cache changed; any cached visibility derived from it is now stale.
         get_cache( zlev ).visibility_cache_dirty = true;
     }
@@ -10593,6 +10591,7 @@ void map::invalidate_map_cache( const int zlev )
         ch.visibility_cache_dirty = true;
         ch.outside_cache_dirty.set();
         ch.suspension_cache_dirty = true;
+        m_last_seen_cache_origin = tripoint_min;
     }
 }
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -9667,7 +9667,6 @@ static void vehicle_caching_internal_above( level_cache &zch_above, const vpart_
     if( vp.has_feature( VPFLAG_ROOF ) || vp.has_feature( VPFLAG_OPAQUE ) ) {
         const tripoint &part_pos = v->global_part_pos3( vp.part() );
         const int tile_idx = zch_above.idx( part_pos.x, part_pos.y );
-        zch_above.floor_cache[tile_idx] = true;
         zch_above.vehicle_floor_cache[tile_idx] = true;
     }
 }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -9815,6 +9815,8 @@ void map::build_map_cache( const int zlev, bool skip_lightmap )
     if( seen_cache_dirty || player_prev_pos != p ) {
         build_seen_cache( p, zlev );
         player_prev_pos = p;
+        // seen_cache changed; any cached visibility derived from it is now stale.
+        get_cache( zlev ).visibility_cache_dirty = true;
     }
     if( !skip_lightmap ) {
         ZoneScopedN( "Phase4_lightmap" );

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -8009,6 +8009,7 @@ void map::shift( point sp )
                 shift_flat_cache( gc.transparency_cache, gc.cache_x, gc.cache_y, SEEX, SEEY, sp );
                 shift_flat_cache( gc.floor_cache, gc.cache_x, gc.cache_y, SEEX, SEEY, sp );
                 shift_flat_cache( gc.outside_cache, gc.cache_x, gc.cache_y, SEEX, SEEY, sp );
+                shift_flat_cache( gc.angled_sunlight_cache, gc.cache_x, gc.cache_y, SEEX, SEEY, sp );
             }
             // Iterate in shift-direction order so copy_grid never reads an
             // already-overwritten source slot.  sp >= 0 → forward; sp < 0 → reverse.
@@ -8051,6 +8052,8 @@ void map::shift( point sp )
             } );
         }
     } // shift_grid_copy_load
+    // New edge submaps have stale solar cache data. Force a rebuild before the next draw.
+    m_solar.last_built_hour = -1;
     if( zlevels ) {
         ZoneScopedN( "shift_add_roofs" );
         //Go through the generated maps and fill in the roofs
@@ -10506,6 +10509,7 @@ level_cache::level_cache( int mx, int my )
       sm( static_cast<size_t>( mx * my ), 0.0f ),
       light_source_buffer( static_cast<size_t>( mx * my ), 0.0f ),
       outside_cache( static_cast<size_t>( mx * my ), false ),
+      angled_sunlight_cache( static_cast<size_t>( mx * my ), false ),
       floor_cache( static_cast<size_t>( mx * my ), false ),
       vehicle_floor_cache( static_cast<size_t>( mx * my ), '\0' ),
       transparency_cache( static_cast<size_t>( mx * my ), 0.0f ),
@@ -10591,6 +10595,7 @@ void map::invalidate_map_cache( const int zlev )
         ch.outside_cache_dirty.set();
         ch.suspension_cache_dirty = true;
         m_last_seen_cache_origin = tripoint_min;
+        m_solar.last_built_hour  = -1;
     }
 }
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -9877,7 +9877,7 @@ void map::build_map_cache( const int zlev, bool skip_lightmap )
                 // from concurrent writes to last_full_vehicle_list.
                 get_vehicles();
                 parallel_for( 0, static_cast<int>( dirty_seen_cache_levels.size() ), [&]( int i ) {
-                    generate_lightmap( dirty_seen_cache_levels[i], /*skip_shared_init=*/true );
+                    generate_lightmap_worker( dirty_seen_cache_levels[i] );
                 } );
             } else {
                 // Single dirty level: run serially using the standard full path.

--- a/src/map.h
+++ b/src/map.h
@@ -2017,7 +2017,8 @@ class map : public submap_load_listener
         // this level, called build_sunlight_cache() once, and applied character
         // lights.  The function then processes only entities whose position z
         // matches zlev, avoiding cross-level cache writes for parallel safety.
-        void generate_lightmap( int zlev, bool skip_shared_init = false );
+        void generate_lightmap( int zlev );
+        void generate_lightmap_worker( int zlev );
         void build_seen_cache( const tripoint &origin, int target_z );
         // Applies vehicle mirror/camera FOV from @p origin's vehicle.
         // Separated from build_seen_cache for readability and Tracy granularity.

--- a/src/map.h
+++ b/src/map.h
@@ -2041,6 +2041,12 @@ class map : public submap_load_listener
         // Written serially before parallel shadowcasting calls.
         exp_lookup weather_lookup_{ LIGHT_TRANSPARENCY_OPEN_AIR * 1.1f };
 
+        // Last player position for which build_seen_cache was run.
+        // Initialized to tripoint_min so the first build_map_cache call always rebuilds.
+        // Reset to tripoint_min by invalidate_map_cache so any full-cache invalidation
+        // forces a seen_cache rebuild regardless of whether the player moved.
+        tripoint m_last_seen_cache_origin = tripoint_min;
+
         /**
          * Absolute coordinates of first submap (get_submap_at(0,0))
          * This is in submap coordinates (see overmapbuffer for explanation).

--- a/src/map.h
+++ b/src/map.h
@@ -355,6 +355,12 @@ struct level_cache {
     // "inside" tiles are protected from sun, rain, etc. (see "INDOORS" flag)
     std::vector<bool>               outside_cache;
 
+    // True when this tile has an unobstructed ray to the sun for the current in-game hour.
+    // Rebuilt by map::build_angled_sunlight_cache() when the hour changes.
+    // Consulted by build_sunlight_cache() to distinguish direct-sun tiles (full
+    // outside_light_level) from scatter-lit outdoor tiles (reduced ambient level).
+    std::vector<bool>               angled_sunlight_cache;
+
     // true when vehicle below has "ROOF" or "OPAQUE" part, furniture below has "SUN_ROOF_ABOVE"
     //      or terrain doesn't have "NO_FLOOR" flag
     // false otherwise
@@ -2003,6 +2009,12 @@ class map : public submap_load_listener
         bool build_vision_transparency_cache( const Character &player );
         // fills lm with sunlight. pzlev is current player's zlevel
         void build_sunlight_cache( int pzlev );
+        // Recomputes sun direction and scatter factor from the current game time.
+        // Called once per in-game hour from build_sunlight_cache.
+        void update_solar_params();
+        // Traces a parallel sun ray from each tile at zlev upward and writes
+        // angled_sunlight_cache.  Reads floor_cache across all z-levels above zlev.
+        void build_angled_sunlight_cache( int zlev );
     public:
         void build_outside_cache( int zlev );
         // Builds a floor cache and returns true if the cache was invalidated.
@@ -2047,6 +2059,22 @@ class map : public submap_load_listener
         // Reset to tripoint_min by invalidate_map_cache so any full-cache invalidation
         // forces a seen_cache rebuild regardless of whether the player moved.
         tripoint m_last_seen_cache_origin = tripoint_min;
+
+        // State for the directional sunlight system.  Rebuilt once per in-game hour by
+        // update_solar_params() and build_angled_sunlight_cache().
+        struct solar_params {
+            // Sun ray horizontal displacement per z-level.
+            // Positive dx_per_z = east (+x); negative = west.
+            // SUN_EAST_SIGN in update_solar_params() flips the axis if needed.
+            // dy_per_z is always 0 (no latitude tilt modelled).
+            float dx_per_z     = 0.f;
+            float dy_per_z     = 0.f;
+            // False at night; true for all daylight hours (day/night boundary only).
+            bool  direct_active  = false;
+            // Game-hour when the cache was last rebuilt; -1 forces a rebuild on first use.
+            int   last_built_hour = -1;
+        };
+        solar_params m_solar;
 
         /**
          * Absolute coordinates of first submap (get_submap_at(0,0))

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2383,15 +2383,15 @@ void options_manager::add_options_performance()
                                           to_translation( "Configure three-dimensional visibility across z-levels." ) ),
     [&]( auto & page_id ) {
         add( "FOV_3D", page_id, translate_marker( "3D field of vision" ),
-             translate_marker( "If false, vision is limited to current z-level.  If true and the world is in z-level mode, the vision will extend beyond current z-level." ),
+             translate_marker( "If false, vision is limited to current z-level. If true and the world is in z-level mode, the vision will extend beyond current z-level." ),
              true
            );
         add( "FOV_3D_Z_RANGE", page_id, translate_marker( "Vertical range of 3D field of vision" ),
-             translate_marker( "How many levels up and down the experimental 3D field of vision reaches.  (This many levels up, this many levels down.)  3D vision of the full height of the world can slow the game down a lot.  Seeing fewer Z-levels is faster." ),
+             translate_marker( "How many levels up and down the experimental 3D field of vision reaches. (This many levels up, this many levels down.)  3D vision of the full height of the world can slow the game down a lot.  Seeing fewer Z-levels is faster." ),
              0, OVERMAP_LAYERS, is_android ? 3 : 5
            );
-        add( "FOV_3D_OCCLUSION", page_id, translate_marker( "3D FoV horizontal occlusion" ),
-             translate_marker( "When enabled, obstacles at other z-levels correctly cast 3D shadows.  Requires 3D FoV.  Significantly slower than disabled." ),
+        add( "FOV_3D_OCCLUSION", page_id, translate_marker( "3D FoV shadow casting" ),
+             translate_marker( "When enabled, obstacles at other z-levels correctly cast 3D shadows. Requires 3D FoV. Significantly slower than disabled." ),
              false
            );
     } );


### PR DESCRIPTION
## Purpose of change (The Why)

Resolves a bug reported a few times in discord where lighting wouldn't update when the player moved, but instead once per standardized turn.
For standard movement speeds, this would only be at most 1 turn of delay, many times none.
3D shadows also blocked line of sight from above with the expensive setting on, but sunlight itself didn't have an effect.
Another bug reappeared as well, which was tiles below the 3D fov range were rendering black.

## Describe the solution (The How)

Fixed the delay.
Cleaned up some lighting calculation ordering errors.
Fixed the black rendering bug again, which was caused by the fix to another bug. Once I realized that I was just toggling bugs, I made the real fix.
Similarly, vehicle roof shadows sometimes appeared again but disconnected, so I fixed them adding to the floor cache erroneously.
Implemented 3D shadows from the sun based on the time of day, cached by the hour.

## Testing

Tried looking at shadows at different times of days, toggling the setting, from different angles. Standard fare.

## Additional context

My life is lighting calculations.