### PR TITLE
perf: map cache iteration feat funnels

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -255,6 +255,7 @@ auto map::resize( int new_mapsize ) -> void
     }
     submaps_with_active_items.clear();
     loaded_vehicles.clear();
+    funnel_locations_.clear();
     // Recompute the circular load footprint for the new bubble radius.
     // Radius = (mapsize - 1) / 2, matching g_half_mapsize.
     submap_loader.update_load_shape( ( new_mapsize - 1 ) / 2 );
@@ -353,6 +354,16 @@ void map::on_submap_loaded( const tripoint_abs_sm &pos, const std::string &dim_i
         submaps_with_active_items.emplace( p );
     }
 
+    // Register any funnel traps so fill_water_collectors can skip the mapbuffer scan.
+    if( sm != nullptr && !sm->trap_cache.empty() ) {
+        const tripoint sm_abs = pos.raw();
+        std::ranges::for_each( sm->trap_cache, [&]( const point & lp ) {
+            if( sm->get_trap( lp ).obj().is_funnel() ) {
+                funnel_locations_.emplace_back( sm_abs, lp );
+            }
+        } );
+    }
+
     if( !contains_abs_sm( pos ) ) {
         return;
     }
@@ -391,6 +402,12 @@ void map::on_submap_unloaded( const tripoint_abs_sm &pos, const std::string &dim
 
     // Stop tracking active items for this submap.
     submaps_with_active_items.erase( pos.raw() );
+
+    // Remove any funnel locations belonging to this submap.
+    const tripoint sm_abs = pos.raw();
+    std::erase_if( funnel_locations_, [&]( const auto & e ) {
+        return e.first == sm_abs;
+    } );
 
     if( !contains_abs_sm( pos ) ) {
         return;
@@ -6411,6 +6428,10 @@ void map::trap_set( const tripoint &p, const trap_id &type )
     }
 
     current_submap->set_trap( l, type );
+    if( type.obj().is_funnel() ) {
+        const tripoint sm_abs( abs_sub.x + p.x / SEEX, abs_sub.y + p.y / SEEY, p.z );
+        funnel_locations_.emplace_back( sm_abs, l );
+    }
 }
 
 void map::disarm_trap( const tripoint &p )
