### PR TITLE
feat: jsonise weather_effect protection

### DIFF
--- a/data/json/weather_type.json
+++ b/data/json/weather_type.json
@@ -249,7 +249,12 @@
         "effect_msg_frequency": 3,
         "effect_msg_blocked_frequency": 32,
         "message_type": 3,
-        "protection_data": [ { "check": "RAIN_PROTECT", "odds": 1 }, { "check": "RAINPROOF", "odds": 1 }, { "check": "ACIDPROOF", "odds": 1}, { "check": "DEFAULT", "odds": 2 } ]
+        "protection_data": [
+          { "check": "RAIN_PROTECT", "odds": 1 },
+          { "check": "RAINPROOF", "odds": 1 },
+          { "check": "ACIDPROOF", "odds": 1 },
+          { "check": "DEFAULT", "odds": 2 }
+        ]
       }
     ],
     "animation": { "factor": 0.01, "color": "c_light_green", "glyph": ".", "tile": "weather_acid_drop" },
@@ -284,7 +289,12 @@
         "effect_msg_frequency": 1,
         "effect_msg_blocked_frequency": 32,
         "message_type": 1,
-        "protection_data": [ { "check": "RAIN_PROTECT", "odds": 1 }, { "check": "RAINPROOF", "odds": 1 }, { "check": "ACIDPROOF", "odds": 1}, { "check": "DEFAULT", "odds": 2 } ]
+        "protection_data": [
+          { "check": "RAIN_PROTECT", "odds": 1 },
+          { "check": "RAINPROOF", "odds": 1 },
+          { "check": "ACIDPROOF", "odds": 1 },
+          { "check": "DEFAULT", "odds": 2 }
+        ]
       }
     ],
     "animation": { "factor": 0.02, "color": "c_light_green", "glyph": ",", "tile": "weather_acid_drop" },

--- a/data/json/weather_type.json
+++ b/data/json/weather_type.json
@@ -245,13 +245,11 @@
         "effect_id_str": "acid_burn_pain_light",
         "effect_intensity": 0,
         "precipitation_name": "acidic drizzle",
-        "ignore_armor": false,
         "effect_msg": "The acidic drizzle burns, but is mostly harmless for now...",
         "effect_msg_frequency": 3,
         "effect_msg_blocked_frequency": 32,
         "message_type": 3,
-        "clothing_protection": 2,
-        "umbrella_protection": 1
+        "protection_data": [ { "check": "RAIN_PROTECT", "odds": 1 }, { "check": "RAINPROOF", "odds": 1 }, { "check": "ACIDPROOF", "odds": 1}, { "check": "DEFAULT", "odds": 2 } ]
       }
     ],
     "animation": { "factor": 0.01, "color": "c_light_green", "glyph": ".", "tile": "weather_acid_drop" },
@@ -282,13 +280,11 @@
         "effect_id_str": "acid_burn_pain",
         "effect_intensity": 0,
         "precipitation_name": "acid rain",
-        "ignore_armor": false,
         "effect_msg": "The acid rain burns your skin!",
         "effect_msg_frequency": 1,
         "effect_msg_blocked_frequency": 32,
         "message_type": 1,
-        "clothing_protection": 2,
-        "umbrella_protection": 1
+        "protection_data": [ { "check": "RAIN_PROTECT", "odds": 1 }, { "check": "RAINPROOF", "odds": 1 }, { "check": "ACIDPROOF", "odds": 1}, { "check": "DEFAULT", "odds": 2 } ]
       }
     ],
     "animation": { "factor": 0.02, "color": "c_light_green", "glyph": ",", "tile": "weather_acid_drop" },

--- a/data/mods/JP_Weather_Variants/weather_type.json
+++ b/data/mods/JP_Weather_Variants/weather_type.json
@@ -22,7 +22,7 @@
         "decay_start": "60 s",
         "morale_id_str": "morale_weather_rainbow",
         "morale_msg": "You stare in awe at the rainbow.",
