### PR TITLE
feat(balance): add recipe to turn mutagenic serum back into 2 mutagen

### DIFF
--- a/data/json/recipes/chem/mutagen.json
+++ b/data/json/recipes/chem/mutagen.json
@@ -79,7 +79,7 @@
     "difficulty": 8,
     "time": "90 m",
     "batch_time_factors": [ 20, 2 ],
-	"charges": 2,
+    "charges": 2,
     "book_learn": [ [ "recipe_serum", 8 ], [ "recipe_labchem", 9 ] ],
     "using": [ [ "serum_production_standard", 37 ] ],
     "components": [ [ [ "iv_mutagen", 1 ] ] ],

--- a/data/json/recipes/chem/mutagen.json
+++ b/data/json/recipes/chem/mutagen.json
@@ -72,6 +72,7 @@
   {
     "type": "recipe",
     "result": "mutagen",
+    "id_suffix": "from_serum",
     "category": "CC_CHEM",
     "subcategory": "CSC_CHEM_MUTAGEN",
     "skill_used": "cooking",

--- a/data/json/recipes/chem/mutagen.json
+++ b/data/json/recipes/chem/mutagen.json
@@ -71,6 +71,22 @@
   },
   {
     "type": "recipe",
+    "result": "mutagen",
+    "category": "CC_CHEM",
+    "subcategory": "CSC_CHEM_MUTAGEN",
+    "skill_used": "cooking",
+    "skills_required": [ "firstaid", 4 ],
+    "difficulty": 8,
+    "time": "90 m",
+    "batch_time_factors": [ 20, 2 ],
+	"charges": 2,
+    "book_learn": [ [ "recipe_serum", 8 ], [ "recipe_labchem", 9 ] ],
+    "using": [ [ "serum_production_standard", 37 ] ],
+    "components": [ [ [ "iv_mutagen", 1 ] ] ],
+    "flags": [ "SECRET" ]
+  },
+  {
+    "type": "recipe",
     "result": "mutagen_jabberblood",
     "//": "jabberwocks have a few of these pumping in them, and they can be crushed down for a lot of mutagen",
     "byproducts": [ [ "jabberwock_heart_desiccated" ] ],


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
All targetted mutagen recipes require 1 mutagen to craft, and you can commonly loot mutagenic serum from labs. However, these mutagenic serums are useless unless you want to get random mutations, and its pretty frustrating to be out of mutagen while having a massive stash of mutagenic serum.

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Adds a crafting recipe which requires the same stats as creating mutagenic serum that allows you to turn mutagenic serum back into 2 mutagen.

<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
Having 24 mutagenic serum but running out of mutagen

## Testing
Debug spawned necessary equipment and skills, recipe works correctly
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context
I'm not sure how chemically accurate this is, but for one gameplay and for another we're talking about a substance made of magical sentient blob so yeah
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
