### PR TITLE
feat: add hover tank and hover apc, update hover repulsor description

### DIFF
--- a/data/json/external_tileset/AFS_external.json
+++ b/data/json/external_tileset/AFS_external.json
@@ -607,7 +607,7 @@
             "rotates": true
           },
           { "id": "mon_uafv_xm246e1", "fg": 401, "rotates": false },
-          { "id": "corpse_mon_uafv_xm246e1", "fg": 402, "rotates": false }
+          { "id": "broken_uafv_xm246e1", "fg": 402, "rotates": false }
         ],
         "//": "range 369 to 415",
         "sprite_width": 64,

--- a/data/json/items/vehicle/jets.json
+++ b/data/json/items/vehicle/jets.json
@@ -37,7 +37,7 @@
     "type": "WHEEL",
     "category": "veh_parts",
     "name": { "str": "hover repulsor" },
-    "description": "This is a lightweight hover repulsor module mounted on the underside of the next-generation hoverbike.  It offers unparalleled maneuverability, allowing the hoverbike to glide effortlessly over swamps and ruins, completely overcoming ground friction.",
+    "description": "This is a lightweight hover repulsor module mounted on the underside of a vehicle.  It offers unparalleled maneuverability, allowing the vehicle to glide effortlessly over swamps and ruins, completely overcoming ground friction.",
     "price": "334000 USD",
     "price_postapoc": "125 USD",
     "weight": "60 kg",

--- a/data/json/vehicle_groups.json
+++ b/data/json/vehicle_groups.json
@@ -285,8 +285,8 @@
       [ "tank_m60_patton", 50 ],
       [ "howitzer_m109", 75 ],
       [ "tank_xm7_elec", 25 ],
-	  [ "tank_xm_hover", 25 ],
-	  [ "xapc_hover", 25 ],
+      [ "tank_xm_hover", 25 ],
+      [ "xapc_hover", 25 ],
       [ "tractor_bandit", 5 ]
     ]
   },
@@ -417,8 +417,8 @@
       [ "tank_m60_patton_mothballed", 10 ],
       [ "howitzer_m109", 50 ],
       [ "tank_xm7_elec", 5 ],
-	  [ "tank_xm_hover", 5 ],
-	  [ "xapc_hover", 5 ]
+      [ "tank_xm_hover", 5 ],
+      [ "xapc_hover", 5 ]
     ]
   },
   {
@@ -482,8 +482,8 @@
       [ "tank_m60_patton_mothballed", 100 ],
       [ "howitzer_m109", 250 ],
       [ "tank_xm7_elec", 50 ],
-	  [ "tank_xm_hover", 50 ],
-	  [ "xapc_hover", 50 ]
+      [ "tank_xm_hover", 50 ],
+      [ "xapc_hover", 50 ]
     ]
   },
   {

--- a/data/json/vehicle_groups.json
+++ b/data/json/vehicle_groups.json
@@ -285,6 +285,8 @@
       [ "tank_m60_patton", 50 ],
       [ "howitzer_m109", 75 ],
       [ "tank_xm7_elec", 25 ],
+	  [ "tank_xm_hover", 25 ],
+	  [ "xapc_hover", 25 ],
       [ "tractor_bandit", 5 ]
     ]
   },
@@ -414,7 +416,9 @@
       [ "tank_m60_patton", 10 ],
       [ "tank_m60_patton_mothballed", 10 ],
       [ "howitzer_m109", 50 ],
-      [ "tank_xm7_elec", 5 ]
+      [ "tank_xm7_elec", 5 ],
+	  [ "tank_xm_hover", 5 ],
+	  [ "xapc_hover", 5 ]
     ]
   },
   {
@@ -477,7 +481,9 @@
       [ "tank_m60_patton", 100 ],
       [ "tank_m60_patton_mothballed", 100 ],
       [ "howitzer_m109", 250 ],
-      [ "tank_xm7_elec", 50 ]
+      [ "tank_xm7_elec", 50 ],
+	  [ "tank_xm_hover", 50 ],
+	  [ "xapc_hover", 50 ]
     ]
   },
   {

--- a/data/json/vehicleparts/jets.json
+++ b/data/json/vehicleparts/jets.json
@@ -73,7 +73,7 @@
     "durability": 300,
     "wheel_type": "off-road",
     "contact_area": 20,
-    "description": "This is a lightweight hover repulsor module mounted on the underside of the next-generation hoverbike.  It offers unparalleled maneuverability, allowing the hoverbike to glide effortlessly over swamps and ruins, completely overcoming ground friction.",
+    "description": "This is a lightweight hover repulsor module mounted on the underside of a vehicle.  It offers unparalleled maneuverability, allowing the vehicle to glide effortlessly over swamps and ruins, completely overcoming ground friction.",
     "damage_modifier": 50,
     "breaks_into": [ { "item": "scrap", "count": [ 15, 30 ] }, { "item": "steel_chunk", "count": [ 8, 16 ] } ],
     "flags": [ "BALLOON", "WHEEL", "FLOATS", "ROTOR", "STABLE", "SELF_JACK", "VARIABLE_SIZE", "TRACKED" ],

--- a/data/json/vehicles/military.json
+++ b/data/json/vehicles/military.json
@@ -2409,5 +2409,230 @@
       { "x": -1, "y": 1, "chance": 25, "items": [ "belt50" ] },
       { "x": -1, "y": 1, "chance": 25, "items": [ "belt50" ] }
     ]
