### PR TITLE
fix(balance): fix accidental override of autocannon turret, tone down dispersion of rotary cannon

### DIFF
--- a/data/json/items/gun/tankguns.json
+++ b/data/json/items/gun/tankguns.json
@@ -94,6 +94,7 @@
     "looks_like": "m134",
     "ammo": "25mm",
     "durability": 9,
+    "dispersion": 50,
     "modes": [ [ "DEFAULT", "auto", 10 ] ],
     "reload": 500,
     "ups_charges": 12,

--- a/data/json/vehicleparts/turret.json
+++ b/data/json/vehicleparts/turret.json
@@ -1041,7 +1041,7 @@
   },
   {
     "type": "vehicle_part",
-    "id": "mounted_25mm_autocannon",
+    "id": "mounted_25mm_rotary_cannon",
     "looks_like": "mounted_m134",
     "copy-from": "turret_tank",
     "name": "25mm rotary cannon",

--- a/data/json/vehicles/aircraft_other.json
+++ b/data/json/vehicles/aircraft_other.json
@@ -816,7 +816,7 @@
         "windshield_nw",
         "turret_mount",
         {
-          "part": "mounted_25mm_autocannon",
+          "part": "mounted_25mm_rotary_cannon",
           "ammo": 80,
           "ammo_types": [ "25mm_apds", "25mm_hei" ],
           "ammo_qty": [ 10, 50 ]
@@ -897,7 +897,7 @@
         "windshield_nw",
         "turret_mount",
         {
-          "part": "mounted_25mm_autocannon",
+          "part": "mounted_25mm_rotary_cannon",
           "ammo": 80,
           "ammo_types": [ "25mm_apds", "25mm_hei" ],
           "ammo_qty": [ 10, 50 ]


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

This separates out some minor JSON stuff from some other C++ stuff I was tinkering with, as I spotted an important fix I had to do.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. Fixed rotary cannon turret having the same ID as the chaingun, causing it to override the mounted bushmaster entirely.
2. Accordingly fixed ID used by the planes.
3. Overrode dispersion for the GAU to not inherit from the gatling abstract, instead gaining a base dispersion between that of the bushmaster and its stripped-down version.

## Describe alternatives you've considered

screm

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

Used my fucking eeeeyyyyeeees

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
