### PR TITLE
feat(balance): buff (cross)bow profession ammo to 20

### DIFF
--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -265,13 +265,13 @@
     "type": "item_group",
     "subtype": "collection",
     "id": "quiver_bow_hunter",
-    "entries": [ { "item": "arrow_cf", "charges": 8 } ]
+    "entries": [ { "item": "arrow_cf", "charges": 20 } ]
   },
   {
     "type": "item_group",
     "subtype": "collection",
     "id": "quiver_crossbow_hunter",
-    "entries": [ { "item": "bolt_metal", "charges": 9 } ]
+    "entries": [ { "item": "bolt_metal", "charges": 19 } ]
   },
   {
     "type": "item_group",
@@ -313,7 +313,7 @@
     "type": "item_group",
     "subtype": "collection",
     "id": "quiver_bionic_prepper",
-    "entries": [ { "item": "bolt_steel", "charges": 20 } ]
+    "entries": [ { "item": "bolt_steel", "charges": 19 } ]
   },
   {
     "type": "item_group",
@@ -325,7 +325,7 @@
     "type": "item_group",
     "subtype": "collection",
     "id": "quiver_crossbow_wanderer",
-    "entries": [ { "item": "bolt_wood", "charges": 20 } ]
+    "entries": [ { "item": "bolt_wood", "charges": 19 } ]
   },
   {
     "type": "item_group",


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

Someone pointed out that bow and crossbow hunters start with very low ammo counts, inconsistent with most other professions. Usually a profession starts with at least one stack of ammo for their weapons, and for archery professions they're allowed to have a full quiver's worth, but the bow hunter wasn't even afforded that much.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. Bumped bow hunter's ammo count from 8 to 20.
2. Bumped crossbow hunter's ammo count from 9 to 19, as they have one loaded in the crossbow already.
3. Conversely, lowered the quiver ammo count for bionic prepper and naturalist from 20 to 19. Minor and arguably pointless but they also have 1 loaded already, so just makes things consistent.

## Describe alternatives you've considered

Not nerfing two professions by a grand total of a single bolt just because they've got one in the chamber already.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

Demonstrated that I do in fact know how to count and that 20 is a higher number than 8.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

<img width="889" height="263" alt="image" src="https://github.com/user-attachments/assets/735f1960-32ec-4ac6-ae7e-e37c2a0df952" />

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
