### PR TITLE
feat(UI): more zombie evolution options

### DIFF
--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -421,13 +421,16 @@ int monster::next_upgrade_time()
     }
     const int scaled_half_life = type->half_life * get_option<float>( "MONSTER_UPGRADE_FACTOR" );
     int day = 1; // 1 day of guaranteed evolve time
-    for( int i = 0; i < UPGRADE_MAX_ITERS; i++ ) {
+    for( int i = 0; i < get_option<int>( "EVOLVE_MAX_ITERS" ); i++ ) {
         if( one_in( 2 ) ) {
             day += rng( 0, scaled_half_life );
             return day;
         } else {
             day += scaled_half_life;
         }
+    }
+    if( get_option<bool>( "ALWAYS_EVOLVE" ) && day >= 0 ) {
+        return day;
     }
     // didn't manage to upgrade, shouldn't ever then
     upgrades = false;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2805,6 +2805,16 @@ void options_manager::add_options_world_default()
          0.0, 100, 2.0, 0.01
        );
 
+    add( "EVOLVE_MAX_ITERS", world_default,
+         translate_marker( "Maximum Evolution Half Lives" ),
+         translate_marker( "The maximum number of attempts for a zombie to evolve at the next half life for one evolution stage" ),
+         0, 200, 5 );
+
+    add( "ALWAYS_EVOLVE", world_default,
+         translate_marker( "Zombies Always Evolve" ),
+         translate_marker( "When reaching the maximum half lives, instead of never evolving they will evolve at that time." ),
+         false );
+
     add_empty_line();
 
     add( "RESTOCK_DELAY_MULT", world_default, translate_marker( "Merchant restock scaling factor" ),


### PR DESCRIPTION
## Purpose of change (The Why)
People want more options
Seemed easy enough

## Describe the solution (The How)
Optionify the 5 and make it so that zombies are forced to mutate

## Describe alternatives you've considered
More options?
Increase default?

## Testing
Loaded world
Appeared all zombies mutated after enough time
I scrungle

## Additional context
~~I dont get distracted guys trust me here~~

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.