### PR TITLE
fix: musical instruments display correctly

### DIFF
--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -2566,9 +2566,6 @@ int musical_instrument_actor::use( player &p, item &it, bool t, const tripoint &
     if( morale_effect >= 0 && calendar::once_every( description_frequency ) ) {
         if( !player_descriptions.empty() && p.is_player() ) {
             desc = _( random_entry( player_descriptions ) );
-        } else if( !npc_descriptions.empty() && p.is_npc() ) {
-            desc = string_format( _( "%1$s %2$s" ), p.disp_name( false ),
-                                  random_entry( npc_descriptions ) );
         }
     } else if( morale_effect < 0 && calendar::once_every( 1_minutes ) ) {
         // No musical skills = possible morale penalty
@@ -2577,6 +2574,10 @@ int musical_instrument_actor::use( player &p, item &it, bool t, const tripoint &
         } else {
             desc = string_format( _( "%s produces an annoying sound" ), p.disp_name( false ) );
         }
+    // Continuous sound messages only print every so often, so this ensures when it does print it'll be the right one.
+    } else if( !npc_descriptions.empty() && p.is_npc() ) {
+            desc = string_format( _( "%1$s %2$s" ), p.disp_name( false ),
+                                  random_entry( npc_descriptions ) );
     }
 
     if( morale_effect >= 0 ) {

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -2574,10 +2574,10 @@ int musical_instrument_actor::use( player &p, item &it, bool t, const tripoint &
         } else {
             desc = string_format( _( "%s produces an annoying sound" ), p.disp_name( false ) );
         }
-    // Continuous sound messages only print every so often, so this ensures when it does print it'll be the right one.
+        // Continuous sound messages only print every so often, so this ensures when it does print it'll be the right one.
     } else if( !npc_descriptions.empty() && p.is_npc() ) {
-            desc = string_format( _( "%1$s %2$s" ), p.disp_name( false ),
-                                  random_entry( npc_descriptions ) );
+        desc = string_format( _( "%1$s %2$s" ), p.disp_name( false ),
+                              random_entry( npc_descriptions ) );
     }
 
     if( morale_effect >= 0 ) {

--- a/src/iuse_actor.h
+++ b/src/iuse_actor.h
@@ -767,11 +767,11 @@ class musical_instrument_actor : public iuse_actor
         /**
         * List of sound descriptions for players
         */
-        std::vector< std::string > player_descriptions;
+        std::vector<std::string> player_descriptions;
         /**
         * List of sound descriptions for NPCs
         */
-        std::vector< std::string > npc_descriptions;
+        std::vector<std::string> npc_descriptions;
         /**
          * Display description once per this duration (@ref calendar::once_every).
          */


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

So I was idly talking with Maleclypse about stuff and the topic of musical instruments came up, with them having some sort of problem getting the messages to display right. I tested and soon got lost in a rabbit hole when I realized they were broken in BN too. After a lot of dicking around I narrowed it down to how it picks the random message failing to trigger, and knowing that `random_entry` itself couldn't be the culprit because it's used everywhere.

So I started trying to look more into what sorta array description messages are to see if it's maybe something invalid, and checking its definition in the .h file I noticed it looked different from the other string vectors in a way that made be go "there's no goddamn way it's this simple"

It was uh...90% just that simple, only other thing was NPC messages didn't print correctly which seems to be a consequence of message spam limitations paired with the music message around being rate-limited.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. In iuse_actor.h, removed the extra spaces from how player and NPC music descriptions are defined. Somehow that was causing it to not correctly set the random string in `musical_instrument_actor::use`, so it'd be stuck with the default string which never prints.
2. In iuse_actor.cpp, changed the order of operations for message generation to fix it so the message played when an NPC is playing for you can trigger correctly. My rough guess is, because the sound is being spammed every turn, it only prints the sound message every so often, and since the playing message is already a once-every-x-seconds thing that lowers the means most turns it prints the NPC message it just prints the default.

## Describe alternatives you've considered

Completely overhauling the offending iuse_actor?

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

1. Compiled and load-tested.
2. Spawned a guitar and started playing.
3. Messages trigger now.
4. Mindfucked the starter NPC and swapped to them.
5. Also seeing NPC sound messages, and it's no longer just "music"

<img width="559" height="135" alt="image" src="https://github.com/user-attachments/assets/09688f39-ba72-4738-a563-b9b66dc0e6d0" />

Note: Advise checking on linux builds too. The random spaces in the vector definition had to be there for a reason, but was it some weird OS/build specific thing or was it just that the code USED to allow those spaces but no longer does?

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

<img width="640" height="378" alt="image" src="https://github.com/user-attachments/assets/94cedfc4-4aeb-4574-96ce-c74ea0351b3e" />

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
