### PR TITLE
test: stabilize ranged AOE pellet tests

### DIFF
--- a/tests/ranged_aoe_test.cpp
+++ b/tests/ranged_aoe_test.cpp
@@ -23,11 +23,14 @@
 static const skill_id skill_gun( "gun" );
 static const skill_id skill_shotgun( "shotgun" );
 
+// Seed 0 preserves the current test-suite RNG state.
+constexpr auto deterministic_rng_seed = 4242424242U;
+
 static auto fire_shell_at_target( const itype_id &ammo_id,
                                   const std::vector<itype_id> &armor_ids ) -> int
 {
     clear_all_state();
-    rng_set_engine_seed( 0 );
+    rng_set_engine_seed( deterministic_rng_seed );
     REQUIRE( get_map().has_zlevels() );
     get_player_character().setpos( {60, 60, -2} );
 
@@ -175,7 +178,7 @@ TEST_CASE( "pellet projectile keeps last hit critter after overpenetration",
            "[ranged][projectile]" )
 {
     clear_all_state();
-    rng_set_engine_seed( 0 );
+    rng_set_engine_seed( deterministic_rng_seed );
     REQUIRE( get_map().has_zlevels() );
 
     auto &shooter = get_player_character();

--- a/tests/ranged_aoe_test.cpp
+++ b/tests/ranged_aoe_test.cpp
@@ -1,6 +1,7 @@
 #include "catch/catch.hpp"
 
 #include <algorithm>
+#include <array>
 #include <optional>
 #include <vector>
 
@@ -24,13 +25,13 @@ static const skill_id skill_gun( "gun" );
 static const skill_id skill_shotgun( "shotgun" );
 
 // Seed 0 preserves the current test-suite RNG state.
-constexpr auto deterministic_rng_seed = 4242424242U;
+constexpr auto deterministic_rng_seeds = std::array { 1U, 2U, 3U, 4U, 5U, 4242424242U };
 
 static auto fire_shell_at_target( const itype_id &ammo_id,
-                                  const std::vector<itype_id> &armor_ids ) -> int
+                                  const std::vector<itype_id> &armor_ids, const unsigned int seed ) -> int
 {
     clear_all_state();
-    rng_set_engine_seed( deterministic_rng_seed );
+    rng_set_engine_seed( seed );
     REQUIRE( get_map().has_zlevels() );
     get_player_character().setpos( {60, 60, -2} );
 
@@ -64,11 +65,24 @@ static auto fire_shell_at_target( const itype_id &ammo_id,
     const auto target_hp_total_before = target->get_hp();
     shooter.wield( std::move( gun ) );
 
-    const auto shots_fired = ranged::fire_gun( shooter, target_pos, 3, shooter.primary_weapon(),
+    const auto shots_to_fire = 5;
+    const auto shots_fired = ranged::fire_gun( shooter, target_pos, shots_to_fire,
+                             shooter.primary_weapon(),
                              nullptr );
 
-    REQUIRE( shots_fired == 3 );
+    REQUIRE( shots_fired == shots_to_fire );
     return target_hp_total_before - target->get_hp();
+}
+
+static auto fire_shells_at_target( const itype_id &ammo_id,
+                                   const std::vector<itype_id> &armor_ids ) -> int
+{
+    auto total_damage = 0;
+    for( const auto seed : deterministic_rng_seeds ) {
+        CAPTURE( seed );
+        total_damage += fire_shell_at_target( ammo_id, armor_ids, seed );
+    }
+    return total_damage;
 }
 
 static void shape_coverage_vs_distance_no_obstacle( const shape_factory_impl &c,
@@ -159,15 +173,15 @@ TEST_CASE( "expected shape coverage through windows", "[shape]" )
 
 TEST_CASE( "character using birdshot against another character", "[ranged]" )
 {
-    const auto damage = fire_shell_at_target( itype_id( "shot_bird" ), {} );
+    const auto damage = fire_shells_at_target( itype_id( "shot_bird" ), {} );
 
     CHECK( damage > 0 );
 }
 
 TEST_CASE( "birdshot pellets are much worse against armor", "[ranged][balance]" )
 {
-    const auto unarmored_damage = fire_shell_at_target( itype_id( "shot_bird" ), {} );
-    const auto armored_damage = fire_shell_at_target( itype_id( "shot_bird" ),
+    const auto unarmored_damage = fire_shells_at_target( itype_id( "shot_bird" ), {} );
+    const auto armored_damage = fire_shells_at_target( itype_id( "shot_bird" ),
     { itype_id( "survivor_suit" ), itype_id( "depowered_helmet" ) } );
 
     CHECK( unarmored_damage > armored_damage );
@@ -178,7 +192,7 @@ TEST_CASE( "pellet projectile keeps last hit critter after overpenetration",
            "[ranged][projectile]" )
 {
     clear_all_state();
-    rng_set_engine_seed( deterministic_rng_seed );
+    rng_set_engine_seed( deterministic_rng_seeds.front() );
     REQUIRE( get_map().has_zlevels() );
 
     auto &shooter = get_player_character();


### PR DESCRIPTION
## Purpose of change (The Why)

Fixes flaky `ranged_aoe_test` behavior observed in #8615 CI. `rng_set_engine_seed( 0 )` preserves the current test-suite RNG state, so pellet damage depended on prior test order.

## Describe the solution (The How)

Use a non-zero deterministic RNG seed for the ranged AOE pellet tests.

## Testing

- `cmake --build --preset linux-full --target astyle`
- `cmake --build --preset linux-full --target cata_test-tiles`
- `./out/build/linux-full/tests/cata_test-tiles "[ranged]" --rng-seed 1777159098 -D`

## Additional context

Related: #8615

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<sup>PR opened by gpt-5.5 high on opencode</sup>