### PR TITLE
fix: is_simulated check usage

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -2541,5 +2541,10 @@ effects_map Creature::get_all_effects() const
 
 bool Creature::is_loaded() const
 {
-    return get_map().inbounds( pos() );
+    return get_map().get_submap_at( pos() ) != nullptr;
+}
+
+bool Creature::is_simulated() const
+{
+    return get_map().is_position_simulated( pos() );
 }

--- a/src/creature.h
+++ b/src/creature.h
@@ -497,6 +497,7 @@ class Creature
         virtual void setpos( const tripoint &pos ) = 0;
 
         bool is_loaded() const;
+        virtual bool is_simulated() const;
 
         /** Processes move stopping effects. Returns false if movement is stopped. */
         virtual bool move_effects( bool attacking ) = 0;

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -1137,6 +1137,8 @@ void debug_write_backtrace( std::ostream &out )
 #endif
 
 #if defined(_WIN32)
+    const std::locale saved_locale = out.getloc();
+    out.imbue( std::locale::classic() );
     std::lock_guard<std::mutex> dbghelp_lock( g_dbghelp_mutex );
     std::call_once( sym_init_once_, []() {
         sym_init_ = std::make_unique<sym_init>();
@@ -1333,6 +1335,7 @@ void debug_write_backtrace( std::ostream &out )
     }
 #endif
     out << "\n";
+    out.imbue( saved_locale );
 #else
 #   if defined(LIBBACKTRACE)
     auto bt_error = [&out]( const char *err_msg, int errnum ) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5019,7 +5019,8 @@ void game::monmove()
             !critter.has_effect( effect_ai_controlled ) &&
             critter.moves > 0 &&
             !critter.has_effect( effect_ridden ) &&
-            critter.lod_tier < 2 ) {
+            critter.lod_tier < 2 &&
+            critter.is_simulated() ) {
             // Tier-2 monsters skip full planning; they use the macro step.
             plannable.push_back( &critter );
         }
@@ -5130,6 +5131,13 @@ void game::monmove()
     // all monsters.  The budget/tier system gates only the move loop below.
     // -----------------------------------------------------------------------
     for( monster &critter : all_monsters() ) {
+        // Skip monsters in lazy-border or otherwise non-simulated submaps — their
+        // submap has no active caches (transparency, lightmap, fields) and
+        // processing them would read stale or missing data.  They will be
+        // despawned into the overmap monster_map when their submap evicts.
+        if( !critter.is_simulated() ) {
+            continue;
+        }
         // Critters in impassable tiles get pushed away, unless it's not impassable for them
         if( !critter.is_dead() && m.impassable( critter.pos() ) && !critter.can_move_to( critter.pos() ) ) {
             std::string msg = string_format( "%s can't move to its location!  %s  %s", critter.name(),
@@ -5192,7 +5200,8 @@ void game::monmove()
         if( !critter.is_dead() &&
             !critter.has_effect( effect_ridden ) &&
             critter.moves > 0 &&
-            critter.next_turn <= current_turn ) {
+            critter.next_turn <= current_turn &&
+            critter.is_simulated() ) {
             eligible.emplace_back( rl_dist( critter.pos(), player_pos ), &critter );
         }
     }
@@ -14084,12 +14093,13 @@ void game::shift_monsters( const tripoint &shift )
             critter.shift( shift.xy() );
         }
 
-        if( m.inbounds( critter.pos() ) && ( shift.z == 0 || m.has_zlevels() )
+        if( ( shift.z == 0 || m.has_zlevels() )
             && m.get_submap_at( critter.pos() ) != nullptr ) {
-            // We're inbounds on a loaded submap, so don't despawn after all.
-            // No need to shift Z-coordinates, they are absolute.
-            // Corner slots within the grid bounds have null submaps (outside the circular
-            // load footprint); treat them like out-of-bounds — save and despawn.
+            // The critter is on a loaded submap — keep it regardless of whether
+            // it's inside the render-area grid (inbounds).  Creatures can validly
+            // reside in loaded-but-OOB submaps (e.g. knocked into a lazy-border
+            // zone) and should not be despawned just because they are outside
+            // the render area.
             continue;
         }
         // Either a vertical shift, the critter is outside the reality bubble, or it

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -9218,6 +9218,16 @@ bool map::inbounds( const tripoint &p ) const
     return map_boundaries.contains( p );
 }
 
+bool map::is_position_simulated( const tripoint &p ) const
+{
+    const tripoint_abs_sm abs_sm(
+        abs_sub.x + divide_round_to_minus_infinity( p.x, SEEX ),
+        abs_sub.y + divide_round_to_minus_infinity( p.y, SEEY ),
+        p.z
+    );
+    return submap_loader.is_simulated( bound_dimension_, abs_sm );
+}
+
 bool tinymap::inbounds( const tripoint &p ) const
 {
     constexpr tripoint map_boundary_min( 0, 0, -OVERMAP_DEPTH );

--- a/src/map.h
+++ b/src/map.h
@@ -505,6 +505,15 @@ class map : public submap_load_listener
         }
 
         /**
+         * Return true if the submap containing local position @p p is actively
+         * simulated (i.e. covered by a non-lazy_border load request).
+         * Use this instead of inbounds() when the question is "should gameplay
+         * logic process this position?" rather than "is this position in the
+         * render-area cache?".
+         */
+        bool is_position_simulated( const tripoint &p ) const;
+
+        /**
          * Bind this map to a specific dimension.
          * Should be called when the player transitions to another dimension.
          */

--- a/src/npc.h
+++ b/src/npc.h
@@ -962,7 +962,7 @@ class npc : public player
         * True if this NPC is in a simulated submap — i.e. loaded and eligible
         * for per-turn AI processing.  Mirrors the check used in npcmove().
         */
-        bool is_simulated() const;
+        bool is_simulated() const override;
         bool is_manually_erased() const {
             return manually_erased_;
         }

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -8081,7 +8081,7 @@ bool vehicle_part_with_feature_range<vpart_bitflags>::matches( const size_t part
 
 bool vehicle::is_loaded() const
 {
-    return attached && get_map().inbounds( global_pos3() );
+    return attached && get_map().get_submap_at( global_pos3() ) != nullptr;
 }
 
 void vehicle::refresh_locations_hack()


### PR DESCRIPTION
## Purpose of change (The Why)

Many functions checked inbounds instead of is_simulated even when that didn't make sense. Another blocker for stuff happening outside the reality bubble.

## Describe the solution (The How)

Use the correct function for the context

## Testing

Run around triggering submap shifts
Stuff seems to work
Am tired, so perhaps a tester will consider something else this might break.