### PR TITLE
fix: sight OoB guard

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -7274,7 +7274,8 @@ bool map::sees( const tripoint &F, const tripoint &T, const int range,
                 int &bresenham_slope ) const
 {
     if( ( range >= 0 && range < rl_dist( F, T ) ) ||
-        !inbounds( T ) ) {
+        !inbounds( T ) ||
+        !inbounds( F ) ) {
         bresenham_slope = 0;
         return false; // Out of range!
     }


### PR DESCRIPTION
## Purpose of change (The Why)

Resolves a fairly common crash that's likely a large source of our crash logs.

## Describe the solution (The How)

Guards against out of bounds for both sides of the sight check.

## Testing

I never replicated the crash. This just guards.