### PR TITLE
feat: keycard readers now work for opening extended doors

### DIFF
--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -52,6 +52,7 @@
 #include "event_bus.h"
 #include "field_type.h"
 #include "flat_set.h"
+#include "flood_fill.h"
 #include "fungal_effects.h"
 #include "game.h"
 #include "game_constants.h"
@@ -1124,8 +1125,13 @@ void iexamine::cardreader( player &p, const tripoint &examp )
         p.mod_moves( -to_turns<int>( 1_seconds ) );
         for( const tripoint &tmp : here.points_in_radius( examp, 3 ) ) {
             if( here.ter( tmp ) == t_door_metal_locked ) {
-                here.ter_set( tmp, t_door_metal_c );
-                open = true;
+                const auto is_door = [&here]( const tripoint & pos ) -> bool { return here.ter( pos ) == t_door_metal_locked; };
+
+                std::unordered_set<tripoint> visited;
+                for( const tripoint &tmp2 : ff::point_flood_fill_4_connected( tmp, visited, is_door ) ) {
+                    here.ter_set( tmp2, t_door_metal_c );
+                    open = true;
+                }
             }
         }
         for( monster &critter : g->all_monsters() ) {


### PR DESCRIPTION
## Purpose of change (The Why)
Military airfield needed it

## Describe the solution (The How)
Search for doors like elevator search

## Describe alternatives you've considered
Unhardcode a lot more about keycard readers
Like how it is for levers

## Testing
Keycard reader in [the military airfield](https://discord.com/channels/830879262763909202/830916451517857894/1497081405799268554) now works for the full gate

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.