+  },
+  {
+    "id": "xapc_hover",
+    "type": "vehicle",
+    "name": "Experimental Hover APC",
+    "parts": [
+      {
+        "x": 5,
+        "y": 2,
+        "parts": [ "frame_carbon_cover", "hdhalfboard_ne", "plating_military" ]
+      },
+      {
+        "x": 5,
+        "y": 1,
+        "parts": [ "frame_carbon_cover", "hdhalfboard_horizontal", "plating_military", "headlight_reinforced" ]
+      },
+      {
+        "x": 5,
+        "y": 0,
+        "parts": [ "frame_carbon_cover", "hdhalfboard_horizontal", "plating_military", "horn_big" ]
+      },
+      {
+        "x": 5,
+        "y": -1,
+        "parts": [ "frame_carbon_cover", "hdhalfboard_horizontal", "plating_military", "headlight_reinforced" ]
+      },
+      {
+        "x": 5,
+        "y": -2,
+        "parts": [ "frame_carbon_cover", "hdhalfboard_nw", "plating_military" ]
+      },
+      {
+        "x": 4,
+        "y": 2,
+        "parts": [ "frame_carbon_cover", "hdboard_ne", "plating_military", "omnicam" ]
+      },
+      {
+        "x": 4,
+        "y": 1,
+        "parts": [ "frame_carbon_cover", "hdboard_horizontal", "plating_military" ]
+      },
+      {
+        "x": 4,
+        "y": 0,
+        "parts": [ "frame_carbon_cover", "plating_military", "hdboard_horizontal" ]
+      },
+      {
+        "x": 4,
+        "y": -1,
+        "parts": [ "frame_carbon_cover", "plating_military", "reinforced_windshield", "v_hdshutter" ]
+      },
+      {
+        "x": 4,
+        "y": -2,
+        "parts": [ "frame_carbon_cover", "hdboard_nw", "plating_military", "omnicam" ]
+      },
+      {
+        "x": 3,
+        "y": 2,
+        "parts": [ "frame_carbon_cover", "hdboard_vertical", "plating_military" ]
+      },
+      {
+        "x": 3,
+        "y": 1,
+        "parts": [ "frame_carbon_cover", "hdroof", "NBC_seal", "plating_military", "cam_control", "turret_mount", "turret_autoloader", "seat", "seatbelt_heavyduty", { "part": "mounted_plasma_gun", "ammo": 50, "ammo_types": [ "plasma" ], "ammo_qty": [ 0, 25 ] }, "controls_turret" ]
+      },
+      {
+        "x": 3,
+        "y": 0,
+        "parts": [ "frame_carbon_cover", "hdroof", "NBC_seal", "plating_military", "engine_electric_super", "storage_battery", "cargo_space_carbon", "recharge_station" ]
+      },
+      {
+        "x": 3,
+        "y": -1,
+        "parts": [ "frame_carbon_cover", "hdroof", "NBC_seal", "controls", "dashboard", "cam_control", "vehicle_clock", "seat", "seatbelt_heavyduty" ]
+      },
+      {
+        "x": 3,
+        "y": -2,
+        "parts": [ "frame_carbon_cover", "hdboard_vertical", "plating_military" ]
+      },
+      {
+        "x": 2,
+        "y": 2,
+        "parts": [ "frame_carbon_cover", "hdboard_vertical", "plating_military" ]
+      },
+      {
+        "x": 2,
+        "y": 1,
+        "parts": [ "frame_carbon_cover", "seat", "hdroof", "NBC_seal", "reinforced_solar_panel" ]
+      },
+      {
+        "x": 2,
+        "y": 0,
+        "parts": [ "frame_carbon_cover", "aisle_horizontal", "hdroof", "NBC_seal", "storage_battery", "reinforced_solar_panel" ]
+      },
+      {
+        "x": 2,
+        "y": -1,
+        "parts": [ "frame_carbon_cover", "seat", "hdroof", "NBC_seal", "reinforced_solar_panel" ]
+      },
+      {
+        "x": 2,
+        "y": -2,
+        "parts": [ "frame_carbon_cover", "hdboard_vertical", "plating_military" ]
+      },
+      {
+        "x": 1,
+        "y": 2,
+        "parts": [ "frame_carbon_cover", "hdboard_vertical", "plating_military" ]
+      },
+      {
+        "x": 1,
+        "y": 1,
+        "parts": [ "frame_carbon_cover", "hdroof", "NBC_seal", "aisle_vertical", "reinforced_solar_panel" ]
+      },
+      {
+        "x": 1,
+        "y": 0,
+        "parts": [ "frame_carbon_cover", "hdroof", "NBC_seal", "atomic_lamp", "hover_repulsor", "reinforced_solar_panel" ]
+      },
+      {
+        "x": 1,
+        "y": -1,
+        "parts": [ "frame_carbon_cover", "hdroof", "NBC_seal", "aisle_vertical", "reinforced_solar_panel" ]
+      },
+      {
+        "x": 1,
+        "y": -2,
+        "parts": [ "frame_carbon_cover", "hdboard_vertical", "plating_military" ]
+      },
+      {
+        "x": 0,
+        "y": 2,
+        "parts": [ "frame_carbon_cover", "hdboard_vertical", "plating_military" ]
+      },
+      {
+        "x": 0,
+        "y": 1,
+        "parts": [ "frame_carbon_cover", "seat", "hdroof", "NBC_seal", "reinforced_solar_panel" ]
+      },
+      {
+        "x": 0,
+        "y": 0,
+        "parts": [ "frame_carbon_cover", "hdroof", "NBC_seal", "aisle_vertical", "reinforced_solar_panel" ]
+      },
+      {
+        "x": 0,
+        "y": -1,
+        "parts": [ "frame_carbon_cover", "seat", "hdroof", "NBC_seal", "reinforced_solar_panel" ]
+      },
+      {
+        "x": 0,
+        "y": -2,
+        "parts": [ "frame_carbon_cover", "hdboard_vertical", "plating_military" ]
+      },
+      {
+        "x": -1,
+        "y": 2,
+        "parts": [ "frame_carbon_cover", "hdboard_vertical", "plating_military" ]
+      },
+      {
+        "x": -1,
+        "y": 1,
+        "parts": [ "frame_carbon_cover", "hdroof", "NBC_seal", "seat" ]
+      },
+      {
+        "x": -1,
+        "y": 0,
+        "parts": [ "frame_carbon_cover", "aisle_horizontal", "hdroof", "NBC_seal" ]
+      },
+      {
+        "x": -1,
+        "y": -1,
+        "parts": [ "frame_carbon_cover", "hdroof", "NBC_seal", "seat" ]
+      },
+      {
+        "x": -1,
+        "y": -2,
+        "parts": [ "frame_carbon_cover", "hdboard_vertical", "plating_military" ]
+      },
+      {
+        "x": -2,
+        "y": 2,
+        "parts": [ "frame_carbon_cover", "hdboard_se", "muffler", "plating_military", "omnicam" ]
+      },
+      {
+        "x": -2,
+        "y": 1,
+        "parts": [ "frame_carbon_cover", "hdboard_horizontal", "plating_military" ]
+      },
+      {
+        "x": -2,
+        "y": 0,
+        "parts": [ "frame_carbon_cover", "hddoor_opaque", "plating_military" ]
+      },
+      {
+        "x": -2,
+        "y": -1,
+        "parts": [ "frame_carbon_cover", "hdboard_horizontal", "plating_military" ]
+      },
+      {
+        "x": -2,
+        "y": -2,
+        "parts": [ "frame_carbon_cover", "hdboard_sw", "muffler", "plating_military", "omnicam" ]
+      }
+    ],
+	"items": [
+      { "x": 3, "y": -1, "chance": 2, "items": [ "id_military" ] },
+      { "x": 3, "y": -1, "chance": 3, "items": [ "mil_gps_device" ] },
+      { "x": 3, "y": -1, "chance": 20, "item_groups": [ "tools_survival" ] },
+      { "x": 3, "y": 1, "chance": 50, "items": [ "ear_plugs" ] },
+      { "x": 2, "y": -1, "chance": 20, "item_groups": [ "ammo_milspec" ] },
+      { "x": 2, "y": 1, "chance": 20, "item_groups": [ "ammo_milspec" ] },
+      { "x": 2, "y": -1, "chance": 20, "item_groups": [ "ammo_milspec" ] },
+      { "x": 2, "y": 1, "chance": 20, "item_groups": [ "ammo_milspec" ] },
+      { "x": 2, "y": -1, "chance": 10, "item_groups": [ "mags_milspec" ] },
+      { "x": 2, "y": 1, "chance": 10, "item_groups": [ "mags_milspec" ] },
+      { "x": 2, "y": -1, "chance": 10, "item_groups": [ "mags_milspec" ] },
+      { "x": 2, "y": 1, "chance": 10, "item_groups": [ "mags_milspec" ] },
+      { "x": 2, "y": -1, "chance": 5, "item_groups": [ "guns_milspec" ] },
+      { "x": 2, "y": 1, "chance": 5, "item_groups": [ "guns_milspec" ] },
+      { "x": 2, "y": -1, "chance": 5, "item_groups": [ "guns_milspec" ] },
+      { "x": 2, "y": 1, "chance": 5, "item_groups": [ "guns_milspec" ] }
+    ]
   }
 ]

