### PR TITLE
style: cleaned up ammo_pouch.json

### DIFF
--- a/data/json/items/armor/ammo_pouch.json
+++ b/data/json/items/armor/ammo_pouch.json
@@ -220,8 +220,8 @@
     "flags": [ "WATER_FRIENDLY", "BELTED", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS", "ALLOWS_HOOVES", "COMPACT" ]
   },
   {
-    "type": "ARMOR",
     "id": "legpouch_large",
+    "type": "ARMOR",
     "name": { "str": "leg magazine pouch", "str_pl": "leg magazine pouches" },
     "description": "A fabric ammo pouch that can be strapped to your leg and capable of holding two magazines close at hand.",
     "weight": "120 g",
@@ -251,8 +251,8 @@
     "flags": [ "WATER_FRIENDLY", "OVERSIZE", "BELTED", "COMPACT", "ALLOWS_TAIL_SNAKE" ]
   },
   {
-    "type": "ARMOR",
     "id": "mag_satchel_leg",
+    "type": "ARMOR",
     "copy-from": "legpouch_large",
     "name": { "str": "leg magazine satchel" },
     "description": "A fabric ammo pouch that can be strapped to the leg, capable of holding a single magazine, ammo belt, or speedloader of modest size.",


### PR DESCRIPTION
Leg magazine pouch and leg magazine satchel have had the "type": "ARMOR" tag moved below the "id" tag for ease of readability and to bring it in line with the rest of the file.