### PR TITLE
perf: Submaps use unordered_map instead of map

### DIFF
--- a/src/mapbuffer.cpp
+++ b/src/mapbuffer.cpp
@@ -382,7 +382,7 @@ void mapbuffer::save( bool delete_after_save, bool notify_tracker, bool show_pro
         }
     } );
 
-    // Evict submaps from memory. std::map mutation is not thread-safe,
+    // Evict submaps from memory. std::unordered_map mutation is not thread-safe,
     // so this is done serially after the parallel write phase completes.
     for( const tripoint &pos : submaps_to_delete ) {
         remove_submap( pos );

--- a/src/mapbuffer.h
+++ b/src/mapbuffer.h
@@ -6,6 +6,7 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -215,7 +216,7 @@ class mapbuffer
         void transfer_all_to( mapbuffer &dest );
 
     private:
-        using submap_map_t = std::map<tripoint, std::unique_ptr<submap>>;
+        using submap_map_t = std::unordered_map<tripoint, std::unique_ptr<submap>>;
 
         /// Guards all accesses to `submaps` that may overlap with background
         /// worker threads calling add_submap().  std::recursive_mutex allows


### PR DESCRIPTION
## Purpose of change (The Why)

World_tick was fairly expensive, so went looking for more optimizations

## Describe the solution (The How)

Change `submap_map_t` from a std::map to std::unordered_map.

## Describe alternatives you've considered

Make a vector<pair<tripoint, submap*>> of simulated submaps using the on_submap_loaded / unloaded functions.
In theory could be better, but would be much more work, and increase complexity. I doubt it would benefit the low end all that much as well, even if it otherwise worked out.

## Testing

With multi-threading off and a bubble size of 4, we get 4.5% savings.
On bubble size 16 with multi-threading on, we get 23.5%.
Sad that Android won't benefit more, but it still does.

## Additional context

The total effect is lower on low powered devices, but it's mostly dependent on bubble size. There's some discrepancy based on multi-threading, but it's 1/2 the benefit in the worst case.
Hopefully this is an easy win.