### PR TITLE
perf: creature iteration improvements

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -350,6 +350,8 @@ extern bool add_key_to_quick_shortcuts( int key, const std::string &category, bo
 //The one and only game instance
 std::unique_ptr<game> g;
 
+std::atomic<uint32_t> g_npc_friends_dirty_version{ 1 };
+
 //The one and only uistate instance
 uistatedata uistate;
 
@@ -1215,6 +1217,7 @@ void game::load_npcs()
         } else {
             active_npc.push_back( temp );
             just_added.push_back( temp );
+            ++g_npc_friends_dirty_version;
         }
     }
 
@@ -1255,6 +1258,7 @@ void game::load_npcs()
                 } else {
                     active_npc.push_back( temp );
                     just_added.push_back( temp );
+                    ++g_npc_friends_dirty_version;
                 }
             }
         }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -351,6 +351,7 @@ extern bool add_key_to_quick_shortcuts( int key, const std::string &category, bo
 std::unique_ptr<game> g;
 
 std::atomic<uint32_t> g_npc_friends_dirty_version{ 1 };
+uint32_t g_npcmove_attitude_epoch{ 0 };
 
 //The one and only uistate instance
 uistatedata uistate;
@@ -5371,6 +5372,7 @@ void game::npcmove()
     ZoneScoped;
     // Active NPC processing.  Extracted from monmove() so it can be
     // individually controlled by SLEEP_SKIP_NPC without affecting monsters.
+    ++g_npcmove_attitude_epoch;
     processing_npcs_ = true;
     const std::string &player_dim = m.get_bound_dimension();
     for( npc &guy : g->all_npcs() ) {

--- a/src/game.h
+++ b/src/game.h
@@ -66,6 +66,9 @@ extern int savegame_loading_version;
 // Monotonically increasing counter; bumped whenever NPC faction membership or active NPC list
 // changes so each NPC can lazily invalidate its cached friends list.
 extern std::atomic<uint32_t> g_npc_friends_dirty_version;
+// Bumped once per npcmove() pass; monsters use it to know when their cached generic-NPC
+// attitude is stale.
+extern uint32_t g_npcmove_attitude_epoch;
 
 class input_context;
 

--- a/src/game.h
+++ b/src/game.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <atomic>
 #include <chrono>
 #include <ctime>
 #include <functional>
@@ -62,6 +63,9 @@ extern std::unique_ptr<game> g;
 
 extern const int savegame_version;
 extern int savegame_loading_version;
+// Monotonically increasing counter; bumped whenever NPC faction membership or active NPC list
+// changes so each NPC can lazily invalidate its cached friends list.
+extern std::atomic<uint32_t> g_npc_friends_dirty_version;
 
 class input_context;
 
@@ -466,6 +470,11 @@ class game : public submap_load_listener
         monster_range all_monsters();
         /// Same as @ref all_creatures but iterators only over npcs.
         npc_range all_npcs();
+        /// Direct non-allocating view of the active NPC list. Only use when no NPCs will be
+        /// added or removed during iteration and dead entries are handled by the caller.
+        const std::list<shared_ptr_fast<npc>> &raw_npcs() const {
+            return active_npc;
+        }
 
         /**
          * Returns all creatures matching a predicate. Only living ( not dead ) creatures

--- a/src/monster.h
+++ b/src/monster.h
@@ -3,6 +3,7 @@
 #include <bitset>
 #include <climits>
 #include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <map>
 #include <optional>
@@ -610,6 +611,10 @@ class monster : public Creature, public location_visitable<monster>
         int friendly;
         int anger = 0;
         int morale = 0;
+        // Per-npcmove-pass cache of attitude_to() result for a generic NPC (no special traits).
+        // Valid when cached_npc_attitude_epoch == g_npcmove_attitude_epoch.
+        uint32_t cached_npc_attitude_epoch = 0;
+        Attitude cached_npc_attitude = A_NEUTRAL;
         std::unordered_map<mfaction_id, int> faction_anger;  //< Per-faction anger tracking
         // Our faction (species, for most monsters)
         mfaction_id faction;

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -512,6 +512,7 @@ void npc::set_fac( const faction_id &id )
         return;
     }
     apply_ownership_to_inv();
+    ++g_npc_friends_dirty_version;
 }
 
 void npc::apply_ownership_to_inv()
@@ -2611,6 +2612,8 @@ void npc::reboot()
     ai_cache.guard_pos = std::nullopt;
     ai_cache.my_weapon_value = 0;
     ai_cache.friends.clear();
+    ai_cache.cached_npc_friends.clear();
+    ai_cache.npc_friends_version = 0;
     ai_cache.dangerous_explosives.clear();
     ai_cache.threat_map.fill( 0.0f );
     ai_cache.searched_tiles.clear();

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -179,9 +179,7 @@ npc::npc()
     attitude = NPCATT_NULL;
 
     *path_settings = pathfinding_settings( 0, 1000, 1000, 10, true, true, true, false, true );
-    for( direction threat_dir : npc_threat_dir ) {
-        ai_cache.threat_map[ threat_dir ] = 0.0f;
-    }
+    ai_cache.threat_map.fill( 0.0f );
 
     // This should be in Character constructor, but because global avatar
     // gets instantiated on game launch and not after data loading stage
@@ -2614,7 +2612,7 @@ void npc::reboot()
     ai_cache.my_weapon_value = 0;
     ai_cache.friends.clear();
     ai_cache.dangerous_explosives.clear();
-    ai_cache.threat_map.clear();
+    ai_cache.threat_map.fill( 0.0f );
     ai_cache.searched_tiles.clear();
     activity = std::make_unique<player_activity>();
     clear_destination();

--- a/src/npc.h
+++ b/src/npc.h
@@ -510,6 +510,9 @@ struct npc_short_term_cache {
 
     // Use weak_ptr to avoid circular references between Creatures
     std::vector<weak_ptr_fast<Creature>> friends;
+    // NPC-typed friends only; rebuilt when g_npc_friends_dirty_version changes
+    std::vector<weak_ptr_fast<Creature>> cached_npc_friends;
+    uint32_t npc_friends_version = 0;
     std::vector<sphere> dangerous_explosives;
     std::array<float, 27> threat_map;
     // Cache of locations the NPC has searched recently in npc::find_item()

--- a/src/npc.h
+++ b/src/npc.h
@@ -511,7 +511,7 @@ struct npc_short_term_cache {
     // Use weak_ptr to avoid circular references between Creatures
     std::vector<weak_ptr_fast<Creature>> friends;
     std::vector<sphere> dangerous_explosives;
-    std::map<direction, float> threat_map;
+    std::array<float, 27> threat_map;
     // Cache of locations the NPC has searched recently in npc::find_item()
     lru_cache<tripoint, int> searched_tiles;
 };

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -549,7 +549,9 @@ void npc::assess_danger()
                 ai_cache.friends.emplace_back( g->shared_from( critter ) );
                 continue;
             }
-            if( att != Attitude::A_HOSTILE && ( critter.friendly || !is_enemy() ) ) {
+            // Skip non-hostile monsters entirely — includes MATT_IGNORE, MATT_FLEE, and
+            // MATT_FOLLOW (tracking but not yet attacking; take neutral attitude at face value).
+            if( att != Attitude::A_HOSTILE ) {
                 continue;
             }
             if( !npc_turn_cached_sees( *this, critter ) ) {

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -537,8 +537,8 @@ void npc::assess_danger()
                 // so this skips the bad weak_ptrs, but this doesn't functionally change the AI Priority
                 // because the horse the NPC is riding is still in the ai_cache.friends vector,
                 // so either one would count as a friendly for this purpose.
-                if( guy.lock() ) {
-                    is_too_close |= too_close( critter.pos(), guy.lock()->pos(), def_radius );
+                if( auto ally = guy.lock() ) {
+                    is_too_close |= too_close( critter.pos(), ally->pos(), def_radius );
                 }
             }
             // ignore distant monsters that our rules prevent us from attacking
@@ -584,9 +584,11 @@ void npc::assess_danger()
             if( self_defense_only ) {
                 break;
             }
-            is_too_close |= too_close( foe.pos(), guy.lock()->pos(), def_radius );
-            if( is_too_close ) {
-                break;
+            if( auto ally = guy.lock() ) {
+                is_too_close |= too_close( foe.pos(), ally->pos(), def_radius );
+                if( is_too_close ) {
+                    break;
+                }
             }
         }
 
@@ -670,7 +672,8 @@ float npc::character_danger( const Character &u ) const
     }
     ret += u_weap_val;
 
-    ret += hp_percentage() * get_hp_max( bodypart_id( "torso" ) ) / 100.0 / my_weap_val;
+    static const bodypart_id torso_id( "torso" );
+    ret += hp_percentage() * get_hp_max( torso_id ) / 100.0 / my_weap_val;
 
     ret += my_gun ? u.get_dodge() / 2 : u.get_dodge();
 

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -13,6 +13,7 @@
 
 #include "active_item_cache.h"
 #include "activity_handlers.h"
+#include "creature_tracker.h"
 #include "bionics.h"
 #include "bodypart.h"
 #include "cata_algo.h"
@@ -117,6 +118,17 @@ static const efftype_id effect_npc_player_looking( "npc_player_still_looking" );
 static const efftype_id effect_npc_run_away( "npc_run_away" );
 static const efftype_id effect_onfire( "onfire" );
 static const efftype_id effect_stunned( "stunned" );
+static const efftype_id effect_attention( "attention" );
+static const efftype_id effect_feral_infighting_punishment( "feral_infighting_punishment" );
+
+static const trait_id trait_BEE( "BEE" );
+static const trait_id trait_FLOWERS( "FLOWERS" );
+static const trait_id trait_MYCUS_FRIEND( "MYCUS_FRIEND" );
+static const trait_id trait_PHEROMONE_INSECT( "PHEROMONE_INSECT" );
+static const trait_id trait_PHEROMONE_MAMMAL( "PHEROMONE_MAMMAL" );
+static const trait_id trait_PROF_FERAL( "PROF_FERAL" );
+static const trait_id trait_TERRIFYING( "TERRIFYING" );
+static const trait_id trait_THRESH_MYCUS( "THRESH_MYCUS" );
 
 static const itype_id itype_battery( "battery" );
 static const itype_id itype_chem_ethanol( "chem_ethanol" );
@@ -379,6 +391,16 @@ static auto npc_turn_cached_sees( const Creature &seer, const Creature &target )
 void npc::assess_danger()
 {
     ZoneScoped;
+    // True if this NPC has traits/effects that cause monster::attitude() to return a
+    // result different from what a generic NPC would get.  When false, we can use each
+    // monster's per-npcmove-pass cached attitude instead of recomputing it.
+    const bool has_special_attitude_traits = guaranteed_hostile() || is_hallucination() ||
+            has_trait( trait_PROF_FERAL ) || has_trait( trait_BEE ) ||
+            has_trait( trait_FLOWERS ) || has_trait( trait_THRESH_MYCUS ) ||
+            has_trait( trait_MYCUS_FRIEND ) || has_trait( trait_PHEROMONE_MAMMAL ) ||
+            has_trait( trait_PHEROMONE_INSECT ) || has_trait( trait_TERRIFYING ) ||
+            has_effect( effect_attention ) || has_effect( effect_feral_infighting_punishment );
+
     float assessment = 0.0f;
     float highest_priority = 1.0f;
     int def_radius = rules.has_flag( ally_rule::follow_close ) ? follow_distance() : 6;
@@ -501,12 +523,26 @@ void npc::assess_danger()
 
     {
         ZoneScopedN( "assess_all_monsters" );
-        for( const monster &critter : g->all_monsters() ) {
+        for( const shared_ptr_fast<monster> &mon_ptr : g->critter_tracker->get_monsters_list() ) {
+            if( mon_ptr->is_dead() ) {
+                continue;
+            }
+            monster &critter = *mon_ptr;
             const auto dist = rl_dist_fast( pos(), critter.pos() );
             if( dist > default_daylight_level() ) {
                 continue;
             }
-            auto att = critter.attitude_to( *this );
+            Attitude att;
+            if( !has_special_attitude_traits &&
+                critter.cached_npc_attitude_epoch == g_npcmove_attitude_epoch ) {
+                att = critter.cached_npc_attitude;
+            } else {
+                att = critter.attitude_to( *this );
+                if( !has_special_attitude_traits ) {
+                    critter.cached_npc_attitude_epoch = g_npcmove_attitude_epoch;
+                    critter.cached_npc_attitude = att;
+                }
+            }
             if( att == Attitude::A_FRIENDLY ) {
                 ai_cache.friends.emplace_back( g->shared_from( critter ) );
                 continue;

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -251,11 +251,9 @@ tripoint npc::good_escape_direction( bool include_pos )
     float best_rating = include_pos ? rate_pt( pos(), 0.0f ) : FLT_MAX;
     candidates.emplace_back( pos() );
 
-    std::map<direction, float> adj_map;
     for( direction pt_dir : npc_threat_dir ) {
         const tripoint &pt = pos() + displace_XY( pt_dir );
-        float cur_rating = rate_pt( pt, ai_cache.threat_map[ pt_dir ] );
-        adj_map[pt_dir] = cur_rating;
+        float cur_rating = rate_pt( pt, ai_cache.threat_map[std::to_underlying( pt_dir )] );
         if( cur_rating == best_rating ) {
             candidates.emplace_back( pos() + displace_XY( pt_dir ) );
         } else if( cur_rating < best_rating ) {
@@ -442,10 +440,10 @@ void npc::assess_danger()
 
         return true;
     };
-    std::map<direction, float> cur_threat_map;
+    std::array<float, 27> cur_threat_map{};
     // start with a decayed version of last turn's map
     for( direction threat_dir : npc_threat_dir ) {
-        cur_threat_map[ threat_dir ] = 0.25f * ai_cache.threat_map[ threat_dir ];
+        cur_threat_map[std::to_underlying( threat_dir )] = 0.25f * ai_cache.threat_map[std::to_underlying( threat_dir )];
     }
     map &here = get_map();
     // cache string_id -> int_id conversion before hot loop
@@ -457,7 +455,7 @@ void npc::assess_danger()
             continue;
         }
         const int dist = rl_dist( pos(), pt );
-        cur_threat_map[direction_from( pos(), pt )] += 2.0f * ( NPC_DANGER_MAX - dist );
+        cur_threat_map[std::to_underlying( direction_from( pos(), pt ) )] += 2.0f * ( NPC_DANGER_MAX - dist );
         if( dist < 3 && !has_effect( effect_npc_fire_bad ) ) {
             warn_about( "fire_bad", 1_minutes );
             add_effect( effect_npc_fire_bad, 5_turns );
@@ -550,7 +548,7 @@ void npc::assess_danger()
             // critter danger is always at least NPC_DANGER_VERY_LOW
             float priority = std::max( critter_danger - 2.0f * ( scaled_distance - 1.0f ),
                                        is_too_close ? critter_danger : 0.0f );
-            cur_threat_map[direction_from( pos(), critter.pos() )] += priority;
+            cur_threat_map[std::to_underlying( direction_from( pos(), critter.pos() ) )] += priority;
             if( priority > highest_priority ) {
                 highest_priority = priority;
                 ai_cache.target = g->shared_from( critter );
@@ -596,7 +594,7 @@ void npc::assess_danger()
             float priority = std::max( foe_threat - 2.0f * ( scaled_distance - 1 ),
                                        is_too_close ? std::max( foe_threat, NPC_DANGER_VERY_LOW ) :
                                        0.0f );
-            cur_threat_map[direction_from( pos(), foe.pos() )] += priority;
+            cur_threat_map[std::to_underlying( direction_from( pos(), foe.pos() ) )] += priority;
             if( priority > highest_priority ) {
                 warn_about( warning, 1_minutes );
                 highest_priority = priority;
@@ -651,8 +649,9 @@ void npc::assess_danger()
         direction threat_dir = npc_threat_dir[i];
         direction dir_right = npc_threat_dir[( i + 1 ) % 8];
         direction dir_left = npc_threat_dir[( i + 7 ) % 8 ];
-        ai_cache.threat_map[threat_dir] = cur_threat_map[threat_dir] + 0.1f *
-                                          ( cur_threat_map[dir_right] + cur_threat_map[dir_left] );
+        ai_cache.threat_map[std::to_underlying( threat_dir )] =
+            cur_threat_map[std::to_underlying( threat_dir )] + 0.1f *
+            ( cur_threat_map[std::to_underlying( dir_right )] + cur_threat_map[std::to_underlying( dir_left )] );
     }
     if( assessment <= 2.0f ) {
         assessment = -10.0f + 5.0f * assessment; // Low danger if no monsters around

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -463,18 +463,33 @@ void npc::assess_danger()
         }
     }
 
-    // find our Character friends and enemies
+    // Find our Character friends and enemies.
+    // NPC friends are cached across turns; only rebuild when faction membership or active NPC
+    // list changes (tracked via g_npc_friends_dirty_version).
     std::vector<weak_ptr_fast<Creature>> hostile_guys;
-    for( const npc &guy : g->all_npcs() ) {
-        if( &guy == this ) {
-            continue;
+    {
+        const uint32_t current_version = g_npc_friends_dirty_version.load( std::memory_order_relaxed );
+        const bool friends_dirty = ( ai_cache.npc_friends_version != current_version );
+        if( friends_dirty ) {
+            ai_cache.cached_npc_friends.clear();
         }
-
-        if( has_faction_relationship( guy, npc_factions::watch_your_back ) ) {
-            ai_cache.friends.emplace_back( g->shared_from( guy ) );
-        } else if( attitude_to( guy ) != Attitude::A_NEUTRAL && sees( guy.pos() ) ) {
-            hostile_guys.emplace_back( g->shared_from( guy ) );
+        for( const shared_ptr_fast<npc> &npc_ptr : g->raw_npcs() ) {
+            const npc &guy = *npc_ptr;
+            if( &guy == this || guy.is_dead() ) {
+                continue;
+            }
+            if( has_faction_relationship( guy, npc_factions::watch_your_back ) ) {
+                if( friends_dirty ) {
+                    ai_cache.cached_npc_friends.emplace_back( g->shared_from( guy ) );
+                }
+            } else if( attitude_to( guy ) != Attitude::A_NEUTRAL && sees( guy.pos() ) ) {
+                hostile_guys.emplace_back( g->shared_from( guy ) );
+            }
         }
+        if( friends_dirty ) {
+            ai_cache.npc_friends_version = current_version;
+        }
+        std::ranges::copy( ai_cache.cached_npc_friends, std::back_inserter( ai_cache.friends ) );
     }
     if( sees( player_character.pos() ) ) {
         if( is_enemy() ) {

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -465,7 +465,8 @@ void npc::assess_danger()
     std::array<float, 27> cur_threat_map{};
     // start with a decayed version of last turn's map
     for( direction threat_dir : npc_threat_dir ) {
-        cur_threat_map[std::to_underlying( threat_dir )] = 0.25f * ai_cache.threat_map[std::to_underlying( threat_dir )];
+        cur_threat_map[std::to_underlying( threat_dir )] = 0.25f * ai_cache.threat_map[std::to_underlying(
+                    threat_dir )];
     }
     map &here = get_map();
     // cache string_id -> int_id conversion before hot loop
@@ -477,7 +478,8 @@ void npc::assess_danger()
             continue;
         }
         const int dist = rl_dist( pos(), pt );
-        cur_threat_map[std::to_underlying( direction_from( pos(), pt ) )] += 2.0f * ( NPC_DANGER_MAX - dist );
+        cur_threat_map[std::to_underlying( direction_from( pos(),
+                                           pt ) )] += 2.0f * ( NPC_DANGER_MAX - dist );
         if( dist < 3 && !has_effect( effect_npc_fire_bad ) ) {
             warn_about( "fire_bad", 1_minutes );
             add_effect( effect_npc_fire_bad, 5_turns );
@@ -702,7 +704,8 @@ void npc::assess_danger()
         direction dir_left = npc_threat_dir[( i + 7 ) % 8 ];
         ai_cache.threat_map[std::to_underlying( threat_dir )] =
             cur_threat_map[std::to_underlying( threat_dir )] + 0.1f *
-            ( cur_threat_map[std::to_underlying( dir_right )] + cur_threat_map[std::to_underlying( dir_left )] );
+            ( cur_threat_map[std::to_underlying( dir_right )] + cur_threat_map[std::to_underlying(
+                        dir_left )] );
     }
     if( assessment <= 2.0f ) {
         assessment = -10.0f + 5.0f * assessment; // Low danger if no monsters around


### PR DESCRIPTION
## Purpose of change (The Why)

NPC threat evaluation is godawful slow

## Describe the solution (The How)

Improved several iterations that impacted performance.
Obviously this includes monster threat assessment by NPCs
I use caching, since most of the calculations are identical between NPCs except in a few notable exceptions, which I guard for
I also cache friends, made a few small improvements to thread safety, and improved the threat map

## Testing

I ran some massive necropolis tests, and the results were really good.
assess_all_monsters used to be the most expensive function, and I reduced that by 78%.
Total time of do_turn was something like 76%.
Do keep in mind that I was fully zoomed in, so this removes most of the rendering cost from the equation.

## Additional context

If you save your Tracy traces to the same folder, here's a handy example of exporting to CSV to do programatic comparisons:
```
csvexport -e Massive_Necrop_PR_3.tracy > Massive_Necrop_PR_3.csv
```
Here's this cool table of the results per phase of this PR to look at:

| Zone | Main | Phase 1 | Phase 2 | Phase 3 | %  Saved |
|---|---|---|---|---|---|
| `assess_all_monsters` | 1,580,606 ns | 1,614,436 ns | 1,576,942 ns | 334,779 ns | 78.8% |
| `npc::assess_danger` | 6,743 ns | 4,679 ns | 4,490 ns | 4,662 ns | 30.9% |
| `npc::regen_ai_cache` | 17,203 ns | 16,851 ns | 17,161 ns | 16,119 ns | 6.3% |
| `npc::move` | 20,459 ns | 20,299 ns | 19,426 ns | 18,297 ns | 10.6% |
| `npc_process_turn` | 63,143 ns | 63,766 ns | 61,471 ns | 59,593 ns | 5.6% |