-        "morale_msg_frequency": 8,
+        "morale_msg_frequency": 64,
         "message_type": 0
       }
     ],
@@ -65,7 +65,7 @@
         "decay_start": "60 s",
         "morale_id_str": "morale_weather_sundog",
         "morale_msg": "You stare in awe at the sundog and the ice crystals suspended in the air.",
-        "morale_msg_frequency": 8,
+        "morale_msg_frequency": 64,
         "message_type": 0
       }
     ],
@@ -109,7 +109,7 @@
         "decay_start": "60 s",
         "morale_id_str": "morale_weather_geomagnetic_lights",
         "morale_msg": "You stare in awe at the violent pink, green, and blue waves rippling across the sky.",
-        "morale_msg_frequency": 5,
+        "morale_msg_frequency": 64,
         "message_type": 0
       },
       {
@@ -119,13 +119,11 @@
         "effect_id_str": "emp",
         "effect_intensity": 0,
         "precipitation_name": "electromagnetic waves",
-        "ignore_armor": true,
         "effect_msg": "You feel an odd wave-like sensation pass through your body.",
         "effect_msg_frequency": 16,
         "effect_msg_blocked_frequency": 32,
         "message_type": 2,
-        "clothing_protection": 0,
-        "umbrella_protection": 0
+        "protection_data": []
       }
     ],
     "sun_intensity": "light",
@@ -166,7 +164,7 @@
         "decay_start": "60 s",
         "morale_id_str": "morale_weather_geomagnetic_lights",
         "morale_msg": "You stare in awe at the pink, green, and blue waves rippling across the sky.",
-        "morale_msg_frequency": 8,
+        "morale_msg_frequency": 64,
         "message_type": 0
       }
     ],
@@ -205,13 +203,11 @@
         "effect_id_str": "acid_burn_pain_light",
         "effect_intensity": 0,
         "precipitation_name": "acidic flurry",
-        "ignore_armor": false,
         "effect_msg": "The acidic snowflakes burn, but are mostly harmless for now...",
         "effect_msg_frequency": 3,
         "effect_msg_blocked_frequency": 32,
         "message_type": 3,
-        "clothing_protection": 2,
-        "umbrella_protection": 1
+        "protection_data": [ { "check": "RAIN_PROTECT", "odds": 1 }, { "check": "RAINPROOF", "odds": 1 }, { "check": "ACIDPROOF", "odds": 1}, { "check": "DEFAULT", "odds": 2 } ]
       }
     ],
     "animation": { "factor": 0.01, "color": "c_light_green", "glyph": ".", "tile": "weather_acid_snow" },
@@ -242,14 +238,12 @@
         "effect_id_str": "acid_burn_pain",
         "effect_intensity": 0,
         "precipitation_name": "acidic snowflakes",
-        "ignore_armor": false,
         "effect_msg": "The acidic snowflakes burn your skin as they melt!",
         "effect_msg_frequency": 1,
         "effect_msg_blocked_frequency": 32,
         "message_type": 1,
-        "clothing_protection": 2,
-        "umbrella_protection": 1
-      }
+        "protection_data": [ { "check": "RAIN_PROTECT", "odds": 1 }, { "check": "RAINPROOF", "odds": 1 }, { "check": "ACIDPROOF", "odds": 1}, { "check": "DEFAULT", "odds": 2 } ]
+     }
     ],
     "animation": { "factor": 0.02, "color": "c_light_green", "glyph": ".", "tile": "weather_acid_snow" },
     "sound_category": "flurries",
@@ -279,13 +273,11 @@
         "effect_id_str": "acid_burn_pain",
         "effect_intensity": 0,
         "precipitation_name": "acidic snowstorm",
-        "ignore_armor": false,
         "effect_msg": "The acidic snowflakes burn your skin as they melt!",
         "effect_msg_frequency": 1,
         "effect_msg_blocked_frequency": 32,
         "message_type": 1,
