### PR TITLE
test: fix test failure due to sight rebalance

### DIFF
--- a/tests/ranged_balance_test.cpp
+++ b/tests/ranged_balance_test.cpp
@@ -290,7 +290,7 @@ TEST_CASE( "competent_shooter_accuracy", "[ranged] [balance]" )
     SECTION( "a skilled shooter with an accurate shotgun" ) {
         arm_character( shooter, "ksg", { "red_dot_sight" } );
         test_shooting_scenario( shooter, 9, 15, 33 );
-        test_fast_shooting( shooter, 75, 0.45 );
+        test_fast_shooting( shooter, 75, 0.5 );
     }
     SECTION( "a skilled shooter with an accurate smg" ) {
         arm_character( shooter, "hk_mp5", { "tele_sight" } );
@@ -324,7 +324,7 @@ TEST_CASE( "expert_shooter_accuracy", "[ranged] [balance]" )
     SECTION( "an expert archer with an excellent crossbow" ) {
         arm_character( shooter, "compcrossbow", { "holo_sight" }, "bolt_cf" );
         test_shooting_scenario( shooter, 12, 20, 100 );
-        test_fast_shooting( shooter, 30, 0.4 );
+        test_fast_shooting( shooter, 30, 0.45 );
     }
     SECTION( "an expert shooter with an excellent shotgun" ) {
         arm_character( shooter, "m1014", { "holo_sight" } );


### PR DESCRIPTION
## Purpose of change (The Why)

Continuation of #8582. The sight rebalance raised short-range hit rates for the KSG and compact crossbow ranged balance tests.

## Describe the solution (The How)

Update the two `test_fast_shooting` expectations to match the current weapon + sight balance.

## Testing

- `cmake --build --preset linux-full --target astyle cata_test-tiles`
- `./out/build/linux-full/tests/cata_test-tiles \"[ranged][balance]\"`

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<sup>PR opened by gpt-5.4 high on opencode</sup>