### PR TITLE
feat(balance): remove dispersion debuff from muzzle break

### DIFF
--- a/data/json/items/gunmod/muzzle.json
+++ b/data/json/items/gunmod/muzzle.json
@@ -40,7 +40,7 @@
     "color": "light_gray",
     "location": "muzzle",
     "mod_target_category": [ [ "RIFLES" ], [ "MACHINE_GUNS" ], [ "GATLING_GUNS" ], [ "SHOTGUNS" ] ],
-    "dispersion_modifier": 25,
+    "dispersion_modifier": 0,
     "handling_modifier": 10,
     "loudness_modifier": 30
   },

--- a/data/json/items/gunmod/muzzle.json
+++ b/data/json/items/gunmod/muzzle.json
@@ -40,7 +40,6 @@
     "color": "light_gray",
     "location": "muzzle",
     "mod_target_category": [ [ "RIFLES" ], [ "MACHINE_GUNS" ], [ "GATLING_GUNS" ], [ "SHOTGUNS" ] ],
-    "dispersion_modifier": 0,
     "handling_modifier": 10,
     "loudness_modifier": 30
   },

--- a/data/json/items/gunmod/muzzle.json
+++ b/data/json/items/gunmod/muzzle.json
@@ -30,7 +30,7 @@
     "id": "muzzle_brake",
     "type": "GUNMOD",
     "name": { "str": "muzzle brake" },
-    "description": "A muzzle brake redirects exhaust gases to compensate for muzzle climb, improving recoil but increasing bulk, noise, and reducing accuracy slightly.",
+    "description": "A muzzle brake redirects exhaust gases to compensate for muzzle climb, improving recoil but increasing bulk and noise.",
     "weight": "380 g",
     "volume": "250 ml",
     "price": "840 USD",


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
The muzzle break is harder to craft and by default can be fitted to less weapons than the ported barrel, yet it has worse stats.
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Removes the dispersion debuff from the muzzle break to make it more fitting for something that takes 8 mechanics to craft vs 6 mechanics to craft. Makes sense anyway, as most muzzle breaks don't directly decrease accuracy.
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
Having the harder to craft item weaker

## Testing
Debug spawned in, seemed fine
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context
Here's to you den-den
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.