-        "clothing_protection": 2,
-        "umbrella_protection": 1
+        "protection_data": [ { "check": "RAIN_PROTECT", "odds": 1 }, { "check": "RAINPROOF", "odds": 1 }, { "check": "ACIDPROOF", "odds": 1}, { "check": "DEFAULT", "odds": 2 } ]
       }
     ],
     "animation": { "factor": 0.02, "color": "c_light_green", "glyph": ".", "tile": "weather_acid_snow" },

--- a/data/mods/JP_Weather_Variants/weather_type.json
+++ b/data/mods/JP_Weather_Variants/weather_type.json
@@ -123,7 +123,7 @@
         "effect_msg_frequency": 16,
         "effect_msg_blocked_frequency": 32,
         "message_type": 2,
-        "protection_data": []
+        "protection_data": [  ]
       }
     ],
     "sun_intensity": "light",
@@ -207,7 +207,12 @@
         "effect_msg_frequency": 3,
         "effect_msg_blocked_frequency": 32,
         "message_type": 3,
-        "protection_data": [ { "check": "RAIN_PROTECT", "odds": 1 }, { "check": "RAINPROOF", "odds": 1 }, { "check": "ACIDPROOF", "odds": 1}, { "check": "DEFAULT", "odds": 2 } ]
+        "protection_data": [
+          { "check": "RAIN_PROTECT", "odds": 1 },
+          { "check": "RAINPROOF", "odds": 1 },
+          { "check": "ACIDPROOF", "odds": 1 },
+          { "check": "DEFAULT", "odds": 2 }
+        ]
       }
     ],
     "animation": { "factor": 0.01, "color": "c_light_green", "glyph": ".", "tile": "weather_acid_snow" },
@@ -242,8 +247,13 @@
         "effect_msg_frequency": 1,
         "effect_msg_blocked_frequency": 32,
         "message_type": 1,
-        "protection_data": [ { "check": "RAIN_PROTECT", "odds": 1 }, { "check": "RAINPROOF", "odds": 1 }, { "check": "ACIDPROOF", "odds": 1}, { "check": "DEFAULT", "odds": 2 } ]
-     }
+        "protection_data": [
+          { "check": "RAIN_PROTECT", "odds": 1 },
+          { "check": "RAINPROOF", "odds": 1 },
+          { "check": "ACIDPROOF", "odds": 1 },
+          { "check": "DEFAULT", "odds": 2 }
+        ]
+      }
     ],
     "animation": { "factor": 0.02, "color": "c_light_green", "glyph": ".", "tile": "weather_acid_snow" },
     "sound_category": "flurries",
@@ -277,7 +287,12 @@
         "effect_msg_frequency": 1,
         "effect_msg_blocked_frequency": 32,
         "message_type": 1,
-        "protection_data": [ { "check": "RAIN_PROTECT", "odds": 1 }, { "check": "RAINPROOF", "odds": 1 }, { "check": "ACIDPROOF", "odds": 1}, { "check": "DEFAULT", "odds": 2 } ]
+        "protection_data": [
+          { "check": "RAIN_PROTECT", "odds": 1 },
+          { "check": "RAINPROOF", "odds": 1 },
+          { "check": "ACIDPROOF", "odds": 1 },
+          { "check": "DEFAULT", "odds": 2 }
+        ]
       }
     ],
     "animation": { "factor": 0.02, "color": "c_light_green", "glyph": ".", "tile": "weather_acid_snow" },

--- a/docs/en/mod/json/reference/map/weather_type.md
+++ b/docs/en/mod/json/reference/map/weather_type.md
@@ -87,7 +87,11 @@ Example effect:
   "effect_msg_frequency": 16, // chance to display this message every time the player is afflicted.
   "effect_msg_blocked_frequency": 32, // chance to display this message every time the player blocks the effect with clothing.
   "message_type": 2, // type of message to display: good, bad, mixed, etc.
