### PR TITLE
feat(balance): increase aim speed of reflex-type sights, increase dispersion of red-dot sight

### DIFF
--- a/data/json/items/gunmod/sights.json
+++ b/data/json/items/gunmod/sights.json
@@ -85,7 +85,7 @@
       [ "SPRAY_GUNS" ]
     ],
     "sight_dispersion": 13,
-    "aim_speed": 6,
+    "aim_speed": 9,
     "flags": [ "DISABLE_SIGHTS" ]
   },
   {
@@ -145,7 +145,7 @@
     "id": "red_dot_sight",
     "type": "GUNMOD",
     "name": { "str": "red dot sight" },
-    "description": "Adds a red dot optic to the top of your gun, replacing the iron sights.  Increases accuracy and weight.",
+    "description": "Adds a red dot optic to the top of your gun, replacing the iron sights.  Speeds up target acquisition.",
     "weight": "300 g",
     "volume": "250 ml",
     "integral_volume": "0 ml",
@@ -170,8 +170,8 @@
       [ "FLAMETHROWERS" ],
       [ "SPRAY_GUNS" ]
     ],
-    "sight_dispersion": 23,
-    "aim_speed": 6,
+    "sight_dispersion": 28,
+    "aim_speed": 9,
     "flags": [ "DISABLE_SIGHTS" ]
   },
   {
@@ -248,7 +248,7 @@
     ],
     "install_time": "30 m",
     "sight_dispersion": 8,
-    "aim_speed": 2,
+    "aim_speed": 6,
     "flags": [ "DISABLE_SIGHTS", "ZOOM" ]
   },
   {

--- a/data/json/items/gunmod/sights.json
+++ b/data/json/items/gunmod/sights.json
@@ -145,7 +145,7 @@
     "id": "red_dot_sight",
     "type": "GUNMOD",
     "name": { "str": "red dot sight" },
-    "description": "Adds a red dot optic to the top of your gun, replacing the iron sights.  Speeds up target acquisition.",
+    "description": "Adds a red dot optic to the top of your gun, replacing the iron sights.  Provides a balance of improved accuracy and faster target acquisition.",
     "weight": "300 g",
     "volume": "250 ml",
     "integral_volume": "0 ml",
@@ -170,7 +170,7 @@
       [ "FLAMETHROWERS" ],
       [ "SPRAY_GUNS" ]
     ],
-    "sight_dispersion": 28,
+    "sight_dispersion": 26,
     "aim_speed": 9,
     "flags": [ "DISABLE_SIGHTS" ]
   },


### PR DESCRIPTION
## Why

make them more like IRL dot sights which are for fast target acquisition

## How

- nerf red dot sight accuracy to be similar to iron sight
- make holographic sight and acog faster to aim

## Extra

I'm fine changing any values as long as dot sights make aiming faster