### PR TITLE
fix: field cache lightning catasrophe prevention

### DIFF
--- a/src/batch_turns.cpp
+++ b/src/batch_turns.cpp
@@ -102,20 +102,20 @@ void batch_turns_field( submap &sm, int n )
     } );
 
     // Compact + deduplicate — mirrors the same fix in process_fields_in_submap.
-    std::bitset<SEEX * SEEY> seen;
+    std::bitset<SEEX *SEEY> seen;
     sm.field_cache.erase(
-        std::ranges::remove_if( sm.field_cache, [&]( const point & local ) {
-            if( !sm.get_field( local ).displayed_field_type() ) {
-                return true;
-            }
-            const auto idx = static_cast<std::size_t>( local.x + local.y * SEEX );
-            if( seen.test( idx ) ) {
-                return true;
-            }
-            seen.set( idx );
-            return false;
-        } ).begin(),
-        sm.field_cache.end()
+    std::ranges::remove_if( sm.field_cache, [&]( const point & local ) {
+        if( !sm.get_field( local ).displayed_field_type() ) {
+            return true;
+        }
+        const auto idx = static_cast<std::size_t>( local.x + local.y * SEEX );
+        if( seen.test( idx ) ) {
+            return true;
+        }
+        seen.set( idx );
+        return false;
+    } ).begin(),
+    sm.field_cache.end()
     );
 }
 

--- a/src/batch_turns.cpp
+++ b/src/batch_turns.cpp
@@ -98,9 +98,15 @@ void batch_turns_field( submap &sm, int n )
         }
     } );
 
-    if( sm.field_count == 0 ) {
-        sm.field_cache.clear();
-    }
+    // Compact: remove positions whose fields have all decayed.
+    // Mirrors the same fix in process_fields_in_submap — prevents unbounded
+    // growth from persistent emitters cycling fields through death/recreation.
+    sm.field_cache.erase(
+        std::ranges::remove_if( sm.field_cache, [&]( const point & local ) {
+            return !sm.get_field( local ).displayed_field_type();
+        } ).begin(),
+        sm.field_cache.end()
+    );
 }
 
 void batch_turns_items( submap &sm, int n )

--- a/src/batch_turns.cpp
+++ b/src/batch_turns.cpp
@@ -1,11 +1,14 @@
 #include "batch_turns.h"
 
 #include <algorithm>
+#include <bitset>
+#include <cstddef>
 #include <ranges>
 
 #include "profile.h"
 
 #include "calendar.h"
+#include "game_constants.h"
 #include "field.h"
 #include "field_type.h"
 #include "item.h"
@@ -98,12 +101,19 @@ void batch_turns_field( submap &sm, int n )
         }
     } );
 
-    // Compact: remove positions whose fields have all decayed.
-    // Mirrors the same fix in process_fields_in_submap — prevents unbounded
-    // growth from persistent emitters cycling fields through death/recreation.
+    // Compact + deduplicate — mirrors the same fix in process_fields_in_submap.
+    std::bitset<SEEX * SEEY> seen;
     sm.field_cache.erase(
         std::ranges::remove_if( sm.field_cache, [&]( const point & local ) {
-            return !sm.get_field( local ).displayed_field_type();
+            if( !sm.get_field( local ).displayed_field_type() ) {
+                return true;
+            }
+            const auto idx = static_cast<std::size_t>( local.x + local.y * SEEX );
+            if( seen.test( idx ) ) {
+                return true;
+            }
+            seen.set( idx );
+            return false;
         } ).begin(),
         sm.field_cache.end()
     );

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -1769,13 +1769,30 @@ auto process_fields_in_submap( submap &sm,
         } // end field-entry loop
     } );
 
