### PR TITLE
fix: prevent crash on force close

### DIFF
--- a/src/cata_arena.h
+++ b/src/cata_arena.h
@@ -12,8 +12,13 @@ class cata_arena
         std::set<T *> pending_deletion;
 
         static cata_arena<T> &get_instance() {
-            static cata_arena<T> instance;
-            return instance;
+            // Heap-allocated and never deleted — intentional. This avoids the static
+            // destruction order fiasco where MAPBUFFER_REGISTRY (a global) calls
+            // mark_for_destruction() during its own destruction, after a function-local
+            // static cata_arena would already be destroyed. The OS reclaims all process
+            // memory on exit, so not running ~cata_arena() is harmless.
+            static cata_arena<T> *instance = new cata_arena<T>();
+            return *instance;
         }
 
         void mark_for_destruction_internal( T *alloc ) {


### PR DESCRIPTION
## Purpose of change (The Why)

resolves #83395
resolves #83423
In all seriousness, fixes the crash that sometimes happens when you force close the game

## Describe the solution (The How)

Keep global singleton for cata_arena
I think this is safe because it's created on launch and obviously destroyed on close
No remaining programs in task manager, either

## Testing

I can't trigger the crash anymore