--- a/data/json/vehicles/military.json
+++ b/data/json/vehicles/military.json
@@ -2236,36 +2236,12 @@
     "type": "vehicle",
     "name": "XMH Hover Tank",
     "parts": [
-      {
-        "x": -3,
-        "y": -2,
-        "parts": [ "frame_carbon_cover", "plating_military", "hdhalfboard_sw" ]
-      },
-      {
-        "x": -2,
-        "y": -2,
-        "parts": [ "frame_carbon_cover", "plating_military", "hdhalfboard_vertical" ]
-      },
-      {
-        "x": -1,
-        "y": -2,
-        "parts": [ "frame_carbon_cover", "plating_military", "hdhalfboard_vertical" ]
-      },
-      {
-        "x": 0,
-        "y": -2,
-        "parts": [ "frame_carbon_cover", "plating_military", "hover_repulsor" ]
-      },
-      {
-        "x": 1,
-        "y": -2,
-        "parts": [ "frame_carbon_cover", "plating_military", "hdhalfboard_vertical" ]
-      },
-      {
-        "x": 2,
-        "y": -2,
-        "parts": [ "frame_carbon_cover", "plating_military", "hdhalfboard_nw" ]
-      },
+      { "x": -3, "y": -2, "parts": [ "frame_carbon_cover", "plating_military", "hdhalfboard_sw" ] },
+      { "x": -2, "y": -2, "parts": [ "frame_carbon_cover", "plating_military", "hdhalfboard_vertical" ] },
+      { "x": -1, "y": -2, "parts": [ "frame_carbon_cover", "plating_military", "hdhalfboard_vertical" ] },
+      { "x": 0, "y": -2, "parts": [ "frame_carbon_cover", "plating_military", "hover_repulsor" ] },
+      { "x": 1, "y": -2, "parts": [ "frame_carbon_cover", "plating_military", "hdhalfboard_vertical" ] },
+      { "x": 2, "y": -2, "parts": [ "frame_carbon_cover", "plating_military", "hdhalfboard_nw" ] },
       {
         "x": -3,
         "y": -1,
@@ -2286,35 +2262,37 @@
         "y": -1,
         "parts": [ "frame_carbon_cover", "hdhatch_opaque", "hdroof", "NBC_seal", "plating_military" ]
       },
-      {
-        "x": 1,
-        "y": -1,
-        "parts": [ "frame_carbon_cover", "hdboard_nw", "plating_military" ]
-      },
+      { "x": 1, "y": -1, "parts": [ "frame_carbon_cover", "hdboard_nw", "plating_military" ] },
       {
         "x": 2,
         "y": -1,
         "parts": [ "frame_carbon_cover", "hdhalfboard_horizontal_2", "omnicam", "headlight_reinforced", "plating_military" ]
       },
-      {
-        "x": -3,
-        "y": 0,
-        "parts": [ "frame_carbon_cover", "plating_military", "hover_repulsor" ]
-      },
+      { "x": -3, "y": 0, "parts": [ "frame_carbon_cover", "plating_military", "hover_repulsor" ] },
       {
         "x": -2,
         "y": 0,
         "parts": [ "frame_carbon_cover", "hdboard_horizontal", "engine_electric_super", "plating_military" ]
       },
-      {
-        "x": -1,
-        "y": 0,
-        "parts": [ "frame_carbon_cover", "trunk", "recharge_station", "hdroof", "NBC_seal" ]
-      },
+      { "x": -1, "y": 0, "parts": [ "frame_carbon_cover", "trunk", "recharge_station", "hdroof", "NBC_seal" ] },
       {
         "x": 0,
         "y": 0,
-        "parts": [ "frame_carbon_cover", "seat", "seatbelt_heavyduty", "drive_by_wire_controls", "dashboard", "vehicle_clock", "cam_control", "horn_big", "turret_mount", "hdroof", "NBC_seal", { "part": "mounted_tank_auto", "ammo": 50, "ammo_types": [ "120mm_usable_heat" ], "ammo_qty": [ 0, 5 ] }, "controls_turret" ]
+        "parts": [
+          "frame_carbon_cover",
+          "seat",
+          "seatbelt_heavyduty",
+          "drive_by_wire_controls",
+          "dashboard",
+          "vehicle_clock",
+          "cam_control",
+          "horn_big",
+          "turret_mount",
+          "hdroof",
+          "NBC_seal",
+          { "part": "mounted_tank_auto", "ammo": 50, "ammo_types": [ "120mm_usable_heat" ], "ammo_qty": [ 0, 5 ] },
+          "controls_turret"
+        ]
       },
       {
         "x": 1,
@@ -2354,43 +2332,26 @@
       {
         "x": 1,
         "y": 1,
-        "parts": [ "frame_carbon_cover", "hdboard_ne", "turret_mount", "plating_military", { "part": "laser_rifle", "ammo": 50, "ammo_qty": [ 0, 0 ] }, "controls_turret" ]
+        "parts": [
+          "frame_carbon_cover",
+          "hdboard_ne",
+          "turret_mount",
+          "plating_military",
+          { "part": "laser_rifle", "ammo": 50, "ammo_qty": [ 0, 0 ] },
+          "controls_turret"
+        ]
       },
       {
         "x": 2,
         "y": 1,
         "parts": [ "frame_carbon_cover", "hdhalfboard_horizontal_2", "omnicam", "headlight_reinforced", "plating_military" ]
       },
-      {
-        "x": -3,
-        "y": 2,
-        "parts": [ "frame_carbon_cover", "plating_military", "hdhalfboard_se" ]
-      },
-      {
-        "x": -2,
-        "y": 2,
-        "parts": [ "frame_carbon_cover", "plating_military", "hdhalfboard_vertical" ]
-      },
-      {
-        "x": -1,
-        "y": 2,
-        "parts": [ "frame_carbon_cover", "plating_military", "hdhalfboard_vertical" ]
-      },
-      {
-        "x": 0,
-        "y": 2,
-        "parts": [ "frame_carbon_cover", "plating_military", "hover_repulsor" ]
-      },
-      {
-        "x": 1,
-        "y": 2,
-        "parts": [ "frame_carbon_cover", "plating_military", "hdhalfboard_vertical" ]
-      },
-      {
-        "x": 2,
-        "y": 2,
-        "parts": [ "frame_carbon_cover", "plating_military", "hdhalfboard_ne" ]
-      }
+      { "x": -3, "y": 2, "parts": [ "frame_carbon_cover", "plating_military", "hdhalfboard_se" ] },
+      { "x": -2, "y": 2, "parts": [ "frame_carbon_cover", "plating_military", "hdhalfboard_vertical" ] },
+      { "x": -1, "y": 2, "parts": [ "frame_carbon_cover", "plating_military", "hdhalfboard_vertical" ] },
+      { "x": 0, "y": 2, "parts": [ "frame_carbon_cover", "plating_military", "hover_repulsor" ] },
+      { "x": 1, "y": 2, "parts": [ "frame_carbon_cover", "plating_military", "hdhalfboard_vertical" ] },
+      { "x": 2, "y": 2, "parts": [ "frame_carbon_cover", "plating_military", "hdhalfboard_ne" ] }
     ],
     "items": [
       { "x": -1, "y": -1, "chance": 100, "item_groups": [ "m1_abrams_ammo_rack" ] },
@@ -2415,111 +2376,86 @@
     "type": "vehicle",
     "name": "Experimental Hover APC",
     "parts": [
-      {
-        "x": 5,
-        "y": 2,
-        "parts": [ "frame_carbon_cover", "hdhalfboard_ne", "plating_military" ]
-      },
+      { "x": 5, "y": 2, "parts": [ "frame_carbon_cover", "hdhalfboard_ne", "plating_military" ] },
       {
         "x": 5,
         "y": 1,
         "parts": [ "frame_carbon_cover", "hdhalfboard_horizontal", "plating_military", "headlight_reinforced" ]
       },
-      {
-        "x": 5,
-        "y": 0,
-        "parts": [ "frame_carbon_cover", "hdhalfboard_horizontal", "plating_military", "horn_big" ]
-      },
+      { "x": 5, "y": 0, "parts": [ "frame_carbon_cover", "hdhalfboard_horizontal", "plating_military", "horn_big" ] },
       {
         "x": 5,
         "y": -1,
         "parts": [ "frame_carbon_cover", "hdhalfboard_horizontal", "plating_military", "headlight_reinforced" ]
       },
-      {
-        "x": 5,
-        "y": -2,
-        "parts": [ "frame_carbon_cover", "hdhalfboard_nw", "plating_military" ]
-      },
-      {
-        "x": 4,
-        "y": 2,
-        "parts": [ "frame_carbon_cover", "hdboard_ne", "plating_military", "omnicam" ]
-      },
-      {
-        "x": 4,
-        "y": 1,
-        "parts": [ "frame_carbon_cover", "hdboard_horizontal", "plating_military" ]
-      },
-      {
-        "x": 4,
-        "y": 0,
-        "parts": [ "frame_carbon_cover", "plating_military", "hdboard_horizontal" ]
-      },
+      { "x": 5, "y": -2, "parts": [ "frame_carbon_cover", "hdhalfboard_nw", "plating_military" ] },
+      { "x": 4, "y": 2, "parts": [ "frame_carbon_cover", "hdboard_ne", "plating_military", "omnicam" ] },
+      { "x": 4, "y": 1, "parts": [ "frame_carbon_cover", "hdboard_horizontal", "plating_military" ] },
+      { "x": 4, "y": 0, "parts": [ "frame_carbon_cover", "plating_military", "hdboard_horizontal" ] },
       {
         "x": 4,
         "y": -1,
         "parts": [ "frame_carbon_cover", "plating_military", "reinforced_windshield", "v_hdshutter" ]
       },
-      {
-        "x": 4,
-        "y": -2,
-        "parts": [ "frame_carbon_cover", "hdboard_nw", "plating_military", "omnicam" ]
-      },
-      {
-        "x": 3,
-        "y": 2,
-        "parts": [ "frame_carbon_cover", "hdboard_vertical", "plating_military" ]
-      },
+      { "x": 4, "y": -2, "parts": [ "frame_carbon_cover", "hdboard_nw", "plating_military", "omnicam" ] },
+      { "x": 3, "y": 2, "parts": [ "frame_carbon_cover", "hdboard_vertical", "plating_military" ] },
       {
         "x": 3,
         "y": 1,
-        "parts": [ "frame_carbon_cover", "hdroof", "NBC_seal", "plating_military", "cam_control", "turret_mount", "turret_autoloader", "seat", "seatbelt_heavyduty", { "part": "mounted_plasma_gun", "ammo": 50, "ammo_types": [ "plasma" ], "ammo_qty": [ 0, 25 ] }, "controls_turret" ]
+        "parts": [
+          "frame_carbon_cover",
+          "hdroof",
+          "NBC_seal",
+          "plating_military",
+          "cam_control",
+          "turret_mount",
+          "turret_autoloader",
+          "seat",
+          "seatbelt_heavyduty",
+          { "part": "mounted_plasma_gun", "ammo": 50, "ammo_types": [ "plasma" ], "ammo_qty": [ 0, 25 ] },
+          "controls_turret"
+        ]
       },
       {
         "x": 3,
         "y": 0,
-        "parts": [ "frame_carbon_cover", "hdroof", "NBC_seal", "plating_military", "engine_electric_super", "storage_battery", "cargo_space_carbon", "recharge_station" ]
+        "parts": [
+          "frame_carbon_cover",
+          "hdroof",
+          "NBC_seal",
+          "plating_military",
+          "engine_electric_super",
+          "storage_battery",
+          "cargo_space_carbon",
+          "recharge_station"
+        ]
       },
       {
         "x": 3,
         "y": -1,
-        "parts": [ "frame_carbon_cover", "hdroof", "NBC_seal", "controls", "dashboard", "cam_control", "vehicle_clock", "seat", "seatbelt_heavyduty" ]
+        "parts": [
+          "frame_carbon_cover",
+          "hdroof",
+          "NBC_seal",
+          "controls",
+          "dashboard",
+          "cam_control",
+          "vehicle_clock",
+          "seat",
+          "seatbelt_heavyduty"
+        ]
       },
-      {
-        "x": 3,
-        "y": -2,
-        "parts": [ "frame_carbon_cover", "hdboard_vertical", "plating_military" ]
-      },
-      {
-        "x": 2,
-        "y": 2,
-        "parts": [ "frame_carbon_cover", "hdboard_vertical", "plating_military" ]
-      },
-      {
-        "x": 2,
-        "y": 1,
-        "parts": [ "frame_carbon_cover", "seat", "hdroof", "NBC_seal", "reinforced_solar_panel" ]
-      },
+      { "x": 3, "y": -2, "parts": [ "frame_carbon_cover", "hdboard_vertical", "plating_military" ] },
+      { "x": 2, "y": 2, "parts": [ "frame_carbon_cover", "hdboard_vertical", "plating_military" ] },
+      { "x": 2, "y": 1, "parts": [ "frame_carbon_cover", "seat", "hdroof", "NBC_seal", "reinforced_solar_panel" ] },
       {
         "x": 2,
         "y": 0,
         "parts": [ "frame_carbon_cover", "aisle_horizontal", "hdroof", "NBC_seal", "storage_battery", "reinforced_solar_panel" ]
       },
-      {
-        "x": 2,
-        "y": -1,
-        "parts": [ "frame_carbon_cover", "seat", "hdroof", "NBC_seal", "reinforced_solar_panel" ]
-      },
-      {
-        "x": 2,
-        "y": -2,
-        "parts": [ "frame_carbon_cover", "hdboard_vertical", "plating_military" ]
-      },
-      {
-        "x": 1,
-        "y": 2,
-        "parts": [ "frame_carbon_cover", "hdboard_vertical", "plating_military" ]
-      },
+      { "x": 2, "y": -1, "parts": [ "frame_carbon_cover", "seat", "hdroof", "NBC_seal", "reinforced_solar_panel" ] },
+      { "x": 2, "y": -2, "parts": [ "frame_carbon_cover", "hdboard_vertical", "plating_military" ] },
+      { "x": 1, "y": 2, "parts": [ "frame_carbon_cover", "hdboard_vertical", "plating_military" ] },
       {
         "x": 1,
         "y": 1,
@@ -2535,88 +2471,28 @@
         "y": -1,
         "parts": [ "frame_carbon_cover", "hdroof", "NBC_seal", "aisle_vertical", "reinforced_solar_panel" ]
       },
-      {
-        "x": 1,
-        "y": -2,
-        "parts": [ "frame_carbon_cover", "hdboard_vertical", "plating_military" ]
-      },
-      {
-        "x": 0,
-        "y": 2,
-        "parts": [ "frame_carbon_cover", "hdboard_vertical", "plating_military" ]
-      },
-      {
-        "x": 0,
-        "y": 1,
-        "parts": [ "frame_carbon_cover", "seat", "hdroof", "NBC_seal", "reinforced_solar_panel" ]
-      },
+      { "x": 1, "y": -2, "parts": [ "frame_carbon_cover", "hdboard_vertical", "plating_military" ] },
+      { "x": 0, "y": 2, "parts": [ "frame_carbon_cover", "hdboard_vertical", "plating_military" ] },
+      { "x": 0, "y": 1, "parts": [ "frame_carbon_cover", "seat", "hdroof", "NBC_seal", "reinforced_solar_panel" ] },
       {
         "x": 0,
         "y": 0,
         "parts": [ "frame_carbon_cover", "hdroof", "NBC_seal", "aisle_vertical", "reinforced_solar_panel" ]
       },
-      {
-        "x": 0,
-        "y": -1,
-        "parts": [ "frame_carbon_cover", "seat", "hdroof", "NBC_seal", "reinforced_solar_panel" ]
-      },
-      {
-        "x": 0,
-        "y": -2,
-        "parts": [ "frame_carbon_cover", "hdboard_vertical", "plating_military" ]
-      },
-      {
-        "x": -1,
-        "y": 2,
-        "parts": [ "frame_carbon_cover", "hdboard_vertical", "plating_military" ]
-      },
-      {
-        "x": -1,
-        "y": 1,
-        "parts": [ "frame_carbon_cover", "hdroof", "NBC_seal", "seat" ]
-      },
-      {
-        "x": -1,
-        "y": 0,
-        "parts": [ "frame_carbon_cover", "aisle_horizontal", "hdroof", "NBC_seal" ]
-      },
-      {
-        "x": -1,
-        "y": -1,
-        "parts": [ "frame_carbon_cover", "hdroof", "NBC_seal", "seat" ]
-      },
-      {
-        "x": -1,
-        "y": -2,
-        "parts": [ "frame_carbon_cover", "hdboard_vertical", "plating_military" ]
-      },
-      {
-        "x": -2,
-        "y": 2,
-        "parts": [ "frame_carbon_cover", "hdboard_se", "muffler", "plating_military", "omnicam" ]
-      },
-      {
-        "x": -2,
-        "y": 1,
-        "parts": [ "frame_carbon_cover", "hdboard_horizontal", "plating_military" ]
-      },
-      {
-        "x": -2,
-        "y": 0,
-        "parts": [ "frame_carbon_cover", "hddoor_opaque", "plating_military" ]
-      },
-      {
-        "x": -2,
-        "y": -1,
-        "parts": [ "frame_carbon_cover", "hdboard_horizontal", "plating_military" ]
-      },
-      {
-        "x": -2,
-        "y": -2,
-        "parts": [ "frame_carbon_cover", "hdboard_sw", "muffler", "plating_military", "omnicam" ]
-      }
+      { "x": 0, "y": -1, "parts": [ "frame_carbon_cover", "seat", "hdroof", "NBC_seal", "reinforced_solar_panel" ] },
+      { "x": 0, "y": -2, "parts": [ "frame_carbon_cover", "hdboard_vertical", "plating_military" ] },
+      { "x": -1, "y": 2, "parts": [ "frame_carbon_cover", "hdboard_vertical", "plating_military" ] },
+      { "x": -1, "y": 1, "parts": [ "frame_carbon_cover", "hdroof", "NBC_seal", "seat" ] },
+      { "x": -1, "y": 0, "parts": [ "frame_carbon_cover", "aisle_horizontal", "hdroof", "NBC_seal" ] },
+      { "x": -1, "y": -1, "parts": [ "frame_carbon_cover", "hdroof", "NBC_seal", "seat" ] },
+      { "x": -1, "y": -2, "parts": [ "frame_carbon_cover", "hdboard_vertical", "plating_military" ] },
+      { "x": -2, "y": 2, "parts": [ "frame_carbon_cover", "hdboard_se", "muffler", "plating_military", "omnicam" ] },
+      { "x": -2, "y": 1, "parts": [ "frame_carbon_cover", "hdboard_horizontal", "plating_military" ] },
+      { "x": -2, "y": 0, "parts": [ "frame_carbon_cover", "hddoor_opaque", "plating_military" ] },
+      { "x": -2, "y": -1, "parts": [ "frame_carbon_cover", "hdboard_horizontal", "plating_military" ] },
+      { "x": -2, "y": -2, "parts": [ "frame_carbon_cover", "hdboard_sw", "muffler", "plating_military", "omnicam" ] }
     ],
-	"items": [
+    "items": [
       { "x": 3, "y": -1, "chance": 2, "items": [ "id_military" ] },
       { "x": 3, "y": -1, "chance": 3, "items": [ "mil_gps_device" ] },
       { "x": 3, "y": -1, "chance": 20, "item_groups": [ "tools_survival" ] },

--- a/data/json/vehicles/military.json
+++ b/data/json/vehicles/military.json
@@ -2230,5 +2230,184 @@
       { "x": -1, "y": 1, "chance": 25, "items": [ "belt50" ] },
       { "x": -1, "y": 1, "chance": 25, "items": [ "belt50" ] }
     ]
+  },
+  {
+    "id": "tank_xm_hover",
+    "type": "vehicle",
+    "name": "XMH Hover Tank",
+    "parts": [
+      {
+        "x": -3,
+        "y": -2,
+        "parts": [ "frame_carbon_cover", "plating_military", "hdhalfboard_sw" ]
+      },
+      {
+        "x": -2,
+        "y": -2,
+        "parts": [ "frame_carbon_cover", "plating_military", "hdhalfboard_vertical" ]
+      },
+      {
+        "x": -1,
+        "y": -2,
+        "parts": [ "frame_carbon_cover", "plating_military", "hdhalfboard_vertical" ]
+      },
+      {
+        "x": 0,
+        "y": -2,
+        "parts": [ "frame_carbon_cover", "plating_military", "hover_repulsor" ]
+      },
+      {
+        "x": 1,
+        "y": -2,
+        "parts": [ "frame_carbon_cover", "plating_military", "hdhalfboard_vertical" ]
+      },
+      {
+        "x": 2,
+        "y": -2,
+        "parts": [ "frame_carbon_cover", "plating_military", "hdhalfboard_nw" ]
+      },
+      {
+        "x": -3,
+        "y": -1,
+        "parts": [ "frame_carbon_cover", "omnicam", "plating_military", "hdhalfboard_horizontal_2" ]
+      },
+      {
+        "x": -2,
+        "y": -1,
+        "parts": [ "frame_carbon_cover", "hdboard_sw", "storage_battery", "plating_military", "reinforced_solar_panel" ]
+      },
+      {
+        "x": -1,
+        "y": -1,
+        "parts": [ "frame_carbon_cover", "hdstowboard_vertical", "plating_military", "reinforced_solar_panel" ]
+      },
+      {
+        "x": 0,
+        "y": -1,
+        "parts": [ "frame_carbon_cover", "hdhatch_opaque", "hdroof", "NBC_seal", "plating_military" ]
+      },
+      {
+        "x": 1,
+        "y": -1,
+        "parts": [ "frame_carbon_cover", "hdboard_nw", "plating_military" ]
+      },
+      {
+        "x": 2,
+        "y": -1,
+        "parts": [ "frame_carbon_cover", "hdhalfboard_horizontal_2", "omnicam", "headlight_reinforced", "plating_military" ]
+      },
+      {
+        "x": -3,
+        "y": 0,
+        "parts": [ "frame_carbon_cover", "plating_military", "hover_repulsor" ]
+      },
+      {
+        "x": -2,
+        "y": 0,
+        "parts": [ "frame_carbon_cover", "hdboard_horizontal", "engine_electric_super", "plating_military" ]
+      },
+      {
+        "x": -1,
+        "y": 0,
+        "parts": [ "frame_carbon_cover", "trunk", "recharge_station", "hdroof", "NBC_seal" ]
+      },
+      {
+        "x": 0,
+        "y": 0,
+        "parts": [ "frame_carbon_cover", "seat", "seatbelt_heavyduty", "drive_by_wire_controls", "dashboard", "vehicle_clock", "cam_control", "horn_big", "turret_mount", "hdroof", "NBC_seal", { "part": "mounted_tank_auto", "ammo": 50, "ammo_types": [ "120mm_usable_heat" ], "ammo_qty": [ 0, 5 ] }, "controls_turret" ]
+      },
+      {
+        "x": 1,
+        "y": 0,
+        "parts": [ "frame_carbon_cover", "hdhalfboard_vertical", "hdroof", "NBC_seal", "plating_military" ]
+      },
+      {
+        "x": 2,
+        "y": 0,
+        "parts": [ "frame_carbon_cover", "hdhalfboard_vertical", "hdroof", "NBC_seal", "plating_military" ]
+      },
+      {
+        "x": 3,
+        "y": 0,
+        "parts": [ "frame_carbon_cover", "hdhalfboard_vertical", "hdroof", "NBC_seal", "plating_military" ]
+      },
+      {
+        "x": -3,
+        "y": 1,
+        "parts": [ "frame_carbon_cover", "omnicam", "plating_military", "hdhalfboard_horizontal_2" ]
+      },
+      {
+        "x": -2,
+        "y": 1,
+        "parts": [ "frame_carbon_cover", "hdboard_se", "storage_battery", "plating_military", "reinforced_solar_panel" ]
+      },
+      {
+        "x": -1,
+        "y": 1,
+        "parts": [ "frame_carbon_cover", "hdstowboard_vertical", "plating_military", "reinforced_solar_panel" ]
+      },
+      {
+        "x": 0,
+        "y": 1,
+        "parts": [ "frame_carbon_cover", "hdboard_vertical", "hdroof", "NBC_seal", "plating_military" ]
+      },
+      {
+        "x": 1,
+        "y": 1,
+        "parts": [ "frame_carbon_cover", "hdboard_ne", "turret_mount", "plating_military", { "part": "laser_rifle", "ammo": 50, "ammo_qty": [ 0, 0 ] }, "controls_turret" ]
+      },
+      {
+        "x": 2,
+        "y": 1,
+        "parts": [ "frame_carbon_cover", "hdhalfboard_horizontal_2", "omnicam", "headlight_reinforced", "plating_military" ]
+      },
+      {
+        "x": -3,
+        "y": 2,
+        "parts": [ "frame_carbon_cover", "plating_military", "hdhalfboard_se" ]
+      },
+      {
+        "x": -2,
+        "y": 2,
+        "parts": [ "frame_carbon_cover", "plating_military", "hdhalfboard_vertical" ]
+      },
+      {
+        "x": -1,
+        "y": 2,
+        "parts": [ "frame_carbon_cover", "plating_military", "hdhalfboard_vertical" ]
+      },
+      {
+        "x": 0,
+        "y": 2,
+        "parts": [ "frame_carbon_cover", "plating_military", "hover_repulsor" ]
+      },
+      {
+        "x": 1,
+        "y": 2,
+        "parts": [ "frame_carbon_cover", "plating_military", "hdhalfboard_vertical" ]
+      },
+      {
+        "x": 2,
+        "y": 2,
+        "parts": [ "frame_carbon_cover", "plating_military", "hdhalfboard_ne" ]
+      }
+    ],
+    "items": [
+      { "x": -1, "y": -1, "chance": 100, "item_groups": [ "m1_abrams_ammo_rack" ] },
+      { "x": -1, "y": -1, "chance": 50, "items": [ "120mm_usable_heat" ] },
+      { "x": -1, "y": -1, "chance": 50, "items": [ "120mm_usable_ap" ] },
+      { "x": -1, "y": 0, "chance": 100, "item_groups": [ "m1_abrams_ammo_rack" ] },
+      { "x": 0, "y": 0, "chance": 25, "items": [ "ear_plugs" ] },
+      { "x": 0, "y": 0, "chance": 10, "items": [ "120mm_usable_heat" ] },
+      { "x": 0, "y": 0, "chance": 25, "items": [ "belt50" ] },
+      { "x": 0, "y": 0, "chance": 2, "items": [ "id_military" ] },
+      { "x": -1, "y": 1, "chance": 50, "item_groups": [ "tools_survival" ] },
+      { "x": -1, "y": 1, "chance": 50, "item_groups": [ "infantry_common_gear" ] },
+      { "x": -1, "y": 1, "chance": 30, "item_groups": [ "ammo_milspec" ] },
+      { "x": -1, "y": 1, "chance": 20, "item_groups": [ "mags_milspec" ] },
+      { "x": -1, "y": 1, "chance": 10, "item_groups": [ "guns_milspec" ] },
+      { "x": -1, "y": 1, "chance": 25, "items": [ "belt50" ] },
+      { "x": -1, "y": 1, "chance": 25, "items": [ "belt50" ] }
+    ]
   }
 ]


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
hover repulsors were just added (#8485), and nothing uses them yet. Also, the hover repulsor description mentions a nonexistent hoverbike.
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
adds two rare hover vehicles, a tank and apc, which use carbon fiber frames, super electric motors, and have reinforced solar panels. the tank has 3 repulsors, and the apc has 1. They also feature high-tech energy weapons. Updates the hover repulsor description to remove mentions of hoverbikes. Also fixes small bug with new beagle sprite, the xm minitank should use the correct broken sprite now.
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
not adding them

## Testing
spawned both vehicles in debug
works as expected

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context
I did my best to make the hover repulsors highly visible. This is probably not "realistic" to how a military vehicle would put hypothetical hover parts, but I wanted to make it obvious these were hover vehicles.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