-    // Compact: remove positions whose fields have all died this tick.
-    // Without this, persistent emitters cause unbounded field_cache growth — each
-    // field creation/death cycle re-appends the same positions, since add_field()
-    // only pushes when a field is first created, not when it is refreshed.
+    // Compact + deduplicate the field_cache in one O(n) pass.
+    //
+    // Two failure modes fixed here:
+    //   1. Dead entries: a position is pushed when a field is first created, but
+    //      never removed when it dies.  The cache grows each creation/death cycle.
+    //   2. Duplicate live entries: when a bolt or spread effect adds a second field
+    //      type to a tile already in the cache, add_field() returns true (new type),
+    //      so the same position is pushed again.  The shock_vent state machine then
+    //      runs N times per tick instead of once, flooding the room with electricity.
+    //
+    // The bitset tracks which of the 144 submap tiles have already been kept so
+    // duplicates are discarded in the same pass that removes dead entries.
+    std::bitset<SEEX * SEEY> seen;
     sm.field_cache.erase(
         std::ranges::remove_if( sm.field_cache, [&]( const point & local ) {
-            return !sm.get_field( local ).displayed_field_type();
+            if( !sm.get_field( local ).displayed_field_type() ) {
+                return true;
+            }
+            const auto idx = static_cast<std::size_t>( local.x + local.y * SEEX );
+            if( seen.test( idx ) ) {
+                return true;
+            }
+            seen.set( idx );
+            return false;
         } ).begin(),
         sm.field_cache.end()
     );

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -1769,9 +1769,16 @@ auto process_fields_in_submap( submap &sm,
         } // end field-entry loop
     } );
 
-    if( sm.field_count == 0 ) {
-        sm.field_cache.clear();
-    }
+    // Compact: remove positions whose fields have all died this tick.
+    // Without this, persistent emitters cause unbounded field_cache growth — each
+    // field creation/death cycle re-appends the same positions, since add_field()
+    // only pushes when a field is first created, not when it is refreshed.
+    sm.field_cache.erase(
+        std::ranges::remove_if( sm.field_cache, [&]( const point & local ) {
+            return !sm.get_field( local ).displayed_field_type();
+        } ).begin(),
+        sm.field_cache.end()
+    );
 
     return has_fire;
 }

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -1781,20 +1781,20 @@ auto process_fields_in_submap( submap &sm,
     //
     // The bitset tracks which of the 144 submap tiles have already been kept so
     // duplicates are discarded in the same pass that removes dead entries.
-    std::bitset<SEEX * SEEY> seen;
+    std::bitset<SEEX *SEEY> seen;
     sm.field_cache.erase(
-        std::ranges::remove_if( sm.field_cache, [&]( const point & local ) {
-            if( !sm.get_field( local ).displayed_field_type() ) {
-                return true;
-            }
-            const auto idx = static_cast<std::size_t>( local.x + local.y * SEEX );
-            if( seen.test( idx ) ) {
-                return true;
-            }
-            seen.set( idx );
-            return false;
-        } ).begin(),
-        sm.field_cache.end()
+    std::ranges::remove_if( sm.field_cache, [&]( const point & local ) {
+        if( !sm.get_field( local ).displayed_field_type() ) {
+            return true;
+        }
+        const auto idx = static_cast<std::size_t>( local.x + local.y * SEEX );
+        if( seen.test( idx ) ) {
+            return true;
+        }
+        seen.set( idx );
+        return false;
+    } ).begin(),
+    sm.field_cache.end()
     );
 
     return has_fire;

--- a/src/submap.h
+++ b/src/submap.h
@@ -276,8 +276,8 @@ class submap : maptile_soa<SEEX, SEEY>
         // A stale entry is benign — it just costs a cheap branch on iteration.
         // trap_cache: positions of any non-null trap; rebuilt incrementally via set_trap.
         std::vector<point> trap_cache;
-        // field_cache: positions of tiles that have ever had a field added this load cycle.
-        // Append-only; cleared when field_count drops to zero after processing.
+        // field_cache: positions of tiles with active fields; compacted after each
+        // processing pass to remove positions whose fields have fully decayed.
         std::vector<point> field_cache;
         // TODO: A future improvement is to unify all per-tile dirty state into a 144-bit
         // bitmask (e.g. std::bitset<SEEX * SEEY> or three uint64_t words), one per category.


### PR DESCRIPTION
## Purpose of change (The Why)

Resolves #8572

## Describe the solution (The How)

Properly remove decayed fields
Remove duplicates of fields / emitters

## Describe alternatives you've considered

Reverting the field cache part of #8561

## Testing

I spawned 3 copies of the different stages of fd_shock_vent (what the generator uses to actually create fd_electricity) and it was still substantially less electric mayhem than it was before the fix.