### PR TITLE
feat: add `MUTATE_THRESH` spell flag for mutation spells

### DIFF
--- a/docs/en/mod/json/reference/creatures/magic.md
+++ b/docs/en/mod/json/reference/creatures/magic.md
@@ -135,6 +135,9 @@ experience you need to get to a level is below:
 
 - `RANDOM_TARGET` - picks a random valid target within your range instead of normal behavior.
 
+- `MUTATE_THRESH` - mutate spell_effect will check for if it can grant the victim that the associated
+  threshold, does nothing if `MUTATE_TRAIT` is also present and requires a category to be specified
+
 - `MUTATE_TRAIT` - overrides the mutate spell_effect to use a specific trait_id instead of a
   category
 

--- a/docs/en/mod/json/reference/creatures/magic.md
+++ b/docs/en/mod/json/reference/creatures/magic.md
@@ -136,7 +136,9 @@ experience you need to get to a level is below:
 - `RANDOM_TARGET` - picks a random valid target within your range instead of normal behavior.
 
 - `MUTATE_THRESH` - mutate spell_effect will check for if it can grant the victim that the associated
-  threshold, does nothing if `MUTATE_TRAIT` is also present and requires a category to be specified
+  threshold, does nothing if `MUTATE_TRAIT` is also present and requires a category to be specified. If
+  accuracy is defined, this will determine how many tiers of that category's thresholds it will try to
+  cross, with a default of tier 1.
 
 - `MUTATE_TRAIT` - overrides the mutate spell_effect to use a specific trait_id instead of a
   category

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -101,6 +101,7 @@ std::string enum_to_string<spell_flag>( spell_flag data )
         case spell_flag::DIVIDE_DAMAGE: return "DIVIDE_DAMAGE";
         case spell_flag::RANDOM_DURATION: return "RANDOM_DURATION";
         case spell_flag::RANDOM_TARGET: return "RANDOM_TARGET";
+        case spell_flag::MUTATE_THRESH: return "MUTATE_THRESH";
         case spell_flag::MUTATE_TRAIT: return "MUTATE_TRAIT";
         case spell_flag::PAIN_NORESIST: return "PAIN_NORESIST";
         case spell_flag::NO_FAIL: return "NO_FAIL";

