### PR TITLE
fix: overmapbuffer data race, OoB cache check, invalidated field range crashes

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2855,6 +2855,9 @@ bool map::supports_above( const tripoint &p ) const
 
 bool map::has_floor_or_support( const tripoint &p ) const
 {
+    if( p.z < -OVERMAP_DEPTH || p.z > OVERMAP_HEIGHT ) {
+        return false;
+    }
     const tripoint below( p.xy(), p.z - 1 );
     return !valid_move( p, below, false, true );
 }

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -1128,7 +1128,12 @@ auto process_fields_in_submap( submap &sm,
 
     auto has_fire = false;
 
-    std::ranges::for_each( sm.field_cache, [&]( const point & local ) {
+    // Snapshot before iterating: wandering-field spread can push_back to sm.field_cache
+    // within the same submap (line ~1742), which would invalidate the range iterators.
+    // Newly-added entries are newborn (age 0) and skip all effects anyway, so processing
+    // them next tick is correct behaviour.
+    const auto field_positions = sm.field_cache;
+    std::ranges::for_each( field_positions, [&]( const point & local ) {
         auto &curfield = sm.get_field( local );
 
         if( !curfield.displayed_field_type() ) {

--- a/src/mapgendata.cpp
+++ b/src/mapgendata.cpp
@@ -82,21 +82,8 @@ mapgendata::mapgendata( const tripoint_abs_omt &over, map &mp, const float densi
             joins.emplace( rotated_dir, *join );
         }
     }
-    if( std::optional<mapgen_arguments> *maybe_args = omap.mapgen_args( over ) ) {
-        if( *maybe_args ) {
-            mapgen_args_ = **maybe_args;
-        } else {
-            // We are the first omt from this overmap_special to be generated,
-            // so now is the time to generate the arguments
-            if( std::optional<overmap_special_id> s = omap.overmap_special_at( over ) ) {
-                const overmap_special &special = **s;
-                *maybe_args = special.get_args( *this );
-                mapgen_args_ = **maybe_args;
-            } else {
-                debugmsg( "mapgen params expected but no overmap special found for terrain %s",
-                          terrain_type_.id().str() );
-            }
-        }
+    if( auto args = omap.get_or_init_mapgen_args( over, *this, terrain_type_.id().str() ) ) {
+        mapgen_args_ = std::move( *args );
     }
 }
 

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -3047,6 +3047,26 @@ std::optional<mapgen_arguments> *overmap::mapgen_args( const tripoint_om_omt &p 
     return &mapgen_arg_storage[it->second];
 }
 
+overmap::mapgen_args_slot overmap::get_mapgen_args_slot( const tripoint_om_omt &p )
+{
+    auto it = mapgen_args_index.find( p );
+    if( it == mapgen_args_index.end() ) {
+        return {};
+    }
+    const int idx = it->second;
+    return { &mapgen_arg_storage[idx], &mapgen_args_init_flags_[idx] };
+}
+
+void overmap::sync_mapgen_args_init_flags()
+{
+    mapgen_args_init_flags_.assign( mapgen_arg_storage.size(), 0 );
+    for( size_t i = 0; i < mapgen_arg_storage.size(); ++i ) {
+        if( mapgen_arg_storage[i].has_value() ) {
+            mapgen_args_init_flags_[i] = 1;
+        }
+    }
+}
+
 bool &overmap::seen( const tripoint_om_omt &p )
 {
     if( !inbounds( p ) ) {
@@ -5867,6 +5887,7 @@ std::vector<tripoint_om_omt> overmap::place_special(
     // Link grid and mapgens
     const int args_index = mapgen_arg_storage.size();
     mapgen_arg_storage.emplace_back();
+    mapgen_args_init_flags_.push_back( 0 );
     for( const tripoint_om_omt &location : result.omts_used ) {
         mapgen_args_index[location] = args_index;
         overmap_special_placements[location] = special.id;

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <climits>
 #include <cstdlib>
 #include <functional>
@@ -315,6 +316,20 @@ class overmap
         const oter_id &ter( const tripoint_om_omt &p ) const;
         std::string *join_used_at( const om_pos_dir & );
         std::optional<mapgen_arguments> *mapgen_args( const tripoint_om_omt & );
+
+        /** Slot returned by get_mapgen_args_slot for lock-free fast-path access. */
+        struct mapgen_args_slot {
+            std::optional<mapgen_arguments> *args = nullptr;
+            /** Atomic flag: 0 = not yet initialized, 1 = initialized.
+             *  Access via std::atomic_ref<char>; never read/written directly. */
+            char *init_flag = nullptr;
+            explicit operator bool() const noexcept { return args != nullptr; }
+        };
+        mapgen_args_slot get_mapgen_args_slot( const tripoint_om_omt &p );
+
+        /** Rebuilds mapgen_args_init_flags_ from mapgen_arg_storage after load. */
+        void sync_mapgen_args_init_flags();
+
         bool &seen( const tripoint_om_omt &p );
         bool seen( const tripoint_om_omt &p ) const;
         bool &explored( const tripoint_om_omt &p );
@@ -460,6 +475,10 @@ class overmap
         // to be evaluated.
         std::vector<std::optional<mapgen_arguments>> mapgen_arg_storage;
         std::unordered_map<tripoint_om_omt, int> mapgen_args_index;
+        /** Parallel to mapgen_arg_storage; non-zero means the entry is fully written.
+         *  Stored as plain char so the vector is movable; accessed atomically via
+         *  std::atomic_ref<char> to provide acquire/release ordering. */
+        std::vector<char> mapgen_args_init_flags_;
 
         oter_id get_default_terrain( int z ) const;
 

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -2,6 +2,7 @@
 #include "overmapbuffer_registry.h"
 
 #include <algorithm>
+#include <atomic>
 #include <cassert>
 #include <climits>
 #include <cstdint>
@@ -891,21 +892,30 @@ std::optional<mapgen_arguments> overmapbuffer::get_or_init_mapgen_args(
     const tripoint_abs_omt &p, const mapgendata &md, const std::string &terrain_type_id )
 {
     const overmap_with_local_coords om_loc = get_om_global( p );
-    std::optional<mapgen_arguments> *const maybe_args = om_loc.om->mapgen_args( om_loc.local );
-    if( !maybe_args ) {
+    const auto slot = om_loc.om->get_mapgen_args_slot( om_loc.local );
+    if( !slot ) {
         return std::nullopt;
     }
+
+    // Lock-free fast path: args already initialized.
+    // acquire ordering ensures we see all writes made before the release store below.
+    if( std::atomic_ref<char>( *slot.init_flag ).load( std::memory_order_acquire ) != 0 ) {
+        return *slot.args;
+    }
+
+    // Slow path: first generation from this special — initialize under mutex.
     auto lk = std::lock_guard( mapgen_args_mutex_ );
-    if( !*maybe_args ) {
+    if( std::atomic_ref<char>( *slot.init_flag ).load( std::memory_order_relaxed ) == 0 ) {
         const std::optional<overmap_special_id> s = om_loc.om->overmap_special_at( om_loc.local );
         if( !s ) {
             debugmsg( "mapgen params expected but no overmap special found for terrain %s",
                       terrain_type_id );
             return std::nullopt;
         }
-        *maybe_args = ( **s ).get_args( md );
+        *slot.args = ( **s ).get_args( md );
+        std::atomic_ref<char>( *slot.init_flag ).store( 1, std::memory_order_release );
     }
-    return *maybe_args;
+    return *slot.args;
 }
 
 bool overmapbuffer::reveal( const point_abs_omt &center, int radius, int z )

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -31,6 +31,7 @@
 #include "int_id.h"
 #include "line.h"
 #include "map.h"
+#include "mapgendata.h"
 #include "memory_fast.h"
 #include "mongroup.h"
 #include "monster.h"
@@ -884,6 +885,27 @@ std::optional<mapgen_arguments> *overmapbuffer::mapgen_args( const tripoint_abs_
 {
     const overmap_with_local_coords om_loc = get_om_global( p );
     return om_loc.om->mapgen_args( om_loc.local );
+}
+
+std::optional<mapgen_arguments> overmapbuffer::get_or_init_mapgen_args(
+    const tripoint_abs_omt &p, const mapgendata &md, const std::string &terrain_type_id )
+{
+    const overmap_with_local_coords om_loc = get_om_global( p );
+    std::optional<mapgen_arguments> *const maybe_args = om_loc.om->mapgen_args( om_loc.local );
+    if( !maybe_args ) {
+        return std::nullopt;
+    }
+    auto lk = std::lock_guard( mapgen_args_mutex_ );
+    if( !*maybe_args ) {
+        const std::optional<overmap_special_id> s = om_loc.om->overmap_special_at( om_loc.local );
+        if( !s ) {
+            debugmsg( "mapgen params expected but no overmap special found for terrain %s",
+                      terrain_type_id );
+            return std::nullopt;
+        }
+        *maybe_args = ( **s ).get_args( md );
+    }
+    return *maybe_args;
 }
 
 bool overmapbuffer::reveal( const point_abs_omt &center, int radius, int z )

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -899,13 +899,27 @@ std::optional<mapgen_arguments> overmapbuffer::get_or_init_mapgen_args(
 
     // Lock-free fast path: args already initialized.
     // acquire ordering ensures we see all writes made before the release store below.
-    if( std::atomic_ref<char>( *slot.init_flag ).load( std::memory_order_acquire ) != 0 ) {
+#if defined(__cpp_lib_atomic_ref)
+    const bool already_init =
+        std::atomic_ref<char>( *slot.init_flag ).load( std::memory_order_acquire ) != 0;
+#else
+    const bool already_init =
+        __atomic_load_n( slot.init_flag, __ATOMIC_ACQUIRE ) != 0;
+#endif
+    if( already_init ) {
         return *slot.args;
     }
 
     // Slow path: first generation from this special — initialize under mutex.
     auto lk = std::lock_guard( mapgen_args_mutex_ );
-    if( std::atomic_ref<char>( *slot.init_flag ).load( std::memory_order_relaxed ) == 0 ) {
+#if defined(__cpp_lib_atomic_ref)
+    const bool still_uninit =
+        std::atomic_ref<char>( *slot.init_flag ).load( std::memory_order_relaxed ) == 0;
+#else
+    const bool still_uninit =
+        __atomic_load_n( slot.init_flag, __ATOMIC_RELAXED ) == 0;
+#endif
+    if( still_uninit ) {
         const std::optional<overmap_special_id> s = om_loc.om->overmap_special_at( om_loc.local );
         if( !s ) {
             debugmsg( "mapgen params expected but no overmap special found for terrain %s",
@@ -913,7 +927,11 @@ std::optional<mapgen_arguments> overmapbuffer::get_or_init_mapgen_args(
             return std::nullopt;
         }
         *slot.args = ( **s ).get_args( md );
+#if defined(__cpp_lib_atomic_ref)
         std::atomic_ref<char>( *slot.init_flag ).store( 1, std::memory_order_release );
+#else
+        __atomic_store_n( slot.init_flag, static_cast<char>( 1 ), __ATOMIC_RELEASE );
+#endif
     }
     return *slot.args;
 }

--- a/src/overmapbuffer.h
+++ b/src/overmapbuffer.h
@@ -26,6 +26,7 @@
 class character_id;
 enum class cube_direction : int;
 class map_extra;
+class mapgendata;
 class monster;
 class npc;
 class overmap;
@@ -225,6 +226,15 @@ class overmapbuffer
         void ter_set( const tripoint_abs_omt &p, const oter_id &id );
         std::string *join_used_at( const std::pair<tripoint_abs_omt, cube_direction> & );
         std::optional<mapgen_arguments> *mapgen_args( const tripoint_abs_omt & );
+        /**
+         * Thread-safe lazy initializer for overmap_special mapgen arguments.
+         * Returns the arguments for @p p, initializing them from the special's
+         * parameter definitions (using @p md as context) if not yet set.
+         * Returns std::nullopt if no args are defined for this position.
+         */
+        std::optional<mapgen_arguments> get_or_init_mapgen_args(
+            const tripoint_abs_omt &p, const mapgendata &md,
+            const std::string &terrain_type_id );
         /**
          * Uses global overmap terrain coordinates.
          */
@@ -594,6 +604,16 @@ class overmapbuffer
          * and add_note() concurrently without blocking unrelated overmapbuffer reads.
          */
         mutable std::mutex extras_mutex_;
+        /**
+         * Protects lazy initialization of overmap_special mapgen arguments stored in
+         * overmap::mapgen_arg_storage.  Must be acquired AFTER any @ref mutex operation
+         * completes — in practice get_om_global() acquires+releases @ref mutex internally,
+         * so mapgen_args_mutex_ is acquired only after that returns.
+         *
+         * Separate from @ref mutex so that generation workers can initialize args
+         * concurrently without blocking unrelated overmapbuffer reads.
+         */
+        mutable std::mutex mapgen_args_mutex_;
         /**
          * Common function used by the find_closest/all/random to determine if the location is
          * findable based on the specified criteria.

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -760,6 +760,7 @@ void overmap::unserialize( std::istream &fin, const std::string &file_path )
             jsin.skip_value();
         }
     }
+    sync_mapgen_args_init_flags();
 }
 
 static void unserialize_array_from_compacted_sequence( JsonIn &jsin, bool ( &array )[OMAPX][OMAPY] )


### PR DESCRIPTION
## Purpose of change (The Why)

Resolves #8517

3 crashes:
- overmapbuffer has a data race
- has_floor_or_support shouldn't check out of bounds
- field cache iteration could push_back on itself, invalidating it

## Describe the solution (The How)

- Use atomic + don't allow concurrent writes until after lock
- has_floor_or_support shouldn't check out of bounds
- Snapshot field cache

## Testing

I never had the crashes, but this *should* fix them.
I tested that it doesn't have new crashes at least.
The oob one was hard to know, since it was likely an NPC trying to climb out the top of a blimp at max height.

## Additional context

Hard to tell if there's a problem or if it's better, but an eye should be kept on perception of performance.