### PR TITLE
fix: Add checks against erroneously nonzero thresh tiers in mutation logic

### DIFF
--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -1715,7 +1715,7 @@ void test_crossing_threshold( Character &guy, const mutation_category_trait &m_c
                 break;
             }
         }
-        if (has_thresh) {
+        if( has_thresh ) {
             return;
         } else {
             // The character does not have a threshold mutation but has a tier greater than 0
@@ -1749,7 +1749,7 @@ void test_crossing_threshold( Character &guy, const mutation_category_trait &m_c
                 break;
             }
         }
-        if (has_thresh) {
+        if( has_thresh ) {
             return;
         } else {
             // The character does not have a threshold mutation but has a tier greater than 0

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -1706,7 +1706,23 @@ void test_crossing_threshold( Character &guy, const mutation_category_trait &m_c
 {
     // Can't cross the same tier threshold multiple times
     if( guy.thresh_tier >= tier ) {
-        return;
+        // Check for the incredibly stupid scenario where the player somehow has a tier but not any actual thresholds
+        // Mostly an issue with debug quit and similar scenarios
+        bool has_thresh = false;
+        for( const trait_id &mut : guy.get_mutations() ) {
+            if( mut->threshold ) {
+                has_thresh = true;
+                break;
+            }
+        }
+        if (has_thresh) {
+            return;
+        } else {
+            // The character does not have a threshold mutation but has a tier greater than 0
+            // This must be a bug, reset their threshold information
+            guy.thresh_tier = 0;
+            guy.thresh_category = mutation_category_id::NULL_ID();
+        }
     }
 
     // No skipping tiers
@@ -1724,7 +1740,23 @@ void test_crossing_threshold( Character &guy, const mutation_category_trait &m_c
     mutation_category_id mutation_category = m_category.id;
     // If you've already passed a threshold, you can't get a different tree's threshold
     if( ( guy.thresh_tier > 0 ) && ( guy.thresh_category != mutation_category ) ) {
-        return;
+        // Check for the incredibly stupid scenario where the player somehow has a tier but not any actual thresholds
+        // Mostly an issue with debug quit and similar scenarios
+        bool has_thresh = false;
+        for( const trait_id &mut : guy.get_mutations() ) {
+            if( mut->threshold ) {
+                has_thresh = true;
+                break;
+            }
+        }
+        if (has_thresh) {
+            return;
+        } else {
+            // The character does not have a threshold mutation but has a tier greater than 0
+            // This must be a bug, reset their threshold information
+            guy.thresh_tier = 0;
+            guy.thresh_category = mutation_category_id::NULL_ID();
+        }
     }
 
     int total = 0;


### PR DESCRIPTION
## Purpose of change (The Why)

Chaosvolt ran into a bug where the thresh tier was 1 even though the character never had any threshold mutations due to debug quit not correctly resetting the field.

Safety is good.

## Describe the solution (The How)

Add checks to relevant early returns to make sure the player actually has a threshold mutation in the first place.

## Describe alternatives you've considered

- One big check at the top whenever the tier is greater than 0
- Try to figure out why debug quit doesn't reset it properly

## Testing

It compiles

## Additional context

Very glad this issue was Not My Fault(tm)

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.