--- a/src/magic.h
+++ b/src/magic.h
@@ -54,7 +54,7 @@ enum spell_flag {
     DIVIDE_DAMAGE, // divides damage equally among all the targets of the spell
     RANDOM_DURATION, // picks random number between min+increment*level and max instead of normal behavior
     RANDOM_TARGET, // picks a random valid target within your range instead of normal behavior.
-    MUTATE_THRESH, // allows mutate spell_effect to try and cross thresholds for the category provided
+    MUTATE_THRESH, // allows mutate spell_effect to try and cross thresholds for the category provided, accuracy optionally defines highest tier of threshold to test for (default of 1).
     MUTATE_TRAIT, // overrides the mutate spell_effect to use a specific trait_id instead of a category
     WONDER, // instead of casting each of the extra_spells, it picks N of them and casts them (where N is std::min( damage(), number_of_spells ))
     PAIN_NORESIST, // pain altering spells can't be resisted (like with the deadened trait)

--- a/src/magic.h
+++ b/src/magic.h
@@ -54,6 +54,7 @@ enum spell_flag {
     DIVIDE_DAMAGE, // divides damage equally among all the targets of the spell
     RANDOM_DURATION, // picks random number between min+increment*level and max instead of normal behavior
     RANDOM_TARGET, // picks a random valid target within your range instead of normal behavior.
+    MUTATE_THRESH, // allows mutate spell_effect to try and cross thresholds for the category provided
     MUTATE_TRAIT, // overrides the mutate spell_effect to use a specific trait_id instead of a category
     WONDER, // instead of casting each of the extra_spells, it picks N of them and casts them (where N is std::min( damage(), number_of_spells ))
     PAIN_NORESIST, // pain altering spells can't be resisted (like with the deadened trait)

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -1246,7 +1246,7 @@ void spell_effect::mutate( const spell &sp, Creature &caster, const tripoint &ta
                 guy->mutate_category( mutation_category_id( sp.effect_data() ) );
                 if( sp.has_flag( spell_flag::MUTATE_THRESH ) ) {
                     test_crossing_threshold( guy, mutation_category_trait::get_category(
-                    mutation_category_id( sp.effect_data() ) ), 1 );
+                                                 mutation_category_id( sp.effect_data() ) ), 1 );
                 }
             }
         }

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -1244,6 +1244,11 @@ void spell_effect::mutate( const spell &sp, Creature &caster, const tripoint &ta
             if( sp.has_flag( spell_flag::MUTATE_TRAIT ) ) {
                 guy->mutate_towards( trait_id( sp.effect_data() ) );
             } else {
+                // As with serum, test threshold both before and after granting mutation.
+                if( sp.has_flag( spell_flag::MUTATE_THRESH ) ) {
+                    test_crossing_threshold( *guy, mutation_category_trait::get_category(
+                                                 mutation_category_id( sp.effect_data() ) ), 1 );
+                }
                 guy->mutate_category( mutation_category_id( sp.effect_data() ) );
                 if( sp.has_flag( spell_flag::MUTATE_THRESH ) ) {
                     test_crossing_threshold( *guy, mutation_category_trait::get_category(

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -1246,7 +1246,7 @@ void spell_effect::mutate( const spell &sp, Creature &caster, const tripoint &ta
             } else {
                 guy->mutate_category( mutation_category_id( sp.effect_data() ) );
                 if( sp.has_flag( spell_flag::MUTATE_THRESH ) ) {
-                    test_crossing_threshold( guy, mutation_category_trait::get_category(
+                    test_crossing_threshold( *guy, mutation_category_trait::get_category(
                                                  mutation_category_id( sp.effect_data() ) ), 1 );
                 }
             }

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -1247,12 +1247,12 @@ void spell_effect::mutate( const spell &sp, Creature &caster, const tripoint &ta
                 // As with serum, test threshold both before and after granting mutation.
                 if( sp.has_flag( spell_flag::MUTATE_THRESH ) ) {
                     test_crossing_threshold( *guy, mutation_category_trait::get_category(
-                                                 mutation_category_id( sp.effect_data() ) ), 1 );
+                                                 mutation_category_id( sp.effect_data() ) ), std::max ( sp.accuracy(), 1 ) );
                 }
                 guy->mutate_category( mutation_category_id( sp.effect_data() ) );
                 if( sp.has_flag( spell_flag::MUTATE_THRESH ) ) {
                     test_crossing_threshold( *guy, mutation_category_trait::get_category(
-                                                 mutation_category_id( sp.effect_data() ) ), 1 );
+                                                 mutation_category_id( sp.effect_data() ) ), std::max ( sp.accuracy(), 1 ) );
                 }
             }
         }

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -41,6 +41,7 @@
 #include "map_iterator.h"
 #include "messages.h"
 #include "monster.h"
+#include "mutation.h"
 #include "overmapbuffer.h"
 #include "player.h"
 #include "point.h"

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -1247,12 +1247,12 @@ void spell_effect::mutate( const spell &sp, Creature &caster, const tripoint &ta
                 // As with serum, test threshold both before and after granting mutation.
                 if( sp.has_flag( spell_flag::MUTATE_THRESH ) ) {
                     test_crossing_threshold( *guy, mutation_category_trait::get_category(
-                                                 mutation_category_id( sp.effect_data() ) ), std::max ( sp.accuracy(), 1 ) );
+                                                 mutation_category_id( sp.effect_data() ) ), std::max( sp.accuracy(), 1 ) );
                 }
                 guy->mutate_category( mutation_category_id( sp.effect_data() ) );
                 if( sp.has_flag( spell_flag::MUTATE_THRESH ) ) {
                     test_crossing_threshold( *guy, mutation_category_trait::get_category(
-                                                 mutation_category_id( sp.effect_data() ) ), std::max ( sp.accuracy(), 1 ) );
+                                                 mutation_category_id( sp.effect_data() ) ), std::max( sp.accuracy(), 1 ) );
                 }
             }
         }

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -1244,6 +1244,10 @@ void spell_effect::mutate( const spell &sp, Creature &caster, const tripoint &ta
                 guy->mutate_towards( trait_id( sp.effect_data() ) );
             } else {
                 guy->mutate_category( mutation_category_id( sp.effect_data() ) );
+                if( sp.has_flag( spell_flag::MUTATE_THRESH ) ) {
+                    test_crossing_threshold( guy, mutation_category_trait::get_category(
+                    mutation_category_id( sp.effect_data() ) ), 1 );
+                }
             }
         }
         if( sp.has_flag( spell_flag::DUPE_SOUND ) || !sound_played ) {


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

A sort of side project to https://github.com/cataclysmbn/Cataclysm-BN/pull/8510 so that mods will have a way to mutate without worrying about point balance if they need it.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

C++ changes:
1. In magic.cpp and magic.h, added definition for `MUTATE_THRESH` spell flag.
2. In magic_spell_effect.cpp, set `spell_effect::mutate` so that, if it's mutating you in a specific category (i.e. `effect` is specified and `MUTATE_TRAIT` is absent), it will test for crossing that category's threshold after it mutates you. This allows for mutation-granting spells to replicate the effects of serums as well regular mutagen. In addition per feedback, it pings threshold tier based on spell accuracy, defaulting to tier-1 since most thresholds have only 1 tier.

Documentation changes:
1. Documented new spell flag in magic.md

## Describe alternatives you've considered

Hacking in support for currently-unimplemented threshold tiers? For now it uses the default tier, dunno how we'd handle that at present. Presumably something like how damage is used for chance of mutation, glom onto some existing spell property when the spell effect is mutation?

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

1. Compiled and load-tested.
2. Started a world with Arcana using the changes in my draft PR implementing them.
3. Spammed restored ritual blade, I can cross the threshold.
4. Restarted and chugged a fuckton of blood effigy, no threshold as expected.
5. Gave myself a sacramental heart after maxing out pre-thresh Dragonblood mutations, aside from a bug we discovered that triggers when savescumming it works fine to grant the thresh.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

<img width="889" height="500" alt="image" src="https://github.com/user-attachments/assets/c21f4515-6b06-4d33-bb3f-7efdc59e356e" />

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