@@ -6481,6 +6502,13 @@ void map::remove_trap( const tripoint &p )
     if( tid != tr_null ) {
         if( g != nullptr && this == &get_map() ) {
             g->u.add_known_trap( p, tr_null.obj() );
+        }
+
+        if( tid.obj().is_funnel() ) {
+            const tripoint sm_abs( abs_sub.x + p.x / SEEX, abs_sub.y + p.y / SEEY, p.z );
+            std::erase_if( funnel_locations_, [&]( const auto & e ) {
+                return e.first == sm_abs && e.second == l;
+            } );
         }
 
         current_submap->set_trap( l, tr_null );
@@ -7845,6 +7873,7 @@ void map::load( const tripoint &w, const bool update_vehicle, const bool pump_ev
     std::fill( grid.begin(), grid.end(), nullptr );
     submaps_with_active_items.clear();
     loaded_vehicles.clear();
+    funnel_locations_.clear();
     set_abs_sub( w );
     for( int gridx = 0; gridx < my_MAPSIZE; gridx++ ) {
         for( int gridy = 0; gridy < my_MAPSIZE; gridy++ ) {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -3485,6 +3485,7 @@ bool map::is_flammable( const tripoint &p )
 
 void map::decay_fields_and_scent( const time_duration &amount )
 {
+    ZoneScopedN( "decay_fields_and_scent" );
     // TODO: Make this happen on all z-levels
 
     // Decay scent separately, so that later we can use field count to skip empty submaps

--- a/src/map.h
+++ b/src/map.h
@@ -2272,6 +2272,14 @@ class map : public submap_load_listener
         std::set<tripoint> submaps_with_active_items;
 
         /**
+         * Flat list of all funnel trap locations in this dimension's loaded submaps.
+         * Each entry is (abs_sm position, local tile point within that submap).
+         * Populated by on_submap_loaded() and trap_set(); pruned by on_submap_unloaded()
+         * and remove_trap(). Lets fill_water_collectors() skip the mapbuffer scan entirely.
+         */
+        std::vector<std::pair<tripoint, point>> funnel_locations_;
+
+        /**
          * Flat registry of all vehicles in loaded submaps (both in-bubble and
          * out-of-bubble).  Populated by loadn() and on_submap_loaded(); pruned
          * by on_submap_unloaded() and detach_vehicle().  Replaces the old
@@ -2341,6 +2349,10 @@ class map : public submap_load_listener
         const visibility_variables &get_visibility_variables_cache() const;
 
         void update_submap_active_item_status( const tripoint &p );
+
+        const std::vector<std::pair<tripoint, point>> &get_funnel_locations() const {
+            return funnel_locations_;
+        }
 
         // Just exposed for unit test introspection.
         const std::set<tripoint> &get_submaps_with_active_items() const {

--- a/src/scent_map.cpp
+++ b/src/scent_map.cpp
@@ -78,6 +78,7 @@ auto scent_map::raw_scent_set( int x, int y, int z, int value ) -> void
         sm->scent_values[x - gx * SEEX][y - gy * SEEY] = value;
         if( value > 0 ) {
             sm->has_scent = true;
+            scent_submaps_[m_.get_bound_dimension()].insert( abs_sm );
         }
     }
 }
@@ -95,30 +96,38 @@ void scent_map::reset()
             }
         } );
     } );
+    scent_submaps_.clear();
     typescent = scenttype_id();
 }
 
 void scent_map::decay()
 {
     ZoneScopedN( "scent_map::decay" );
-    // Decay scent on all loaded submaps across every dimension within scent z-range.
+    // Decay scent on tracked submaps across every dimension within scent z-range.
     // Called during precipitation, so rain washes away scent globally.
-    // Submaps without any non-zero scent values are skipped via has_scent.
+    // Only submaps registered in scent_submaps_ are visited — no mapbuffer scan needed.
     const int levz = gm.get_levz();
-    MAPBUFFER_REGISTRY.for_each( [&]( const std::string &, mapbuffer & buf ) {
-        std::ranges::for_each( buf, [&]( auto & entry ) {
-            auto &[raw_pos, sm_ptr] = entry;
-            if( !sm_ptr || sm_ptr->is_uniform || !sm_ptr->has_scent ||
-                std::abs( raw_pos.z - levz ) > SCENT_MAP_Z_REACH ) {
-                return;
+    MAPBUFFER_REGISTRY.for_each( [&]( const std::string & dim_id, mapbuffer & buf ) {
+        auto dim_it = scent_submaps_.find( dim_id );
+        if( dim_it == scent_submaps_.end() ) {
+            return;
+        }
+        std::erase_if( dim_it->second, [&]( const tripoint & abs_sm ) {
+            if( std::abs( abs_sm.z - levz ) > SCENT_MAP_Z_REACH ) {
+                return false;
+            }
+            auto *sm = buf.lookup_submap_in_memory( abs_sm );
+            if( !sm || sm->is_uniform ) {
+                return true;
             }
             bool any_nonzero = false;
-            std::ranges::for_each( std::span( &sm_ptr->scent_values[0][0], SEEX * SEEY ),
+            std::ranges::for_each( std::span( &sm->scent_values[0][0], SEEX * SEEY ),
             [&any_nonzero]( auto & v ) {
                 v = std::max( 0, v - 1 );
                 any_nonzero |= v > 0;
             } );
-            sm_ptr->has_scent = any_nonzero;
+            sm->has_scent = any_nonzero;
+            return !any_nonzero;
         } );
     } );
 }

--- a/src/scent_map.cpp
+++ b/src/scent_map.cpp
@@ -76,6 +76,9 @@ auto scent_map::raw_scent_set( int x, int y, int z, int value ) -> void
     auto *sm = MAPBUFFER_REGISTRY.get( m_.get_bound_dimension() ).lookup_submap_in_memory( abs_sm );
     if( sm ) {
         sm->scent_values[x - gx * SEEX][y - gy * SEEY] = value;
+        if( value > 0 ) {
+            sm->has_scent = true;
+        }
     }
 }
 
@@ -88,6 +91,7 @@ void scent_map::reset()
             auto &[raw_pos, sm_ptr] = entry;
             if( sm_ptr && !sm_ptr->is_uniform ) {
                 std::ranges::fill( std::span( &sm_ptr->scent_values[0][0], SEEX * SEEY ), 0 );
+                sm_ptr->has_scent = false;
             }
         } );
     } );
@@ -99,15 +103,22 @@ void scent_map::decay()
     ZoneScopedN( "scent_map::decay" );
     // Decay scent on all loaded submaps across every dimension within scent z-range.
     // Called during precipitation, so rain washes away scent globally.
+    // Submaps without any non-zero scent values are skipped via has_scent.
     const int levz = gm.get_levz();
     MAPBUFFER_REGISTRY.for_each( [&]( const std::string &, mapbuffer & buf ) {
         std::ranges::for_each( buf, [&]( auto & entry ) {
             auto &[raw_pos, sm_ptr] = entry;
-            if( !sm_ptr || sm_ptr->is_uniform || std::abs( raw_pos.z - levz ) > SCENT_MAP_Z_REACH ) {
+            if( !sm_ptr || sm_ptr->is_uniform || !sm_ptr->has_scent ||
+                std::abs( raw_pos.z - levz ) > SCENT_MAP_Z_REACH ) {
                 return;
             }
+            bool any_nonzero = false;
             std::ranges::for_each( std::span( &sm_ptr->scent_values[0][0], SEEX * SEEY ),
-            []( auto & v ) { v = std::max( 0, v - 1 ); } );
+            [&any_nonzero]( auto & v ) {
+                v = std::max( 0, v - 1 );
+                any_nonzero |= v > 0;
+            } );
+            sm_ptr->has_scent = any_nonzero;
         } );
     } );
 }

--- a/src/scent_map.h
+++ b/src/scent_map.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <map>
 #include <optional>
 #include <set>
 #include <string>
@@ -44,6 +45,12 @@ class scent_map
 
         const game &gm;
         map &m_;
+
+        // Per-dimension sets of absolute submap positions that currently have at least
+        // one non-zero scent value. Keyed by dimension_id to match MAPBUFFER_REGISTRY.
+        // Populated by raw_scent_set(); pruned by decay() once all values reach zero.
+        // Lets decay() skip the full mapbuffer scan for each dimension.
+        std::map<std::string, std::set<tripoint>> scent_submaps_;
 
     public:
         scent_map( const game &g, map &m ) : gm( g ), m_( m ) { }

--- a/src/submap.h
+++ b/src/submap.h
@@ -308,6 +308,9 @@ class submap : maptile_soa<SEEX, SEEY>
         char   floor_cache[SEEX][SEEY]         = {};
         pf_special pf_special_cache[SEEX][SEEY]  = {};
         int    scent_values[SEEX][SEEY]        = {};
+        // True if any scent_values cell is non-zero. Set in raw_scent_set; cleared by
+        // scent_map::decay once all values reach zero. Lets decay() skip unvisited submaps.
+        bool has_scent = false;
 
         bool transparency_dirty = true;
         bool outside_dirty      = true;

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -331,62 +331,50 @@ double trap::funnel_turns_per_charge( double rain_depth_mm_per_hour ) const
 /**
  * Main routine for filling funnels from weather effects.
  */
-static void fill_funnels( int rain_depth_mm_per_hour, bool acid, const trap &tr )
+/**
+ * Fill funnels and makeshift funnels from weather effects.
+ * Single mapbuffer pass: each loaded submap's trap_cache is visited once and each
+ * funnel trap found is processed directly, rather than making one full pass per funnel type.
+ * Covers funnels at player bases and other loaded-but-out-of-bubble locations.
+ */
+static void fill_water_collectors( int mmPerHour, bool acid )
 {
-    const double turns_per_charge = tr.funnel_turns_per_charge( rain_depth_mm_per_hour );
-    // Scan all loaded submaps in the current dimension's mapbuffer instead of the
-    // bubble-bounded traplocs.  This covers funnels at player bases and other
-    // loaded-but-out-of-bubble locations.
+    ZoneScopedN( "fill_water_collectors" );
     const auto abs_sub = g->m.get_abs_sub();
     auto &mbuf = MAPBUFFER_REGISTRY.get( g->m.get_bound_dimension() );
-    std::ranges::for_each( mbuf, [&]( auto & entry ) {
+    std::ranges::for_each( mbuf, [&]( auto &entry ) {
         auto &[raw_pos, sm_ptr] = entry;
         if( !sm_ptr || sm_ptr->is_uniform || sm_ptr->trap_cache.empty() ) {
             return;
         }
-        std::ranges::for_each( sm_ptr->trap_cache, [&]( const point & lp ) {
-            if( sm_ptr->get_trap( lp ) != tr.loadid ) {
+        std::ranges::for_each( sm_ptr->trap_cache, [&]( const point &lp ) {
+            const trap &tr = sm_ptr->get_trap( lp ).obj();
+            if( !tr.is_funnel() ) {
                 return;
             }
-            const auto lx = lp.x;
-            const auto ly = lp.y;
-            const tripoint loc( ( raw_pos.x - abs_sub.x ) * SEEX + lx,
-                                ( raw_pos.y - abs_sub.y ) * SEEY + ly,
-                                raw_pos.z );
+            if( !one_in( tr.funnel_turns_per_charge( mmPerHour ) ) ) {
+                return;
+            }
+            const tripoint loc(
+                ( raw_pos.x - abs_sub.x ) * SEEX + lp.x,
+                ( raw_pos.y - abs_sub.y ) * SEEY + lp.y,
+                raw_pos.z );
+            // Put the rain in the largest container here which is either empty or
+            // contains some mixture of impure water and acid.
             units::volume maxcontains = 0_ml;
-            if( one_in( turns_per_charge ) ) {
-                // FIXME:
-                //add_msg("%d mm/h %d tps %.4f: fill",int(calendar::turn),rain_depth_mm_per_hour,turns_per_charge);
-                // This funnel has collected some rain! Put the rain in the largest
-                // container here which is either empty or contains some mixture of
-                // impure water and acid.
-                map_stack items = g->m.i_at( loc );
-                auto container = items.end();
-                for( auto candidate_container = items.begin(); candidate_container != items.end();
-                     ++candidate_container ) {
-                    if( ( *candidate_container )->is_funnel_container( maxcontains ) ) {
-                        container = candidate_container;
-                    }
+            map_stack items = g->m.i_at( loc );
+            auto container = items.end();
+            for( auto candidate = items.begin(); candidate != items.end(); ++candidate ) {
+                if( ( *candidate )->is_funnel_container( maxcontains ) ) {
+                    container = candidate;
                 }
-
-                if( container != items.end() ) {
-                    ( *container )->add_rain_to_container( acid, 1 );
-                    ( *container )->set_age( 0_turns );
-                }
+            }
+            if( container != items.end() ) {
+                ( *container )->add_rain_to_container( acid, 1 );
+                ( *container )->set_age( 0_turns );
             }
         } );
     } );
-}
-
-/**
- * Fill funnels and makeshift funnels from weather effects.
- * @see fill_funnels
- */
-static void fill_water_collectors( int mmPerHour, bool acid )
-{
-    for( auto &e : trap::get_funnels() ) {
-        fill_funnels( mmPerHour, acid, *e );
-    }
 }
 
 /**
@@ -403,6 +391,7 @@ static void fill_water_collectors( int mmPerHour, bool acid )
  */
 void weather_effect::wet_player( int amount )
 {
+    ZoneScopedN( "wet_player" );
     Character &target = get_avatar();
     if( !is_player_outside() ||
         target.has_trait( trait_FEATHERS ) ||

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -333,47 +333,46 @@ double trap::funnel_turns_per_charge( double rain_depth_mm_per_hour ) const
  */
 /**
  * Fill funnels and makeshift funnels from weather effects.
- * Single mapbuffer pass: each loaded submap's trap_cache is visited once and each
- * funnel trap found is processed directly, rather than making one full pass per funnel type.
- * Covers funnels at player bases and other loaded-but-out-of-bubble locations.
+ * Iterates map::funnel_locations_ — a persistent list of known funnel positions —
+ * so no mapbuffer scan is required. Covers funnels at player bases and other
+ * loaded-but-out-of-bubble locations.
  */
 static void fill_water_collectors( int mmPerHour, bool acid )
 {
     ZoneScopedN( "fill_water_collectors" );
     const auto abs_sub = g->m.get_abs_sub();
     auto &mbuf = MAPBUFFER_REGISTRY.get( g->m.get_bound_dimension() );
-    std::ranges::for_each( mbuf, [&]( auto &entry ) {
-        auto &[raw_pos, sm_ptr] = entry;
-        if( !sm_ptr || sm_ptr->is_uniform || sm_ptr->trap_cache.empty() ) {
+    std::ranges::for_each( g->m.get_funnel_locations(), [&]( const auto &entry ) {
+        auto &[sm_abs, lp] = entry;
+        auto *sm = mbuf.lookup_submap_in_memory( sm_abs );
+        if( !sm ) {
             return;
         }
-        std::ranges::for_each( sm_ptr->trap_cache, [&]( const point &lp ) {
-            const trap &tr = sm_ptr->get_trap( lp ).obj();
-            if( !tr.is_funnel() ) {
-                return;
+        const trap &tr = sm->get_trap( lp ).obj();
+        if( !tr.is_funnel() ) {
+            return;
+        }
+        if( !one_in( tr.funnel_turns_per_charge( mmPerHour ) ) ) {
+            return;
+        }
+        const tripoint loc(
+            ( sm_abs.x - abs_sub.x ) * SEEX + lp.x,
+            ( sm_abs.y - abs_sub.y ) * SEEY + lp.y,
+            sm_abs.z );
+        // Put the rain in the largest container here which is either empty or
+        // contains some mixture of impure water and acid.
+        units::volume maxcontains = 0_ml;
+        map_stack items = g->m.i_at( loc );
+        auto container = items.end();
+        for( auto candidate = items.begin(); candidate != items.end(); ++candidate ) {
+            if( ( *candidate )->is_funnel_container( maxcontains ) ) {
+                container = candidate;
             }
-            if( !one_in( tr.funnel_turns_per_charge( mmPerHour ) ) ) {
-                return;
-            }
-            const tripoint loc(
-                ( raw_pos.x - abs_sub.x ) * SEEX + lp.x,
-                ( raw_pos.y - abs_sub.y ) * SEEY + lp.y,
-                raw_pos.z );
-            // Put the rain in the largest container here which is either empty or
-            // contains some mixture of impure water and acid.
-            units::volume maxcontains = 0_ml;
-            map_stack items = g->m.i_at( loc );
-            auto container = items.end();
-            for( auto candidate = items.begin(); candidate != items.end(); ++candidate ) {
-                if( ( *candidate )->is_funnel_container( maxcontains ) ) {
-                    container = candidate;
-                }
-            }
-            if( container != items.end() ) {
-                ( *container )->add_rain_to_container( acid, 1 );
-                ( *container )->set_age( 0_turns );
-            }
-        } );
+        }
+        if( container != items.end() ) {
+            ( *container )->add_rain_to_container( acid, 1 );
+            ( *container )->set_age( 0_turns );
+        }
     } );
 }
 

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -342,7 +342,7 @@ static void fill_water_collectors( int mmPerHour, bool acid )
     ZoneScopedN( "fill_water_collectors" );
     const auto abs_sub = g->m.get_abs_sub();
     auto &mbuf = MAPBUFFER_REGISTRY.get( g->m.get_bound_dimension() );
-    std::ranges::for_each( g->m.get_funnel_locations(), [&]( const auto &entry ) {
+    std::ranges::for_each( g->m.get_funnel_locations(), [&]( const auto & entry ) {
         auto &[sm_abs, lp] = entry;
         auto *sm = mbuf.lookup_submap_in_memory( sm_abs );
         if( !sm ) {


### PR DESCRIPTION
## Purpose of change (The Why)

Weather was still costing way more than it should, so my previous improvement - while valid - wasn't enough.

## Describe the solution (The How)

Change the cache method, keep one large list like before, but accounting for dimensions and Map Overhaul additions

## Testing

Behold the most beautiful table I've ever seen:

| Zone | W_1 baseline | W_2 | W_3 | W_4 | W_5 | W_6 | vs Baseline |
|---|---|---|---|---|---|---|---|
| `fill_water_collectors` | 15,505,399 ns | 3,767,480 ns | 3,724,842 ns | 3,809,923 ns | 371 ns | 267 ns | −100.0% |
| `scent_map::decay` | 2,698,000 ns | 3,080,119 ns | 1,902,050 ns | 2,056,736 ns | 3,991,657 ns | 2,706 ns | −99.9% |
| `decay_fields_and_scent` self | 63,976 ns | 63,183 ns | 56,245 ns | 60,556 ns | 61,156 ns | 72,807 ns | flat |
| `wet_player` | 19,925 ns | 17,196 ns | 13,613 ns | 14,242 ns | 11,688 ns | 4,921 ns | flat |
| Combined per rain turn | ~18.3 ms | ~6.9 ms | ~5.7 ms | ~5.9 ms | ~4.1 ms | ~0.084 ms | −99.5% |