### PR TITLE
fix: flame vents spawn correct intensity of flame burst

### DIFF
--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -1539,7 +1539,7 @@ auto process_fields_in_submap( submap &sm,
                         // create_hot_air() skipped — render/audio effect only.
                     } else {
                         auto self = SubTile{ &sm, local };
-                        sub_add_field( self, fd_flame_burst, 3, cur.get_field_age() );
+                        sub_add_field( self, fd_flame_burst, 1, cur.get_field_age() );
                         cur.set_field_intensity( 0 );
                     }
                 }


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

Smol easy fix, someone was having crashes in labs caused by a field with an invalid intensity where evidently the code only recently started to give a shit about that.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

In map_field.cpp, set `process_fields_in_submap` so flame vents only create intensity-1 flame bursts instead of intensity 3, a tier that doesn't exist.

## Describe alternatives you've considered

Not bein' so sus with all these vents.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

Used elementary math to confirm that 1 is a smaller number than 3. Can't compile-test since out and about on laptop.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
