### PR TITLE
fix: stop creature teleportation on returning to area

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1307,11 +1307,13 @@ void game::on_submap_unloaded( const tripoint_abs_sm &pos, const std::string &/*
     std::erase_if( active_npc, in_evicted );
 
     // Evict monsters whose absolute submap position matches the unloaded submap.
-    // get_map().getabs() is pure coordinate arithmetic — safe after the submap pointer is gone.
+    // Use critter.pos_abs (stamped before any shift by update_map) rather than
+    // recomputing via getabs(): during a map shift abs_sub is already updated when
+    // this fires, so getabs(local_pos) would produce a position displaced by 1 submap.
     // all_monsters() snapshots weak_ptrs at construction; despawn_monster() marks hp=0 so the
     // non_dead_range iterator skips evicted entries on subsequent steps, mirroring shift_monsters().
     for( monster &critter : all_monsters() ) {
-        const tripoint sm = ms_to_sm_copy( get_map().getabs( critter.pos() ) );
+        const tripoint sm = ms_to_sm_copy( critter.pos_abs.raw() );
         if( sm == raw ) {
             despawn_monster( critter );
         }
@@ -13735,6 +13737,19 @@ point game::update_map( int &x, int &y )
         return point_zero;
     }
 
+    // Stamp absolute positions for all active monsters before abs_sub changes.
+    // on_submap_unloaded fires after m.shift() updates abs_sub but before
+    // shift_monsters() adjusts local positions; using getabs() in that window
+    // produces a position displaced by 1 submap in the shift direction.
+    // shift_in_progress_ tells despawn_monster() to trust pos_abs as-is.
+    shift_in_progress_ = true;
+    // non_dead_range's iterator lacks the typedefs required by std::ranges concepts,
+    // so std::ranges::for_each cannot be used here — range-for matches all other
+    // all_monsters() call sites in the codebase.
+    for( monster &critter : all_monsters() ) {
+        critter.pos_abs = tripoint_abs_ms( get_map().getabs( critter.pos() ) );
+    }
+
     // this handles loading/unloading submaps that have scrolled on or off the viewport
     // NOLINTNEXTLINE(cata-use-named-point-constants)
     inclusive_rectangle<point> size_1( point( -1, -1 ), point( 1, 1 ) );
@@ -13785,6 +13800,7 @@ point game::update_map( int &x, int &y )
 
     // Shift monsters
     shift_monsters( tripoint( shift, 0 ) );
+    shift_in_progress_ = false;
     const point shift_ms = sm_to_ms_copy( shift );
     u.shift_destination( -shift_ms );
 
@@ -14097,10 +14113,14 @@ void game::update_stair_monsters()
 
 void game::despawn_monster( monster &critter )
 {
-    // Stamp absolute position while we still have a valid map context.
-    // despawn_monster() and on_submap_unloaded() eviction
-    // will use this instead of recomputing via get_map().
-    critter.pos_abs = tripoint_abs_ms( get_map().getabs( critter.pos() ) );
+    // During a map shift (shift_in_progress_), pos_abs was stamped by update_map()
+    // before abs_sub changed, so it is already correct.  Recomputing here would use
+    // the updated abs_sub with the not-yet-shifted local position and produce a value
+    // displaced by 1 submap in the shift direction.
+    // Outside of a shift, abs_sub and local position are consistent, so getabs() is correct.
+    if( !shift_in_progress_ ) {
+        critter.pos_abs = tripoint_abs_ms( get_map().getabs( critter.pos() ) );
+    }
     if( !critter.is_hallucination() ) {
         // hallucinations aren't stored, they come and go as they like,
         get_overmapbuffer( critter.get_dimension() ).despawn_monster( critter );

--- a/src/game.h
+++ b/src/game.h
@@ -1283,6 +1283,13 @@ class game : public submap_load_listener
         // Default 5 matches REALITY_BUBBLE_SIZE=2 (original 11×11 grid).
         int reality_bubble_radius_ = 5;
 
+        // True during the update_map() shift window: abs_sub has been updated by
+        // m.shift() but creature local positions have not yet been adjusted by
+        // shift_monsters().  despawn_monster() skips recomputing pos_abs in this
+        // window because the pre-shift stamp is already correct and getabs() would
+        // return a value displaced by 1 submap in the shift direction.
+        bool shift_in_progress_ = false;
+
     private:
         location_vector<item> fake_items;
     public:


### PR DESCRIPTION
## Purpose of change (The Why)

Entities would teleport by 12 tiles in a direction if you walked away, in that direction.

## Describe the solution (The How)

Fix map::shift with absolute position in mind in the correct order.

## Testing

Spawn a cow on a tile surrounded by air of 1 gap, so if they teleported by more than 1 tile, they'd be on a valid tile (otherwise they would despawn).
No longer occurs.