### PR TITLE
feat(balance): rebalance and implement VTOL thruster, add Harriers

### DIFF
--- a/data/json/vehicle_groups.json
+++ b/data/json/vehicle_groups.json
@@ -731,6 +731,7 @@
     "vehicles": [
       [ "plane_small", 500 ],
       [ "plane_f35_lightning", 25 ],
+      [ "plane_av8_harrier", 5 ],
       [ "2seater2", 100 ],
       [ "SmallFlier1", 300 ],
       [ "2seater2_Wreck", 100 ],
@@ -1158,9 +1159,10 @@
     "type": "vehicle_group",
     "id": "aircraft_carrier_flight_deck",
     "vehicles": [
-      [ "plane_f35_lightning", 30 ],
+      [ "plane_f35_lightning", 25 ],
+      [ "plane_av8_harrier", 10 ],
       [ "helicopter_apache_1a", 5 ],
-      [ "helicopter_apache_1b", 15 ],
+      [ "helicopter_apache_1b", 10 ],
       [ "helicopter_apache_1c", 10 ],
       [ "helicopter_osprey_2c", 15 ],
       [ "helicopter_osprey_2b", 10 ],

--- a/data/json/vehicleparts/jets.json
+++ b/data/json/vehicleparts/jets.json
@@ -17,7 +17,7 @@
     "durability": 120,
     "damage_modifier": 80,
     "breaks_into": [ { "item": "scrap", "count": [ 10, 20 ] } ],
-    "flags": [ "PROPELLER", "PROTUSION", "SHOCK_RESISTANT" ],
+    "flags": [ "PROPELLER", "SHOCK_RESISTANT" ],
     "damage_reduction": { "bash": 10 }
   },
   {
@@ -39,18 +39,17 @@
     "broken_symbol": "x",
     "color": "light_gray",
     "rotor_diameter": 16,
+    "propeller_diameter": 8,
     "requirements": {
       "install": { "skills": [ [ "mechanics", 7 ] ], "time": "60 m", "using": [ [ "welding_standard", 20 ] ] },
       "removal": { "skills": [ [ "mechanics", 7 ] ], "time": "60 m", "using": [ [ "vehicle_weld_removal", 10 ] ] },
       "repair": { "skills": [ [ "mechanics", 8 ] ], "time": "60 m", "using": [ [ "welding_standard", 20 ] ] }
     },
     "durability": 350,
-    "wheel_type": "off-road",
-    "contact_area": 20,
-    "description": "This is a vertical takeoff and landing (VTOL) propulsion system used in military VTOL aircraft and large transport drones.  It allows for free takeoff and landing on land, at sea, or in the air.",
+    "description": "This is a vertical takeoff and landing (VTOL) propulsion system used in military VTOL aircraft and large transport drones.  It provides both lift for taking off and thrust when in the air.",
     "damage_modifier": 50,
     "breaks_into": [ { "item": "scrap", "count": [ 15, 30 ] }, { "item": "steel_chunk", "count": [ 8, 16 ] } ],
-    "flags": [ "BALLOON", "WHEEL", "FLOATS", "ROTOR", "STABLE", "SELF_JACK", "VARIABLE_SIZE", "TRACKED" ],
+    "flags": [ "ROTOR", "PROPELLER", "SHOCK_RESISTANT" ],
     "damage_reduction": { "all": 35 }
   },
   {

--- a/data/json/vehicleparts/jets.json
+++ b/data/json/vehicleparts/jets.json
@@ -38,8 +38,8 @@
     "symbol": "O",
     "broken_symbol": "x",
     "color": "light_gray",
-    "rotor_diameter": 16,
-    "propeller_diameter": 8,
+    "rotor_diameter": 5,
+    "propeller_diameter": 5,
     "requirements": {
       "install": { "skills": [ [ "mechanics", 7 ] ], "time": "60 m", "using": [ [ "welding_standard", 20 ] ] },
       "removal": { "skills": [ [ "mechanics", 7 ] ], "time": "60 m", "using": [ [ "vehicle_weld_removal", 10 ] ] },

--- a/data/json/vehicles/aircraft_other.json
+++ b/data/json/vehicles/aircraft_other.json
@@ -859,13 +859,7 @@
       "=": [ "xlframe_vertical", "carbon_halfboard_horizontal", "wing_carbon_horizontal" ],
       "B": [ "xlframe_vertical", "trunk_carbon", "bomber controls", "wing_carbon_horizontal" ],
       "b": [ "xlframe_vertical", "trunk_carbon", "bomber controls", "wheel_mount_light", "wheel_small", "wing_carbon_horizontal" ],
-      "E": [
-        "xlframe_vertical",
-        "carbon_halfboard_vertical",
-        "engine_turbine_medium",
-        "alternator_car",
-        "medium_storage_battery"
-      ],
+      "E": [ "xlframe_vertical", "carbon_halfboard_vertical", "engine_turbine_medium", "alternator_car", "medium_storage_battery" ],
       "F": [
         "xlframe_vertical",
         "trunk_carbon",
@@ -873,7 +867,14 @@
         "bomber controls",
         "wing_carbon_horizontal"
       ],
-      "G": [ "xlframe_vertical", "carbon_halfboard_horizontal", "wheel_mount_medium", "wheel", { "part": "tank_30gal_drum", "fuel": "jp8" }, "wing_carbon_horizontal" ],
+      "G": [
+        "xlframe_vertical",
+        "carbon_halfboard_horizontal",
+        "wheel_mount_medium",
+        "wheel",
+        { "part": "tank_30gal_drum", "fuel": "jp8" },
+        "wing_carbon_horizontal"
+      ],
       "S": [
         "xlframe_vertical",
         "seat",
@@ -885,10 +886,7 @@
         "tracker",
         "roof"
       ],
-      "T": [         "xlframe_vertical",
-        "carbon_halfboard_vertical",
-        "vtol_thruster"
- ],
+      "T": [ "xlframe_vertical", "carbon_halfboard_vertical", "vtol_thruster" ],
       "1": [ "xlframe_vertical", "windshield_sw" ],
       "2": [ "xlframe_vertical", "windshield_horizontal_rear", "wheel_mount_medium_steerable", "wheel" ],
       "3": [ "xlframe_vertical", "windshield_se" ],

--- a/data/json/vehicles/aircraft_other.json
+++ b/data/json/vehicles/aircraft_other.json
@@ -786,7 +786,7 @@
       "E": [
         "xlframe_vertical",
         "carbon_halfboard_vertical",
-        "engine_turbine_small",
+        "engine_turbine_large",
         "alternator_car",
         "medium_storage_battery",
         "wing_carbon_horizontal"
@@ -837,6 +837,89 @@
       { "x": -3, "y": -1, "chance": 50, "items": [ "aerial_bomb" ] },
       { "x": -2, "y": 1, "chance": 50, "items": [ "aerial_bomb" ] },
       { "x": -3, "y": 1, "chance": 50, "items": [ "aerial_bomb" ] }
+    ]
+  },
+  {
+    "id": "plane_av8_harrier",
+    "type": "vehicle",
+    "name": "AV-8 Harrier",
+    "blueprint": [
+      "  |&       ",
+      "  |b!      ",
+      "! |B=--147 ",
+      "|-=FGET2S8>",
+      "# |B=--369 ",
+      "  |b#      ",
+      "  |(       "
+    ],
+    "blueprint_origin": { "x": 8, "y": 3 },
+    "palette": {
+      "-": [ "xlframe_vertical", "carbon_halfboard_vertical" ],
+      ">": [ "xlframe_vertical", "carbon_halfboard_cover" ],
+      "=": [ "xlframe_vertical", "carbon_halfboard_horizontal", "wing_carbon_horizontal" ],
+      "B": [ "xlframe_vertical", "trunk_carbon", "bomber controls", "wing_carbon_horizontal" ],
+      "b": [ "xlframe_vertical", "trunk_carbon", "bomber controls", "wheel_mount_light", "wheel_small", "wing_carbon_horizontal" ],
+      "E": [
+        "xlframe_vertical",
+        "carbon_halfboard_vertical",
+        "engine_turbine_medium",
+        "alternator_car",
+        "medium_storage_battery"
+      ],
+      "F": [
+        "xlframe_vertical",
+        "trunk_carbon",
+        { "part": "tank_30gal_drum", "fuel": "jp8" },
+        "bomber controls",
+        "wing_carbon_horizontal"
+      ],
+      "G": [ "xlframe_vertical", "carbon_halfboard_horizontal", "wheel_mount_medium", "wheel", { "part": "tank_30gal_drum", "fuel": "jp8" }, "wing_carbon_horizontal" ],
+      "S": [
+        "xlframe_vertical",
+        "seat",
+        "seatbelt_heavyduty",
+        "controls",
+        "dashboard",
+        "black_box",
+        "programmable_autopilot",
+        "tracker",
+        "roof"
+      ],
+      "T": [         "xlframe_vertical",
+        "carbon_halfboard_vertical",
+        "vtol_thruster"
+ ],
+      "1": [ "xlframe_vertical", "windshield_sw" ],
+      "2": [ "xlframe_vertical", "windshield_horizontal_rear", "wheel_mount_medium_steerable", "wheel" ],
+      "3": [ "xlframe_vertical", "windshield_se" ],
+      "4": [ "xlframe_vertical", "door_vertical_left" ],
+      "6": [ "xlframe_vertical", "door_vertical_right" ],
+      "7": [
+        "xlframe_nw",
+        "windshield_nw",
+        "turret_mount",
+        {
+          "part": "mounted_25mm_autocannon",
+          "ammo": 80,
+          "ammo_types": [ "25mm_apds", "25mm_hei" ],
+          "ammo_qty": [ 10, 50 ]
+        }
+      ],
+      "8": [ "xlframe_vertical", "windshield_horizontal_front" ],
+      "9": [ "xlframe_ne", "windshield_ne" ],
+      "|": [ "wing_carbon_external_horizontal" ],
+      "!": [ "wing_carbon_external_left" ],
+      "&": [ "lit_wing_carbon_external_left" ],
+      "#": [ "wing_carbon_external_right" ],
+      "(": [ "lit_wing_carbon_external_right" ]
+    },
+    "items": [
+      { "x": 0, "y": 0, "chance": 100, "item_groups": [ "pilot_bail_kit" ] },
+      { "x": -5, "y": -2, "chance": 50, "items": [ "aerial_bomb" ] },
+      { "x": -5, "y": -1, "chance": 50, "items": [ "aerial_bomb" ] },
+      { "x": -5, "y": 0, "chance": 50, "items": [ "aerial_bomb" ] },
+      { "x": -5, "y": 1, "chance": 50, "items": [ "aerial_bomb" ] },
+      { "x": -5, "y": 2, "chance": 50, "items": [ "aerial_bomb" ] }
     ]
   }
 ]


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

This rebalances and implements VTOL thrusters, with some other associated changes to related vehicles.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. Tweaked VTOL thrusters to count as as rotors and propellers instead of counting as a balloon, wheel, and rotor. Propeller data made a bit worse than a jet thruster and rotor data twice that of its propeller strength, making it a jack of all trades thruster.
2. Added a Harrier jet, basically a slower VTOL strike aircraft to contrast with the F-35 getting to be faster but limited to standard takeoff and a couple less slots for bombs.
3. Added Harriers to relevant vehicle groups.
4. Misc: Upgraded F-35's turbine engine from small to large, to let it have more spicy speed over the Harrier.
5. Misc: Removed `PROTRUSION` from non-external jet thrusters.

## Describe alternatives you've considered

Changing osprey rotors to also double as propellers, since they're tiltrotors IRL. Main issue I found with that was doing that just casuaslly gave the Osprey an airspeed over 1000 MPH no matter how low I set the propeller radius. XD

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Ported JSON changes to playthrough build and load-tested.
3. Confirmed Harrier looks as intended when spawned.
4. Confirmed F-35 has a stupid high airspeed (over 700 MPH), while Harrier has a more reasonable airspeed.

Minor oddity: a vehicle that uses wings but has enough rotor lift to VTOL unassisted displays a massive negative number for its takeoff speed.
<img width="320" height="28" alt="goofy thing" src="https://github.com/user-attachments/assets/66a967f8-9461-4252-9629-5d00b480f5b9" />

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

<img width="879" height="493" alt="image" src="https://github.com/user-attachments/assets/f669c89a-ed79-451a-aa87-12c3132ac036" />

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