-  "protection_data": [ { "check": "RAIN_PROTECT", "odds": 1 }, { "check": "ACIDPROOF", "odds": 1}, { "check": "DEFAULT", "odds": 2 } ] //Check is a flag/trait the player may have, odds is the one in x chance this flag/trait will protect the player from this weather effect.
+  "protection_data": [
+    { "check": "RAIN_PROTECT", "odds": 1 },
+    { "check": "ACIDPROOF", "odds": 1 },
+    { "check": "DEFAULT", "odds": 2 }
+  ] //Check is a flag/trait the player may have, odds is the one in x chance this flag/trait will protect the player from this weather effect.
   //"check": "DEFAULT" has special behaviour and will roll the one in x chance without checking if the player has a flag/trait actually called "DEFAULT"
 }
 ```

--- a/docs/en/mod/json/reference/map/weather_type.md
+++ b/docs/en/mod/json/reference/map/weather_type.md
@@ -82,14 +82,13 @@ Example effect:
   "effect_id_str": "emp",
   "effect_intensity": 0, // intensity of the effect applied.
   "precipitation_name": "brain waves", // name of precipitation to display when "The <PRECIPITATION> is blocked by your umbrella!" type messages display.
-  "ignore_armor": true, // ignores all protection.
   "bodypart_string": "head", // bodypart to apply the effect on.
   "effect_msg": "You feel an odd wave-like sensation pass through your head.", // message to display in chat when the player is afflicted
   "effect_msg_frequency": 16, // chance to display this message every time the player is afflicted.
   "effect_msg_blocked_frequency": 32, // chance to display this message every time the player blocks the effect with clothing.
   "message_type": 2, // type of message to display: good, bad, mixed, etc.
-  "clothing_protection": 0, // one in X chance to block precipitation.
-  "umbrella_protection": 0 // one in X chance to block precipitation.
+  "protection_data": [ { "check": "RAIN_PROTECT", "odds": 1 }, { "check": "ACIDPROOF", "odds": 1}, { "check": "DEFAULT", "odds": 2 } ] //Check is a flag/trait the player may have, odds is the one in x chance this flag/trait will protect the player from this weather effect.
+  //"check": "DEFAULT" has special behaviour and will roll the one in x chance without checking if the player has a flag/trait actually called "DEFAULT"
 }
 ```
 

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -522,19 +522,19 @@ void weather_effect::effect( int intensity, time_duration duration,
                              const std::string &effect_id_str,
                              const std::string &effect_msg, int effect_msg_frequency, int effect_msg_blocked_frequency,
                              game_message_type message_type,
-                             std::string precipitation_name, std::vector<std::tuple<std::string, int>> protection_data)
+                             std::string precipitation_name, std::vector<std::tuple<std::string, int>> protection_data )
 {
     if( !( calendar::once_every( time_duration::from_seconds( intensity ) ) && is_player_outside() ) ) {
         return;
     }
 
-    for (auto data : protection_data) {
+    for( auto data : protection_data ) {
         const std::string trait_or_flag = std::get<0>( data );
         const int odds = std::get<1>( data );
         std::string name;
 
-        if (trait_or_flag == "DEFAULT") {
-            //Special case: if the check string is equal to "DEFAULT" 
+        if( trait_or_flag == "DEFAULT" ) {
+            //Special case: if the check string is equal to "DEFAULT"
             // we dont check for any protection items
             name = "clothing";
         } else {
@@ -544,7 +544,7 @@ void weather_effect::effect( int intensity, time_duration duration,
             bool valid_trait = trait_id.is_valid();
             bool valid_flag = flag_id.is_valid();
 
-            if (!valid_trait && !valid_flag) {
+            if( !valid_trait && !valid_flag ) {
                 debugmsg( "Invalid trait or flag ID: %s", trait_or_flag.c_str() );
                 return;
             }
@@ -554,11 +554,11 @@ void weather_effect::effect( int intensity, time_duration duration,
 
             //Checking if a player has any applicable protection items
             //and resolving the name of that item if true
-            if ( valid_flag && you.item_worn_with_flag( flag_id ) != nullptr ) {
+            if( valid_flag && you.item_worn_with_flag( flag_id ) != nullptr ) {
                 name = you.item_worn_with_flag( flag_id )->tname();
-            } else if (valid_flag && held.has_flag( flag_id )) {
+            } else if( valid_flag && held.has_flag( flag_id ) ) {
                 name = held.tname();
-            } else if (valid_trait && you.has_trait( trait_id )) {
+            } else if( valid_trait && you.has_trait( trait_id ) ) {
                 name = trait_id->name();
             } else {
                 //Player lacks protection items, move to next entry
@@ -566,8 +566,8 @@ void weather_effect::effect( int intensity, time_duration duration,
             }
         }
 
-        if ( one_in(odds) ) {
-            if ( one_in(effect_msg_blocked_frequency) ) {
+        if( one_in( odds ) ) {
+            if( one_in( effect_msg_blocked_frequency ) ) {
                 add_msg( _( "Your %s protects you from the %s." ), name, precipitation_name );
             }
             return;

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -39,6 +39,7 @@
 #include "submap.h"
 #include "translations.h"
 #include "trap.h"
+#include "type_id.h"
 #include "units.h"
 #include "units_temperature.h"
 #include "vpart_position.h"
@@ -521,35 +522,53 @@ void weather_effect::effect( int intensity, time_duration duration,
                              const std::string &effect_id_str,
                              const std::string &effect_msg, int effect_msg_frequency, int effect_msg_blocked_frequency,
                              game_message_type message_type,
-                             std::string precipitation_name, bool ignore_armor, int clothing_protection,
-                             int umbrella_protection )
+                             std::string precipitation_name, std::vector<std::tuple<std::string, int>> protection_data)
 {
     if( !( calendar::once_every( time_duration::from_seconds( intensity ) ) && is_player_outside() ) ) {
         return;
     }
 
-    if( !ignore_armor ) {
-        auto &you = get_avatar();
-        bool has_helmet = false;
-        if( one_in( umbrella_protection ) && you.primary_weapon().has_flag( json_flag_RAIN_PROTECT ) ) {
-            if( one_in( effect_msg_blocked_frequency ) ) {
-                add_msg( _( "Your umbrella protects you from the %s." ), precipitation_name );
+    for (auto data : protection_data) {
+        const std::string trait_or_flag = std::get<0>( data );
+        const int odds = std::get<1>( data );
+        std::string name;
+
+        if (trait_or_flag == "DEFAULT") {
+            //Special case: if the check string is equal to "DEFAULT" 
+            // we dont check for any protection items
+            name = "clothing";
+        } else {
+            const trait_id trait_id( trait_or_flag );
+            const flag_id flag_id( trait_or_flag );
+
+            bool valid_trait = trait_id.is_valid();
+            bool valid_flag = flag_id.is_valid();
+
+            if (!valid_trait && !valid_flag) {
+                debugmsg( "Invalid trait or flag ID: %s", trait_or_flag.c_str() );
+                return;
             }
-            return;
-        } else if( one_in( umbrella_protection ) && you.worn_with_flag( json_flag_RAINPROOF ) ) {
-            if( one_in( effect_msg_blocked_frequency ) ) {
-                add_msg( _( "Your rainproof clothing protects you from the %s." ), precipitation_name );
+
+            auto &you = get_avatar();
+            auto held = you.primary_weapon();
+
+            //Checking if a player has any applicable protection items
+            //and resolving the name of that item if true
+            if ( valid_flag && you.item_worn_with_flag( flag_id ) != nullptr ) {
+                name = you.item_worn_with_flag( flag_id )->tname();
+            } else if (valid_flag && held.has_flag( flag_id )) {
+                name = held.tname();
+            } else if (valid_trait && you.has_trait( trait_id )) {
+                name = trait_id->name();
+            } else {
+                //Player lacks protection items, move to next entry
+                continue;
             }
-            return;
-        } else if( one_in( clothing_protection ) ) {
-            if( one_in( effect_msg_blocked_frequency ) ) {
-                add_msg( _( "Your clothing protects you from the %s." ), precipitation_name );
-            }
-            return;
-        } else if( you.is_wearing_power_armor( &has_helmet ) && ( has_helmet ||
-                   !one_in( clothing_protection ) ) ) {
-            if( one_in( effect_msg_blocked_frequency ) ) {
-                add_msg( _( "Your power armor protects you from the %s." ), precipitation_name );
+        }
+
+        if ( one_in(odds) ) {
+            if ( one_in(effect_msg_blocked_frequency) ) {
+                add_msg( _( "Your %s protects you from the %s." ), name, precipitation_name );
             }
             return;
         }

--- a/src/weather.h
+++ b/src/weather.h
@@ -81,8 +81,7 @@ void effect( int intensity, time_duration duration, bodypart_str_id bp_id,
              const std::string &effect_id_str,
              const std::string &effect_msg,
              int effect_msg_frequency, int effect_msg_blocked_frequency, game_message_type message_type,
-             std::string precipitation_name,
-             bool ignore_armor, int clothing_protection, int umbrella_protection );
+             std::string precipitation_name, std::vector<std::tuple<std::string, int>>);
 void morale( int intensity, int bonus, int bonus_max, time_duration duration,
              time_duration decay_start,
              const std::string &morale_id_str, const std::string &morale_msg,

--- a/src/weather.h
+++ b/src/weather.h
@@ -81,7 +81,7 @@ void effect( int intensity, time_duration duration, bodypart_str_id bp_id,
              const std::string &effect_id_str,
              const std::string &effect_msg,
              int effect_msg_frequency, int effect_msg_blocked_frequency, game_message_type message_type,
-             std::string precipitation_name, std::vector<std::tuple<std::string, int>>);
+             std::string precipitation_name, std::vector<std::tuple<std::string, int>> );
 void morale( int intensity, int bonus, int bonus_max, time_duration duration,
              time_duration decay_start,
              const std::string &morale_id_str, const std::string &morale_msg,

--- a/src/weather_type.cpp
+++ b/src/weather_type.cpp
@@ -6,6 +6,8 @@
 #include "bodypart.h"
 #include "weather.h"
 
+//#include "itype.h"
+
 namespace
 {
 generic_factory<weather_type> weather_type_factory( "weather_type" );
@@ -177,8 +179,8 @@ void weather_type::load( const JsonObject &jo, const std::string & )
         if( name == "effect" ) {
             std::string id_str = weather_effect.get_string( "effect_id_str" );
             std::string msg = weather_effect.get_string( "effect_msg" );
-            int freq = weather_effect.get_int( "effect_msg_frequency" );
-            int blocked_freq = weather_effect.get_int( "effect_msg_blocked_frequency" );
+            int msg_freq = weather_effect.get_int( "effect_msg_frequency" );
+            int msg_blocked_freq = weather_effect.get_int( "effect_msg_blocked_frequency" );
             int effect_intensity = weather_effect.get_int( "effect_intensity" );
             std::string bodypart_string = weather_effect.get_string( "bodypart_string", "" );
             time_duration duration = read_from_json_string<time_duration>
@@ -191,17 +193,29 @@ void weather_type::load( const JsonObject &jo, const std::string & )
             }
 
             std::string precipitation_name = weather_effect.get_string( "precipitation_name" );
-            bool ignore_armor = weather_effect.get_bool( "ignore_armor" );
+            std::vector<std::tuple<std::string, int>> protection_data;
+
+            for( const JsonValue entry : weather_effect.get_array( "protection_data" ) ) {
+                std::string check;
+                int odds = 0;
+                if( entry.test_object() ) {
+                    JsonObject jc = entry.get_object();
+                    check = jc.get_string( "check", "" );
+                    odds = jc.get_int( "odds", 0 );
+                }
+                if( check != "" && odds > 0 ) {
+                   protection_data.emplace_back( check, odds);
+                }
+            }
+
             int message_type = weather_effect.get_int( "message_type" );
-            int clothing_protection = weather_effect.get_int( "clothing_protection" );
-            int umbrella_protection = weather_effect.get_int( "umbrella_protection" );
             game_message_type gmt = static_cast<game_message_type>( message_type );
 
             effects.emplace_back(
             [ = ]( int intensity ) {
                 weather_effect::effect( intensity, duration, bp_id, effect_intensity, id_str, msg,
-                                        freq, blocked_freq,
-                                        gmt, precipitation_name, ignore_armor, clothing_protection, umbrella_protection );
+                                        msg_freq, msg_blocked_freq,
+                                        gmt, precipitation_name, protection_data);
             },
             intensity
             );

--- a/src/weather_type.cpp
+++ b/src/weather_type.cpp
@@ -202,7 +202,7 @@ void weather_type::load( const JsonObject &jo, const std::string & )
                     odds = jc.get_int( "odds", 0 );
                 }
                 if( check != "" && odds > 0 ) {
-                   protection_data.emplace_back( check, odds);
+                    protection_data.emplace_back( check, odds );
                 }
             }
 
@@ -213,7 +213,7 @@ void weather_type::load( const JsonObject &jo, const std::string & )
             [ = ]( int intensity ) {
                 weather_effect::effect( intensity, duration, bp_id, effect_intensity, id_str, msg,
                                         msg_freq, msg_blocked_freq,
-                                        gmt, precipitation_name, protection_data);
+                                        gmt, precipitation_name, protection_data );
             },
             intensity
             );

--- a/src/weather_type.cpp
+++ b/src/weather_type.cpp
@@ -6,8 +6,6 @@
 #include "bodypart.h"
 #include "weather.h"
 
-//#include "itype.h"
-
 namespace
 {
 generic_factory<weather_type> weather_type_factory( "weather_type" );


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

The way weather effects handle protection (or immunity) from said effect is kind of a mess and also hardcoded entirely

umbrella_protection despite its name is the odds of an item with the RAIN_PROTECT (umbrellas) flag or the RAINPROOF (raincoats) flag actually protecting you, and theres no way for these flags to have different odds of protecting you

clothing_protection is the odds of you being protected from the weather effect when you lack any items with the above flags

ignore armor simply skips all these checks

theres absolutely no way for a modder to check for a different flag or even a trait

and the protection messages dont actually show *what* protected you from the weather effect

## Describe the solution (The How)

Rip out umbrella_protection, clothing_protection and ignore_armor

replace it with protection_data, which allows a modder to individually specify a trait or flag that can protect the player from this weather effect, and the odds of that trait/flag protecting the player from the weather effect

protection_data does have special behaviour, if "DEFAULT" is used in place of a trait/flag, then the odds of being protected from the weather effect are rolled without checking if the player has a trait/flag called "DEFAULT"

migrates all weather_effect entrys over to using protection_data, 
and additionally adjusts acid rain so that the acidproof trait grants immunity to said acid rain

note that protection_data doesnt actually need to contain any data if a modder does not wish for the weather effect to have anything that can actually protect against it

additionally prints the name of the item or trait that protected the player from the current weather effect

and also entirely unrelated from the above
 reduces the odds of jp_weathers morale weather from showing a chat message because chat spam bad

fixes https://github.com/cataclysmbn/Cataclysm-BN/issues/7555
fixes https://github.com/cataclysmbn/Cataclysm-BN/issues/7558
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
- not doing this

- making the adjustments to the jp morale weathers in a seperate pr
could but I figure I might as well just do it as I need to update the jp weathers to use protection_data anyway

## Testing
Booted up the game, made sure RAIN_PROTECT and RAINPROOF clothing gave immunity to acid rain
also checked that the ACIDPROOF trait gave immunity to acid rain
verified the protection messages displayed what actually protected you from the weather
verified acid rain has a 50% chance to effect you if you have no protective items

also verified acid snowstorms and geostorms from jp_weathers still function correctly

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

this really probably wasnt worth the effort but oh well

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

<!-- please remove checkboxes unrelated to this PR. -->

- [x] This is a C++ PR that modifies JSON loading or behavior.
  - [x] I have documented the changes in the appropriate location in the `docs/` folder.
  - [x] If applicable, add checks on game load that would validate the loaded data.